### PR TITLE
Fix Flask url_for() RuntimeError in background email jobs

### DIFF
--- a/signaltrackers/services/briefing_email_service.py
+++ b/signaltrackers/services/briefing_email_service.py
@@ -7,7 +7,7 @@ Aggregates market data, AI summaries, and user alerts into a comprehensive email
 
 from datetime import datetime, timedelta
 import pytz
-from flask import url_for
+from flask import current_app
 from services.email_service import send_email
 from models.user import User
 from models.alert import AlertPreference, Alert
@@ -184,6 +184,7 @@ def send_daily_briefing_to_user(user):
         portfolio_analysis = get_portfolio_analysis_snippet(user)
 
         # Prepare template context
+        base_url = current_app.config['BASE_URL']
         context = {
             'user': user,
             'briefing_date': datetime.now().strftime('%A, %B %d, %Y'),
@@ -195,8 +196,8 @@ def send_daily_briefing_to_user(user):
             'triggered_alerts': triggered_alerts,
             'include_portfolio': prefs.include_portfolio_analysis,
             'portfolio_analysis': portfolio_analysis,
-            'dashboard_url': url_for('index', _external=True),
-            'unsubscribe_url': url_for('unsubscribe_briefing', user_id=user.id, _external=True)
+            'dashboard_url': base_url,
+            'unsubscribe_url': f"{base_url}/unsubscribe/{user.id}"
         }
 
         # Send email


### PR DESCRIPTION
## Summary
Fixes RuntimeError when Flask's `url_for()` is called in background email jobs that run outside HTTP request context.

## Changes
- **File**: `signaltrackers/services/briefing_email_service.py`
  - Replaced `url_for` import with `current_app`
  - Updated `dashboard_url` to use `BASE_URL` from Flask config
  - Updated `unsubscribe_url` to use `BASE_URL` with f-string formatting
  
## Root Cause
Background jobs (scheduled tasks) don't have an active HTTP request context. Flask's `url_for()` requires either:
1. An active HTTP request (doesn't exist in background jobs), OR
2. `SERVER_NAME` configured in Flask config

## Solution
Use the existing `BASE_URL` configuration (already set in `config.py:57`) instead of `url_for()` to generate external URLs.

## Testing
- Verified `BASE_URL` is configured in [config.py:57](signaltrackers/config.py#L57)
- Searched for other instances of `url_for()` in email services (none found)
- Changes tested: URL generation for dashboard link and unsubscribe link

Fixes #54