### PR TITLE
Fix daily briefing emails not sent for non-7AM preferences

### DIFF
--- a/signaltrackers/scheduler.py
+++ b/signaltrackers/scheduler.py
@@ -63,18 +63,17 @@ def register_jobs(app):
     )
     logger.info("Registered job: check_alerts (every 15 minutes)")
 
-    # Daily briefings - 7 AM ET (12:00 UTC in winter, 11:00 UTC in summer)
-    # Note: Will need to handle user-specific timezones in the job itself
+    # Daily briefings - runs every hour, sends to users when their local time matches preference
+    # Job checks each user's timezone and preferred time, only sends when hour matches
     scheduler.add_job(
         func=send_daily_briefings_wrapper,
         trigger='cron',
-        hour=12,  # 12 UTC = 7 AM ET (winter)
-        minute=0,
+        minute=0,  # Run every hour at the top of the hour
         id='daily_briefings',
         name='Send daily briefing emails',
         replace_existing=True
     )
-    logger.info("Registered job: daily_briefings (daily at 12:00 UTC)")
+    logger.info("Registered job: daily_briefings (every hour at :00)")
 
 
 def shutdown_scheduler():


### PR DESCRIPTION
## Summary
Fixes bug where users with daily briefing email preferences set to times other than 7:00 AM EST were not receiving their scheduled emails.

## Changes
- Modified scheduler to run daily briefing job **every hour** instead of once daily at 12:00 UTC
- Updated comments to reflect new hourly execution pattern
- Email job logic already checked user timezone/preference matching, now works for all hours

## How It Works
- Scheduler runs every hour at :00
- Email job checks each user's local time against their configured preference
- Sends emails only when user's local hour matches their preferred hour
- Users can now receive daily briefings at any hour they configure (7 AM, 10 AM, etc.)

## Testing Plan
1. Set test user preference to 10:00 AM EST
2. Deploy fix to staging/production
3. Verify email received at 10:00 AM EST
4. Verify users with 7:00 AM preference still receive emails (no regression)
5. Check logs for proper time matching at different hours

## Files Changed
- [signaltrackers/scheduler.py](signaltrackers/scheduler.py#L66-L76) - Changed from `hour=12, minute=0` to just `minute=0` for hourly execution

Fixes #47