### PR TITLE
Add Market Conditions at a Glance summary widget (US-1.2.1)

### DIFF
--- a/signaltrackers/static/css/dashboard.css
+++ b/signaltrackers/static/css/dashboard.css
@@ -1613,3 +1613,200 @@ footer {
         font-size: 0.75rem;
     }
 }
+
+/* ========================================
+   Market Conditions Summary Widget (US-1.2.1)
+   ======================================== */
+
+.market-summary-widget {
+    margin-bottom: 1.5rem;
+}
+
+.market-summary-widget .card {
+    border: none;
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+.market-summary-widget .card-header {
+    background: linear-gradient(135deg, #495057 0%, #343a40 100%);
+    color: white;
+    padding: 1rem 1.25rem;
+    border-bottom: none;
+}
+
+.market-summary-widget .card-header h3 {
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
+.market-summary-widget .card-header .btn {
+    font-size: 0.8rem;
+    padding: 0.35rem 0.75rem;
+    border-color: rgba(255,255,255,0.5);
+    color: rgba(255,255,255,0.9);
+}
+
+.market-summary-widget .card-header .btn:hover {
+    background-color: rgba(255,255,255,0.1);
+    border-color: rgba(255,255,255,0.8);
+    color: white;
+}
+
+.market-summary-widget .card-body {
+    padding: 1.25rem;
+}
+
+/* Summary Indicators Container */
+.summary-indicators {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-around;
+    gap: 0.75rem;
+}
+
+/* Individual Indicator */
+.summary-indicator {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    text-decoration: none;
+    color: inherit;
+    border-radius: 8px;
+    transition: all 0.2s ease;
+    min-width: 100px;
+    flex: 1;
+    max-width: 140px;
+}
+
+.summary-indicator:hover {
+    background-color: #f8f9fa;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    text-decoration: none;
+    color: inherit;
+}
+
+.summary-indicator-icon {
+    font-size: 1.5rem;
+    margin-bottom: 0.25rem;
+}
+
+.summary-indicator-name {
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: #6c757d;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 0.35rem;
+}
+
+/* Summary Status Badge */
+.summary-status-badge {
+    font-size: 0.65rem;
+    font-weight: 700;
+    padding: 0.35em 0.6em;
+    border-radius: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+/* AI Synthesis Section */
+.summary-synthesis {
+    font-size: 0.95rem;
+    line-height: 1.5;
+    padding-top: 1rem;
+}
+
+.summary-synthesis .synthesis-text {
+    color: #333;
+    font-style: italic;
+}
+
+/* Additional Status Badge Colors for new statuses */
+.status-spiking {
+    background-color: #dc3545 !important;
+    color: white;
+}
+
+.status-stable {
+    background-color: #6c757d !important;
+    color: white;
+}
+
+.status-expanding {
+    background-color: #198754 !important;
+    color: white;
+}
+
+.status-contracting {
+    background-color: #dc3545 !important;
+    color: white;
+}
+
+/* Responsive: Tablet and below */
+@media (max-width: 991px) {
+    .summary-indicators {
+        gap: 0.5rem;
+    }
+
+    .summary-indicator {
+        min-width: 80px;
+        padding: 0.5rem 0.75rem;
+    }
+
+    .summary-indicator-icon {
+        font-size: 1.25rem;
+    }
+
+    .summary-indicator-name {
+        font-size: 0.65rem;
+    }
+
+    .summary-status-badge {
+        font-size: 0.6rem;
+    }
+}
+
+/* Responsive: Mobile */
+@media (max-width: 767px) {
+    .market-summary-widget .card-header {
+        flex-direction: column;
+        gap: 0.75rem;
+        text-align: center;
+    }
+
+    .market-summary-widget .card-header h3 {
+        font-size: 1rem;
+    }
+
+    .summary-indicators {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 0.5rem;
+    }
+
+    .summary-indicator {
+        max-width: none;
+        padding: 0.5rem;
+    }
+
+    .summary-indicator-icon {
+        font-size: 1.1rem;
+    }
+
+    .summary-indicator-name {
+        font-size: 0.6rem;
+    }
+
+    .summary-status-badge {
+        font-size: 0.55rem;
+        padding: 0.25em 0.5em;
+    }
+
+    .summary-synthesis {
+        font-size: 0.85rem;
+        text-align: center;
+    }
+}

--- a/signaltrackers/templates/index.html
+++ b/signaltrackers/templates/index.html
@@ -61,6 +61,35 @@
     </div>
 </section>
 
+<!-- Section 1.5: Market Conditions at a Glance (US-1.2.1) -->
+<section class="market-summary-widget mb-4">
+    <div class="card shadow">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <h3 class="mb-0">
+                <i class="bi bi-speedometer2 me-2"></i>Market Conditions at a Glance
+            </h3>
+            <a href="#market-conditions-grid" class="btn btn-outline-secondary btn-sm">View Details →</a>
+        </div>
+        <div class="card-body">
+            <!-- Status indicators row -->
+            <div class="summary-indicators d-flex flex-wrap justify-content-around mb-3" id="summary-indicators">
+                <!-- Loading state -->
+                <div class="text-center text-muted py-3 w-100" id="summary-loading">
+                    <div class="spinner-border spinner-border-sm me-2" role="status">
+                        <span class="visually-hidden">Loading...</span>
+                    </div>
+                    Loading market conditions...
+                </div>
+            </div>
+            <!-- AI synthesis -->
+            <div class="summary-synthesis border-top pt-3" id="summary-synthesis">
+                <small class="text-muted"><i class="bi bi-robot me-1"></i></small>
+                <span id="summary-synthesis-text" class="text-muted">Loading market synthesis...</span>
+            </div>
+        </div>
+    </div>
+</section>
+
 <!-- Section 2: What's Moving Today -->
 <section class="whats-moving-section mb-4">
     <div class="section-header d-flex justify-content-between align-items-center mb-3">
@@ -123,7 +152,7 @@
 </div>
 
 <!-- Section 3: Market Conditions Grid -->
-<section class="market-conditions-grid mb-4">
+<section class="market-conditions-grid mb-4" id="market-conditions-grid">
     <h3 class="section-title">Market Conditions</h3>
     <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
         <!-- Credit Card -->
@@ -961,13 +990,26 @@ function calculateMarketStatuses(data) {
     else if (dxy < 97) dollarStatus = { text: 'VERY WEAK', class: 'status-very-weak' };
     else if (dxy < 100) dollarStatus = { text: 'WEAK', class: 'status-weak' };
 
+    // Volatility Status (based on VIX level)
+    let volatilityStatus = { text: 'CALM', class: 'status-calm' };
+    if (vix > 30) volatilityStatus = { text: 'SPIKING', class: 'status-spiking' };
+    else if (vix > 20) volatilityStatus = { text: 'ELEVATED', class: 'status-elevated' };
+
+    // Liquidity Status (based on M2 YoY change)
+    const m2YoY = metrics.economic_indicators?.m2_money_supply?.yoy_change || 0;
+    let liquidityStatus = { text: 'STABLE', class: 'status-stable' };
+    if (m2YoY > 8) liquidityStatus = { text: 'EXPANDING', class: 'status-expanding' };
+    else if (m2YoY < 0) liquidityStatus = { text: 'CONTRACTING', class: 'status-contracting' };
+
     return {
         credit: creditStatus,
         equities: equitiesStatus,
         rates: ratesStatus,
         havens: havensStatus,
         crypto: cryptoStatus,
-        dollar: dollarStatus
+        dollar: dollarStatus,
+        volatility: volatilityStatus,
+        liquidity: liquidityStatus
     };
 }
 
@@ -1091,6 +1133,72 @@ function updateMarketConditionsGrid(data) {
     if (dollarStatusEl) {
         dollarStatusEl.textContent = statuses.dollar.text;
         dollarStatusEl.className = 'badge ' + statuses.dollar.class;
+    }
+
+    // Update Summary Widget (US-1.2.1)
+    updateSummaryWidget(statuses);
+}
+
+// ========================================
+// Market Conditions Summary Widget (US-1.2.1)
+// ========================================
+
+// Define summary dimension configuration
+const summaryDimensions = [
+    { key: 'credit', name: 'CREDIT', icon: '💳', link: '/rates' },
+    { key: 'equities', name: 'EQUITIES', icon: '📈', link: '/equity' },
+    { key: 'rates', name: 'RATES', icon: '📊', link: '/rates' },
+    { key: 'volatility', name: 'VOLATILITY', icon: '📉', link: '/equity' },
+    { key: 'dollar', name: 'DOLLAR', icon: '💵', link: '/dollar' },
+    { key: 'liquidity', name: 'LIQUIDITY', icon: '💧', link: '/rates' }
+];
+
+// Update the summary widget with current statuses
+function updateSummaryWidget(statuses) {
+    const container = document.getElementById('summary-indicators');
+    const loadingEl = document.getElementById('summary-loading');
+
+    if (!container) return;
+
+    // Hide loading state
+    if (loadingEl) loadingEl.style.display = 'none';
+
+    // Build the indicator HTML
+    const html = summaryDimensions.map(dim => {
+        const status = statuses[dim.key] || { text: '--', class: 'status-neutral' };
+        return `
+            <a href="${dim.link}" class="summary-indicator" title="View ${dim.name} details">
+                <div class="summary-indicator-icon">${dim.icon}</div>
+                <div class="summary-indicator-name">${dim.name}</div>
+                <span class="badge summary-status-badge ${status.class}">${status.text}</span>
+            </a>
+        `;
+    }).join('');
+
+    container.innerHTML = html;
+}
+
+// Load and display AI market conditions synthesis
+async function loadMarketSynthesis() {
+    const synthesisTextEl = document.getElementById('summary-synthesis-text');
+    if (!synthesisTextEl) return;
+
+    try {
+        const response = await fetch('/api/market-conditions-synthesis');
+        const data = await response.json();
+
+        if (data.synthesis) {
+            synthesisTextEl.textContent = data.synthesis;
+            synthesisTextEl.classList.remove('text-muted');
+            synthesisTextEl.classList.add('synthesis-text');
+        } else {
+            synthesisTextEl.textContent = 'Market synthesis unavailable. Check back shortly.';
+            synthesisTextEl.classList.add('text-muted');
+        }
+    } catch (error) {
+        console.error('Error loading market synthesis:', error);
+        synthesisTextEl.textContent = 'Market synthesis unavailable.';
+        synthesisTextEl.classList.add('text-muted');
     }
 }
 
@@ -1739,6 +1847,7 @@ document.addEventListener('DOMContentLoaded', function() {
     loadDashboard();
     loadPredictionMarkets();
     loadAISummary();
+    loadMarketSynthesis();
 
     // Refresh every 60 seconds
     setInterval(loadDashboard, 60000);
@@ -1746,6 +1855,8 @@ document.addEventListener('DOMContentLoaded', function() {
     setInterval(loadPredictionMarkets, 900000);
     // Refresh AI summary every 5 minutes (in case it was regenerated)
     setInterval(loadAISummary, 300000);
+    // Refresh market synthesis every 5 minutes (in case it was regenerated)
+    setInterval(loadMarketSynthesis, 300000);
 });
 </script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- Implements compact "Market Conditions at a Glance" widget positioned after Hero Briefing section
- Displays all 6 market dimension statuses (Credit, Equities, Rates, Volatility, Dollar, Liquidity) with color-coded badges
- Adds new Volatility (based on VIX) and Liquidity (based on M2 YoY) status calculations
- Integrates AI-generated one-liner synthesis from the `/api/market-conditions-synthesis` endpoint
- Click-through navigation to relevant detail pages for each dimension

## Test plan
- [ ] Widget displays correctly on desktop (full row of 6 indicators)
- [ ] Widget displays correctly on mobile (2x3 grid or stacked)
- [ ] All status badges show correct colors per status type
- [ ] Clicking each indicator navigates to correct page
- [ ] Loading states display appropriately
- [ ] Widget gracefully handles missing data (shows "--" or "Loading")
- [ ] AI synthesis section renders (with placeholder if API not ready)

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)