### PR TITLE
Fix KeyError for us_recessions.csv in CSV loading functions

### DIFF
--- a/signaltrackers/dashboard.py
+++ b/signaltrackers/dashboard.py
@@ -476,7 +476,9 @@ def load_csv_data(filename):
     filepath = DATA_DIR / filename
     if filepath.exists():
         df = pd.read_csv(filepath)
-        df['date'] = pd.to_datetime(df['date'])
+        # us_recessions.csv has start_date/end_date, not date
+        if filename != 'us_recessions.csv':
+            df['date'] = pd.to_datetime(df['date'])
         return df
     return None
 

--- a/signaltrackers/export_for_ai.py
+++ b/signaltrackers/export_for_ai.py
@@ -19,7 +19,9 @@ def load_csv_safely(filename):
     if filepath.exists():
         try:
             df = pd.read_csv(filepath)
-            df['date'] = pd.to_datetime(df['date'])
+            # us_recessions.csv has start_date/end_date, not date
+            if filename != 'us_recessions.csv':
+                df['date'] = pd.to_datetime(df['date'])
             return df
         except Exception as e:
             print(f"Error loading {filename}: {e}")

--- a/signaltrackers/export_for_ai_neutral.py
+++ b/signaltrackers/export_for_ai_neutral.py
@@ -19,7 +19,9 @@ def load_csv_safely(filename):
     if filepath.exists():
         try:
             df = pd.read_csv(filepath)
-            df['date'] = pd.to_datetime(df['date'])
+            # us_recessions.csv has start_date/end_date, not date
+            if filename != 'us_recessions.csv':
+                df['date'] = pd.to_datetime(df['date'])
             return df
         except Exception as e:
             print(f"Error loading {filename}: {e}")

--- a/signaltrackers/market_signals.py
+++ b/signaltrackers/market_signals.py
@@ -743,7 +743,11 @@ def get_latest_metrics():
             if df.empty:
                 continue
 
-            df['date'] = pd.to_datetime(df['date'])
+            # us_recessions.csv has start_date/end_date, not date
+            if metric_name != 'us_recessions':
+                df['date'] = pd.to_datetime(df['date'])
+            else:
+                continue  # Skip us_recessions.csv in metric loading
 
             # Get the value column (second column)
             value_col = df.columns[1]
@@ -812,7 +816,11 @@ def get_historical_metrics(days_ago=1):
             if df.empty:
                 continue
 
-            df['date'] = pd.to_datetime(df['date'])
+            # us_recessions.csv has start_date/end_date, not date
+            if metric_name != 'us_recessions':
+                df['date'] = pd.to_datetime(df['date'])
+            else:
+                continue  # Skip us_recessions.csv in metric loading
 
             # Get the value column (second column)
             value_col = df.columns[1]

--- a/signaltrackers/metric_tools.py
+++ b/signaltrackers/metric_tools.py
@@ -201,7 +201,9 @@ def load_csv_data(filename):
     if filepath.exists():
         try:
             df = pd.read_csv(filepath)
-            df['date'] = pd.to_datetime(df['date'])
+            # us_recessions.csv has start_date/end_date, not date
+            if filename != 'us_recessions.csv':
+                df['date'] = pd.to_datetime(df['date'])
             return df
         except Exception as e:
             print(f"Error loading {filename}: {e}")


### PR DESCRIPTION
## Summary
- Fixed KeyError exceptions when loading `us_recessions.csv` (18+ occurrences on app startup)
- Added special case handling to skip date column conversion for `us_recessions.csv`
- The file uses `start_date/end_date` columns instead of the standard `date` column

## Changes Made
Modified CSV loading in 6 locations to check for `us_recessions.csv` and skip date conversion:
- [metric_tools.py:load_csv_data()](signaltrackers/metric_tools.py#L198-L208)
- [export_for_ai.py:load_csv_safely()](signaltrackers/export_for_ai.py#L16-L27)
- [export_for_ai_neutral.py:load_csv_safely()](signaltrackers/export_for_ai_neutral.py#L16-L27)
- [dashboard.py:load_csv_data()](signaltrackers/dashboard.py#L474-L481)
- [market_signals.py:get_latest_metrics()](signaltrackers/market_signals.py#L741-L749)
- [market_signals.py:get_historical_metrics()](signaltrackers/market_signals.py#L810-L818)

## Test Plan
- [x] Created test script to verify us_recessions.csv loads without errors
- [x] Confirmed normal metric CSVs still load with proper date conversion
- [x] us_recessions.csv successfully loads with start_date/end_date columns intact
- [x] vix_price.csv successfully loads with date column converted to datetime

Fixes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)