### PR TITLE
Fix AI summary generation order to enable market-specific briefing synthesis

### DIFF
--- a/signaltrackers/dashboard.py
+++ b/signaltrackers/dashboard.py
@@ -1963,20 +1963,7 @@ def run_data_collection():
         reload_status['last_reload'] = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         print("Data reload completed successfully!")
 
-        # Generate AI summary after successful data reload
-        reload_status['status'] = 'Generating AI daily summary...'
-        print("Generating AI daily summary...")
-        try:
-            market_summary = generate_market_summary()
-            top_movers = calculate_top_movers(5)
-            result = generate_daily_summary(market_summary, top_movers)
-            if result['success']:
-                print("AI summary generated successfully!")
-            else:
-                print(f"AI summary generation failed: {result['error']}")
-        except Exception as summary_error:
-            print(f"AI summary error (non-fatal): {summary_error}")
-
+        # Generate market-specific briefings FIRST so they can be included in general summary
         # Generate Crypto AI summary
         reload_status['status'] = 'Generating Crypto AI summary...'
         print("Generating Crypto AI summary...")
@@ -2015,6 +2002,21 @@ def run_data_collection():
                 print(f"Rates AI summary generation failed: {rates_result['error']}")
         except Exception as rates_summary_error:
             print(f"Rates AI summary error (non-fatal): {rates_summary_error}")
+
+        # Generate general AI summary AFTER market-specific briefings
+        # This allows it to include crypto/equity/rates briefings as context
+        reload_status['status'] = 'Generating AI daily summary...'
+        print("Generating AI daily summary...")
+        try:
+            market_summary = generate_market_summary()
+            top_movers = calculate_top_movers(5)
+            result = generate_daily_summary(market_summary, top_movers)
+            if result['success']:
+                print("AI summary generated successfully!")
+            else:
+                print(f"AI summary generation failed: {result['error']}")
+        except Exception as summary_error:
+            print(f"AI summary error (non-fatal): {summary_error}")
 
         # Generate Market Conditions Synthesis (one-liner)
         reload_status['status'] = 'Generating market conditions synthesis...'


### PR DESCRIPTION
## Summary
Fixes the bug where the general daily briefing couldn't include market-specific content because it was generated before those briefings existed.

## Changes Made
- **Reordered AI summary generation** in `run_data_collection()` ([dashboard.py:1966-2019](signaltrackers/dashboard.py#L1966-L2019)):
  1. Market-specific briefings generate FIRST (crypto, equity, rates)
  2. General daily summary generates AFTER (can now include briefings as context)
  3. Market synthesis remains last (can include all briefings)

## How It Works
The `generate_daily_summary()` function in [ai_summary.py:507-534](signaltrackers/ai_summary.py#L507-L534) checks for today's market-specific briefings and includes them as context. With this fix, those briefings will exist when the general summary is generated, allowing proper synthesis.

## Impact
- General briefing can now synthesize crypto/equity/rates briefings into a cohesive narrative
- Fulfills the system prompt intent: "SYNTHESIZE key insights from [market briefings] into a cohesive narrative"
- Improves overall briefing quality and comprehensiveness

## Testing Plan
1. Run a data refresh
2. Check the general briefing content
3. Verify it includes synthesized content from crypto/equity/rates briefings
4. Confirm the narrative flows naturally (not just bullet points)

Fixes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)