### PR TITLE
[US-2.0.4] Move Yen Carry Trade section to dollar page

### DIFF
--- a/signaltrackers/templates/dollar.html
+++ b/signaltrackers/templates/dollar.html
@@ -346,6 +346,60 @@
     </div>
 </div>
 
+<!-- Yen Carry Trade -->
+<div class="row mb-4">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <h5 class="mb-0">
+                    <i class="bi bi-currency-yen"></i> Yen Carry Trade Monitor
+                </h5>
+            </div>
+            <div class="card-body">
+                <div class="row">
+                    <div class="col-md-6 mb-3">
+                        <a href="/explorer?metric=usdjpy_price" class="text-decoration-none">
+                            <div class="card h-100 metric-card">
+                                <div class="card-body">
+                                    <h6 class="text-muted">USD/JPY Exchange Rate</h6>
+                                    <div class="d-flex justify-content-between align-items-center">
+                                        <h3 class="mb-0" id="yen-carry-usdjpy-value">--</h3>
+                                        <small class="text-muted">
+                                            <span id="yen-carry-usdjpy-change-5d">--</span>% (5d) / <span id="yen-carry-usdjpy-change-30d">--</span>% (30d)
+                                        </small>
+                                        <span class="badge" id="yen-carry-usdjpy-percentile">--</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </a>
+                    </div>
+                    <div class="col-md-6 mb-3">
+                        <a href="/explorer?metric=japan_10y_yield" class="text-decoration-none">
+                            <div class="card h-100 metric-card">
+                                <div class="card-body">
+                                    <h6 class="text-muted">Japan 10Y Government Bond Yield</h6>
+                                    <div class="d-flex justify-content-between align-items-center">
+                                        <h3 class="mb-0" id="yen-carry-japan-10y-value">--</h3>
+                                        <small class="text-muted">
+                                            <span id="yen-carry-japan-10y-change-5d">--</span>% (5d) / <span id="yen-carry-japan-10y-change-30d">--</span>% (30d)
+                                        </small>
+                                        <span class="badge" id="yen-carry-japan-10y-percentile">--</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </a>
+                    </div>
+                </div>
+                <div class="mt-2">
+                    <small class="text-muted">
+                        <i class="bi bi-info-circle"></i> Carry trade risk: Investors borrow cheap yen to invest in higher-yielding assets. Sharp yen strengthening (USD/JPY drop) or rising JGB yields can trigger violent unwinds.
+                    </small>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
 <!-- Educational Sections -->
 <div class="row mb-4">
     <div class="col-md-6 mb-3">
@@ -650,6 +704,54 @@ async function loadDollarData() {
             } else {
                 statusEl.textContent = 'YEN STRONG';
                 statusEl.className = 'badge bg-success';
+            }
+
+            // Also populate Yen Carry Trade section
+            document.getElementById('yen-carry-usdjpy-value').textContent = current.toFixed(2);
+            if (change5d !== null) {
+                document.getElementById('yen-carry-usdjpy-change-5d').textContent = (change5d >= 0 ? '+' : '') + change5d.toFixed(1);
+            }
+            if (change30d !== null) {
+                document.getElementById('yen-carry-usdjpy-change-30d').textContent = (change30d >= 0 ? '+' : '') + change30d.toFixed(1);
+            }
+
+            // Percentile for Yen Carry Trade section
+            const percentile = calcPercentile(usdjpyData.values, current);
+            if (percentile !== null) {
+                const usdjpyBadge = document.getElementById('yen-carry-usdjpy-percentile');
+                usdjpyBadge.textContent = `${percentile.toFixed(0)}%ile`;
+                // Lower USD/JPY (stronger yen) = more risk, so invert the warning logic
+                usdjpyBadge.className = percentile < 20 ? 'badge bg-danger' :
+                                        percentile < 40 ? 'badge bg-warning' : 'badge bg-secondary';
+            }
+        }
+
+        // Load Japan 10Y Yield for Yen Carry Trade section
+        const japan10yResponse = await fetch('/api/metrics/japan_10y_yield');
+        const japan10yData = await japan10yResponse.json();
+
+        if (japan10yData && japan10yData.values && japan10yData.values.length > 0) {
+            const current = japan10yData.values[japan10yData.values.length - 1];
+            document.getElementById('yen-carry-japan-10y-value').textContent = current.toFixed(2) + '%';
+
+            const change5d = calcPctChange(japan10yData.values, 5);
+            const change30d = calcPctChange(japan10yData.values, 30);
+
+            if (change5d !== null) {
+                document.getElementById('yen-carry-japan-10y-change-5d').textContent = (change5d >= 0 ? '+' : '') + change5d.toFixed(1);
+            }
+            if (change30d !== null) {
+                document.getElementById('yen-carry-japan-10y-change-30d').textContent = (change30d >= 0 ? '+' : '') + change30d.toFixed(1);
+            }
+
+            // Percentile for Japan 10Y
+            const percentile = calcPercentile(japan10yData.values, current);
+            if (percentile !== null) {
+                const japan10yBadge = document.getElementById('yen-carry-japan-10y-percentile');
+                japan10yBadge.textContent = `${percentile.toFixed(0)}%ile`;
+                // Higher Japan yields = more risk (carry trade unwinding)
+                japan10yBadge.className = percentile > 80 ? 'badge bg-danger' :
+                                          percentile > 60 ? 'badge bg-warning' : 'badge bg-secondary';
             }
         }
 

--- a/signaltrackers/templates/index.html
+++ b/signaltrackers/templates/index.html
@@ -430,60 +430,6 @@
 </section>
 
 <!-- Additional Insights Section -->
-<!-- Yen Carry Trade -->
-<div class="row mb-4">
-    <div class="col-12">
-        <div class="card">
-            <div class="card-header">
-                <h5 class="mb-0">
-                    <i class="bi bi-currency-yen"></i> Yen Carry Trade Monitor
-                </h5>
-            </div>
-            <div class="card-body">
-                <div class="row">
-                    <div class="col-md-6 mb-3">
-                        <a href="/explorer?metric=usdjpy_price" class="text-decoration-none">
-                            <div class="card h-100 metric-card">
-                                <div class="card-body">
-                                    <h6 class="text-muted">USD/JPY Exchange Rate</h6>
-                                    <div class="d-flex justify-content-between align-items-center">
-                                        <h3 class="mb-0" id="usdjpy-value">--</h3>
-                                        <small class="text-muted">
-                                            <span id="usdjpy-change-5d">--</span>% (5d) / <span id="usdjpy-change-30d">--</span>% (30d)
-                                        </small>
-                                        <span class="badge" id="usdjpy-percentile">--</span>
-                                    </div>
-                                </div>
-                            </div>
-                        </a>
-                    </div>
-                    <div class="col-md-6 mb-3">
-                        <a href="/explorer?metric=japan_10y_yield" class="text-decoration-none">
-                            <div class="card h-100 metric-card">
-                                <div class="card-body">
-                                    <h6 class="text-muted">Japan 10Y Government Bond Yield</h6>
-                                    <div class="d-flex justify-content-between align-items-center">
-                                        <h3 class="mb-0" id="japan-10y-value">--</h3>
-                                        <small class="text-muted">
-                                            <span id="japan-10y-change-5d">--</span>% (5d) / <span id="japan-10y-change-30d">--</span>% (30d)
-                                        </small>
-                                        <span class="badge" id="japan-10y-percentile">--</span>
-                                    </div>
-                                </div>
-                            </div>
-                        </a>
-                    </div>
-                </div>
-                <div class="mt-2">
-                    <small class="text-muted">
-                        <i class="bi bi-info-circle"></i> Carry trade risk: Investors borrow cheap yen to invest in higher-yielding assets. Sharp yen strengthening (USD/JPY drop) or rising JGB yields can trigger violent unwinds.
-                    </small>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
-
 <!-- Economic Indicators -->
 <div class="row mb-4">
     <div class="col-12">
@@ -723,37 +669,6 @@ async function loadDashboard() {
                 (data.metrics.ccc_hy_ratio.change_5d >= 0 ? '+' : '') + data.metrics.ccc_hy_ratio.change_5d.toFixed(2);
             document.getElementById('ccc-change-30d').textContent =
                 (data.metrics.ccc_hy_ratio.change_30d >= 0 ? '+' : '') + data.metrics.ccc_hy_ratio.change_30d.toFixed(2);
-        }
-
-        // Update yen carry trade metrics
-        if (data.metrics.carry_trade) {
-            const carry = data.metrics.carry_trade;
-
-            if (carry.usdjpy) {
-                document.getElementById('usdjpy-value').textContent = carry.usdjpy.current.toFixed(2);
-                document.getElementById('usdjpy-change-5d').textContent =
-                    (carry.usdjpy.change_5d >= 0 ? '+' : '') + carry.usdjpy.change_5d.toFixed(1);
-                document.getElementById('usdjpy-change-30d').textContent =
-                    (carry.usdjpy.change_30d >= 0 ? '+' : '') + carry.usdjpy.change_30d.toFixed(1);
-                const usdjpyBadge = document.getElementById('usdjpy-percentile');
-                usdjpyBadge.textContent = `${carry.usdjpy.percentile.toFixed(0)}%ile`;
-                // Lower USD/JPY (stronger yen) = more risk, so invert the warning logic
-                usdjpyBadge.className = carry.usdjpy.percentile < 20 ? 'badge bg-danger' :
-                                        carry.usdjpy.percentile < 40 ? 'badge bg-warning' : 'badge bg-secondary';
-            }
-
-            if (carry.japan_10y) {
-                document.getElementById('japan-10y-value').textContent = carry.japan_10y.current.toFixed(2) + '%';
-                document.getElementById('japan-10y-change-5d').textContent =
-                    (carry.japan_10y.change_5d >= 0 ? '+' : '') + carry.japan_10y.change_5d.toFixed(1);
-                document.getElementById('japan-10y-change-30d').textContent =
-                    (carry.japan_10y.change_30d >= 0 ? '+' : '') + carry.japan_10y.change_30d.toFixed(1);
-                const japan10yBadge = document.getElementById('japan-10y-percentile');
-                japan10yBadge.textContent = `${carry.japan_10y.percentile.toFixed(0)}%ile`;
-                // Higher Japan yields = more risk (carry trade unwinding)
-                japan10yBadge.className = carry.japan_10y.percentile > 80 ? 'badge bg-danger' :
-                                          carry.japan_10y.percentile > 60 ? 'badge bg-warning' : 'badge bg-secondary';
-            }
         }
 
         // Update Market Conditions Grid (US-1.1.2)


### PR DESCRIPTION
## Summary
Moved the Yen Carry Trade Monitor section from the homepage to the dollar page for better contextual organization.

## Changes Made
- ✅ Added Yen Carry Trade Monitor section to [dollar.html](templates/dollar.html)
  - Includes USD/JPY Exchange Rate metric card
  - Includes Japan 10Y Government Bond Yield metric card
  - Includes explanatory text about carry trade risk
- ✅ Added JavaScript to load Japan 10Y yield data
- ✅ Updated element IDs to be unique (`yen-carry-` prefix) to avoid conflicts with existing USD/JPY metrics on dollar page
- ✅ Removed Yen Carry Trade section from [index.html](templates/index.html) 
- ✅ Removed associated JavaScript code from homepage

## Testing Checklist
Manual testing required (Flask dependencies not installed in dev environment):
- [ ] Visit `/dollar` page, verify Yen Carry Trade section displays
- [ ] Verify USD/JPY Exchange Rate card shows correct data
- [ ] Verify Japan 10Y Government Bond Yield card shows correct data
- [ ] Click metric links, verify navigation to `/explorer` works
- [ ] Visit homepage, verify section is removed
- [ ] Check browser console for errors on both pages
- [ ] Test on mobile/responsive layout

## Notes
- The dollar page already had a USD/JPY metric in the main metrics row, so I prefixed the Yen Carry Trade section IDs with `yen-carry-` to avoid duplicate IDs
- The section fits naturally on the dollar page as yen is a major dollar pair
- Some references to `carry_trade` remain in the Market Conditions Grid code (index.html), but these use optional chaining and won't cause errors

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)