### PR TITLE
Fix alert 'Mark Read' button 400 BAD REQUEST error

### DIFF
--- a/signaltrackers/templates/alerts.html
+++ b/signaltrackers/templates/alerts.html
@@ -237,10 +237,15 @@ function filterAlerts() {
 document.querySelectorAll('.mark-read-btn').forEach(btn => {
     btn.addEventListener('click', async function() {
         const alertId = this.dataset.alertId;
+        const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
 
         try {
             const response = await fetch(`/alerts/${alertId}/mark-read`, {
-                method: 'POST'
+                method: 'POST',
+                headers: {
+                    'X-CSRFToken': csrfToken,
+                    'Content-Type': 'application/json'
+                }
             });
 
             if (response.ok) {
@@ -252,8 +257,14 @@ document.querySelectorAll('.mark-read-btn').forEach(btn => {
                 // Remove NEW badge
                 const newBadge = card.querySelector('.badge.bg-primary');
                 if (newBadge) newBadge.remove();
+            } else {
+                // Show error message to user
+                alert('Failed to mark alert as read. Please try again.');
+                console.error('Failed to mark alert as read:', response.status, response.statusText);
             }
         } catch (error) {
+            // Show error message to user
+            alert('An error occurred while marking the alert as read. Please try again.');
             console.error('Error marking alert as read:', error);
         }
     });

--- a/signaltrackers/templates/base.html
+++ b/signaltrackers/templates/base.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Daily macro intelligence briefings for individual investors. Track credit, equities, rates, safe havens, crypto, and currency markets in one dashboard.">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{% block title %}SignalTrackers - Macro Intelligence Platform{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">


### PR DESCRIPTION
## Summary
Fixes the 'Mark Read' button on the Alert History page that was failing with HTTP 400 BAD REQUEST error.

## Root Cause
The JavaScript fetch request was missing the CSRF token required by Flask-WTF's CSRFProtect middleware. All POST requests without a valid CSRF token are rejected with a 400 error.

## Changes Made
1. **Added CSRF token meta tag** to [base.html](signaltrackers/templates/base.html#L7)
   - Makes CSRF token accessible to JavaScript across all pages
   
2. **Updated JavaScript in alerts.html** to include CSRF protection:
   - Retrieves CSRF token from meta tag
   - Includes `X-CSRFToken` header in fetch request
   - Added `Content-Type: application/json` header for consistency
   
3. **Improved error handling**:
   - Added user-facing alert messages for failed requests
   - Enhanced console logging for debugging
   - Handles both network errors and HTTP error responses

## Test Plan
- [ ] Navigate to Alert History page
- [ ] Click 'Mark Read' button on any unread alert
- [ ] Verify alert is marked as read (NEW badge removed, button disappears)
- [ ] Verify UI updates without page reload
- [ ] Test with multiple alerts to ensure consistency
- [ ] Verify error handling by temporarily breaking the endpoint (should show alert message)

## Files Changed
- `signaltrackers/templates/base.html` - Added CSRF meta tag
- `signaltrackers/templates/alerts.html` - Updated JavaScript with CSRF token and error handling

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)