### PR TITLE
Fix: Increase AI summary max_iterations from 3 to 6

### DIFF
--- a/signaltrackers/ai_summary.py
+++ b/signaltrackers/ai_summary.py
@@ -146,7 +146,10 @@ def _call_openai_with_tools(client, system_prompt, user_prompt, max_tokens, log_
         print(f"{log_prefix} Web search tool not available (Tavily not configured)")
 
     # Tool calling loop
-    max_iterations = 3
+    # Allow up to 6 web search iterations for comprehensive market analysis
+    # Complex market days often require 4-5 searches for context (breaking news,
+    # economic data, Fed policy, sector developments, geopolitical events)
+    max_iterations = 6
     iteration = 0
 
     while iteration < max_iterations:
@@ -256,7 +259,10 @@ def _call_anthropic_with_tools(client, system_prompt, user_prompt, max_tokens, l
     thinking_budget = effort_budgets.get(ANTHROPIC_EFFORT, 4096)
 
     # Tool calling loop
-    max_iterations = 3
+    # Allow up to 6 web search iterations for comprehensive market analysis
+    # Complex market days often require 4-5 searches for context (breaking news,
+    # economic data, Fed policy, sector developments, geopolitical events)
+    max_iterations = 6
     iteration = 0
 
     while iteration < max_iterations:


### PR DESCRIPTION
## Summary
Increases the `max_iterations` limit from 3 to 6 for AI summary generation to reduce "Exceeded maximum tool call iterations" errors.

Fixes #59

## Changes
- Updated `max_iterations` from 3 to 6 in both OpenAI and Anthropic implementations ([ai_summary.py:149](signaltrackers/ai_summary.py#L149) and [ai_summary.py:259](signaltrackers/ai_summary.py#L259))
- Added explanatory comments documenting why 6 iterations are needed for comprehensive market analysis

## Problem
AI summary generation was failing ~40-50% of the time with "Exceeded maximum tool call iterations" errors. The limit of 3 web searches was insufficient for complex market days that require context from multiple sources (breaking news, economic data, Fed policy, sector developments, geopolitical events).

## Solution
Increased the iteration limit to 6, allowing the AI to make 4-5 searches when needed for thorough analysis while still preventing runaway loops.

## Testing Required
After merge, please:
1. Trigger a full data refresh
2. Monitor logs for "Exceeded max iterations" errors
3. Verify all summaries generate successfully:
   - General daily briefing
   - Crypto briefing
   - Equity briefing
   - Rates briefing
   - Market synthesis
4. Check that errors drop to near zero

## Notes
- This is the "quick fix" Option 1 from the issue analysis
- Future enhancements could include improved pre-fetching (Option 2/3) if needed
- Monitoring actual iteration usage will inform future optimization

🤖 Generated with [Claude Code](https://claude.com/claude-code)