### PR TITLE
Fix AI summaries to show Eastern Time instead of UTC (Fixes #60)

### DIFF
--- a/signaltrackers/ai_summary.py
+++ b/signaltrackers/ai_summary.py
@@ -11,6 +11,7 @@ import os
 import json
 from datetime import datetime, timedelta
 from pathlib import Path
+import pytz
 
 # AI Provider imports - both optional
 try:
@@ -410,7 +411,8 @@ def get_recent_summaries(days=3):
     if not data["summaries"]:
         return []
 
-    cutoff = (datetime.now() - timedelta(days=days)).strftime('%Y-%m-%d')
+    eastern = pytz.timezone('US/Eastern')
+    cutoff = (datetime.now(eastern) - timedelta(days=days)).strftime('%Y-%m-%d')
     recent = [s for s in data["summaries"] if s["date"] >= cutoff]
     # Sort by date ascending (oldest first) for chronological context
     return sorted(recent, key=lambda x: x["date"])
@@ -423,17 +425,18 @@ def save_summary(date_str, summary_text, web_search_used=False, news_context=Non
     # Remove existing summary for this date if present
     data["summaries"] = [s for s in data["summaries"] if s["date"] != date_str]
 
+    eastern = pytz.timezone('US/Eastern')
     # Add new summary
     data["summaries"].append({
         "date": date_str,
-        "generated_at": datetime.now().isoformat(),
+        "generated_at": datetime.now(eastern).isoformat(),
         "summary": summary_text,
         "web_search_used": web_search_used,
         "news_context": news_context[:500] if news_context else None  # Store snippet of news used
     })
 
     # Keep last 90 days of summaries
-    cutoff = (datetime.now() - timedelta(days=90)).strftime('%Y-%m-%d')
+    cutoff = (datetime.now(eastern) - timedelta(days=90)).strftime('%Y-%m-%d')
     data["summaries"] = [s for s in data["summaries"] if s["date"] >= cutoff]
 
     save_summaries(data)
@@ -493,7 +496,8 @@ def generate_daily_summary(market_data_summary, top_movers):
         }
 
     try:
-        today = datetime.now().strftime('%Y-%m-%d')
+        eastern = pytz.timezone('US/Eastern')
+        today = datetime.now(eastern).strftime('%Y-%m-%d')
 
         # Get previous summaries for context
         recent_summaries = get_recent_summaries(days=3)
@@ -677,7 +681,8 @@ def get_recent_crypto_summaries(days=3):
     if not data["summaries"]:
         return []
 
-    cutoff = (datetime.now() - timedelta(days=days)).strftime('%Y-%m-%d')
+    eastern = pytz.timezone('US/Eastern')
+    cutoff = (datetime.now(eastern) - timedelta(days=days)).strftime('%Y-%m-%d')
     recent = [s for s in data["summaries"] if s["date"] >= cutoff]
     return sorted(recent, key=lambda x: x["date"])
 
@@ -689,17 +694,18 @@ def save_crypto_summary(date_str, summary_text, web_search_used=False, news_cont
     # Remove existing summary for this date if present
     data["summaries"] = [s for s in data["summaries"] if s["date"] != date_str]
 
+    eastern = pytz.timezone('US/Eastern')
     # Add new summary
     data["summaries"].append({
         "date": date_str,
-        "generated_at": datetime.now().isoformat(),
+        "generated_at": datetime.now(eastern).isoformat(),
         "summary": summary_text,
         "web_search_used": web_search_used,
         "news_context": news_context[:500] if news_context else None
     })
 
     # Keep last 90 days of summaries
-    cutoff = (datetime.now() - timedelta(days=90)).strftime('%Y-%m-%d')
+    cutoff = (datetime.now(eastern) - timedelta(days=90)).strftime('%Y-%m-%d')
     data["summaries"] = [s for s in data["summaries"] if s["date"] >= cutoff]
 
     save_crypto_summaries(data)
@@ -750,7 +756,8 @@ def generate_crypto_summary(crypto_data_summary):
         }
 
     try:
-        today = datetime.now().strftime('%Y-%m-%d')
+        eastern = pytz.timezone('US/Eastern')
+        today = datetime.now(eastern).strftime('%Y-%m-%d')
 
         # Get previous crypto summaries for context
         recent_summaries = get_recent_crypto_summaries(days=3)
@@ -894,7 +901,8 @@ def get_recent_equity_summaries(days=3):
     if not data["summaries"]:
         return []
 
-    cutoff = (datetime.now() - timedelta(days=days)).strftime('%Y-%m-%d')
+    eastern = pytz.timezone('US/Eastern')
+    cutoff = (datetime.now(eastern) - timedelta(days=days)).strftime('%Y-%m-%d')
     recent = [s for s in data["summaries"] if s["date"] >= cutoff]
     return sorted(recent, key=lambda x: x["date"])
 
@@ -906,17 +914,18 @@ def save_equity_summary(date_str, summary_text, web_search_used=False, news_cont
     # Remove existing summary for this date if present
     data["summaries"] = [s for s in data["summaries"] if s["date"] != date_str]
 
+    eastern = pytz.timezone('US/Eastern')
     # Add new summary
     data["summaries"].append({
         "date": date_str,
-        "generated_at": datetime.now().isoformat(),
+        "generated_at": datetime.now(eastern).isoformat(),
         "summary": summary_text,
         "web_search_used": web_search_used,
         "news_context": news_context[:500] if news_context else None
     })
 
     # Keep last 90 days of summaries
-    cutoff = (datetime.now() - timedelta(days=90)).strftime('%Y-%m-%d')
+    cutoff = (datetime.now(eastern) - timedelta(days=90)).strftime('%Y-%m-%d')
     data["summaries"] = [s for s in data["summaries"] if s["date"] >= cutoff]
 
     save_equity_summaries(data)
@@ -967,7 +976,8 @@ def generate_equity_summary(equity_data_summary):
         }
 
     try:
-        today = datetime.now().strftime('%Y-%m-%d')
+        eastern = pytz.timezone('US/Eastern')
+        today = datetime.now(eastern).strftime('%Y-%m-%d')
 
         # Get previous equity summaries for context
         recent_summaries = get_recent_equity_summaries(days=3)
@@ -1093,6 +1103,7 @@ def save_rates_summary(date_str, summary_text, web_search_used=False, news_conte
     """Save a rates AI summary to storage."""
     data = load_rates_summaries()
 
+    eastern = pytz.timezone('US/Eastern')
     # Update existing or add new
     existing_idx = None
     for idx, s in enumerate(data["summaries"]):
@@ -1102,7 +1113,7 @@ def save_rates_summary(date_str, summary_text, web_search_used=False, news_conte
 
     summary_entry = {
         "date": date_str,
-        "generated_at": datetime.now().isoformat(),
+        "generated_at": datetime.now(eastern).isoformat(),
         "summary": summary_text,
         "web_search_used": web_search_used,
         "news_context": news_context[:500] if news_context else None
@@ -1186,7 +1197,8 @@ def generate_rates_summary(rates_data_summary):
         }
 
     try:
-        today = datetime.now().strftime('%Y-%m-%d')
+        eastern = pytz.timezone('US/Eastern')
+        today = datetime.now(eastern).strftime('%Y-%m-%d')
 
         # Get previous rates summaries for context
         recent_summaries = get_recent_rates_summaries(days=3)
@@ -1312,6 +1324,7 @@ def save_dollar_summary(date_str, summary_text, web_search_used=False, news_cont
     """Save a dollar AI summary to storage."""
     data = load_dollar_summaries()
 
+    eastern = pytz.timezone('US/Eastern')
     # Update existing or add new
     existing_idx = None
     for idx, s in enumerate(data["summaries"]):
@@ -1321,7 +1334,7 @@ def save_dollar_summary(date_str, summary_text, web_search_used=False, news_cont
 
     summary_entry = {
         "date": date_str,
-        "generated_at": datetime.now().isoformat(),
+        "generated_at": datetime.now(eastern).isoformat(),
         "summary": summary_text,
         "web_search_used": web_search_used,
         "news_context": news_context[:500] if news_context else None
@@ -1405,7 +1418,8 @@ def generate_dollar_summary(dollar_data_summary):
         }
 
     try:
-        today = datetime.now().strftime('%Y-%m-%d')
+        eastern = pytz.timezone('US/Eastern')
+        today = datetime.now(eastern).strftime('%Y-%m-%d')
 
         # Get previous dollar summaries for context
         recent_summaries = get_recent_dollar_summaries(days=3)
@@ -1531,6 +1545,7 @@ def save_portfolio_summary_entry(date_str, summary_text, portfolio_context=None)
     """Save a portfolio AI summary to storage."""
     data = load_portfolio_summaries()
 
+    eastern = pytz.timezone('US/Eastern')
     # Update existing or add new
     existing_idx = None
     for idx, s in enumerate(data["summaries"]):
@@ -1540,7 +1555,7 @@ def save_portfolio_summary_entry(date_str, summary_text, portfolio_context=None)
 
     summary_entry = {
         "date": date_str,
-        "generated_at": datetime.now().isoformat(),
+        "generated_at": datetime.now(eastern).isoformat(),
         "summary": summary_text,
         "portfolio_context": portfolio_context[:1000] if portfolio_context else None
     }
@@ -1606,6 +1621,7 @@ def db_save_portfolio_summary(user_id, date_str, summary_text, portfolio_context
     if not DB_AVAILABLE:
         return
 
+    eastern = pytz.timezone('US/Eastern')
     # Check if entry exists for this user and date
     existing = PortfolioSummary.query.filter_by(
         user_id=user_id,
@@ -1616,7 +1632,7 @@ def db_save_portfolio_summary(user_id, date_str, summary_text, portfolio_context
         # Update existing
         existing.summary = summary_text
         existing.portfolio_context = portfolio_context[:1000] if portfolio_context else None
-        existing.generated_at = datetime.now()
+        existing.generated_at = datetime.now(eastern)
     else:
         # Create new
         summary = PortfolioSummary(
@@ -1724,7 +1740,8 @@ def generate_portfolio_summary(portfolio_data, market_context, user_client=None,
         }
 
     try:
-        today = datetime.now().strftime('%Y-%m-%d')
+        eastern = pytz.timezone('US/Eastern')
+        today = datetime.now(eastern).strftime('%Y-%m-%d')
 
         # Get previous portfolio summaries for context (user-specific if user_id provided)
         if user_id and DB_AVAILABLE:

--- a/signaltrackers/comprehensive_report.py
+++ b/signaltrackers/comprehensive_report.py
@@ -8,6 +8,7 @@ import pandas as pd
 import numpy as np
 from pathlib import Path
 from datetime import datetime, timedelta
+import pytz
 
 
 class ComprehensiveAnalyzer:
@@ -98,9 +99,10 @@ class ComprehensiveAnalyzer:
     def print_comprehensive_report(self):
         """Generate comprehensive analysis report."""
 
+        eastern = pytz.timezone('US/Eastern')
         print("\n" + "="*100)
         print("COMPREHENSIVE MARKET ANALYSIS REPORT")
-        print(f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        print(f"Generated: {datetime.now(eastern).strftime('%Y-%m-%d %H:%M:%S')} ET")
         print("="*100)
 
         # SECTION 1: CREDIT MARKETS

--- a/signaltrackers/credit_signals.py
+++ b/signaltrackers/credit_signals.py
@@ -15,6 +15,7 @@ Data is appended daily to CSV files for historical tracking.
 import os
 import sys
 from datetime import datetime, timedelta
+import pytz
 import pandas as pd
 import requests
 from pathlib import Path
@@ -237,6 +238,7 @@ class CreditSignalsTracker:
         Args:
             lookback_days: Number of days to look back for new data (default: 12775, ~35 years)
         """
+        eastern = pytz.timezone('US/Eastern')
         print("\n=== Collecting FRED Data ===")
 
         for signal_name, series_id in self.fred_series.items():
@@ -250,7 +252,7 @@ class CreditSignalsTracker:
                 start_date = (last_date - timedelta(days=5)).strftime('%Y-%m-%d')
                 print(f"Last date in file: {last_date.date()}, fetching from {start_date}")
             else:
-                start_date = (datetime.now() - timedelta(days=lookback_days)).strftime('%Y-%m-%d')
+                start_date = (datetime.now(eastern) - timedelta(days=lookback_days)).strftime('%Y-%m-%d')
                 print(f"No existing data, fetching from {start_date}")
 
             df = self.fetch_fred_data(series_id, start_date=start_date)
@@ -266,6 +268,7 @@ class CreditSignalsTracker:
         Args:
             lookback_days: Number of days to look back for new data (default: 12775, ~35 years)
         """
+        eastern = pytz.timezone('US/Eastern')
         print("\n=== Collecting ETF Data ===")
 
         # Collect individual ETF data
@@ -276,7 +279,7 @@ class CreditSignalsTracker:
             last_date = self.get_last_date_in_file(filepath)
 
             # Always fetch based on lookback_days from today to get full history
-            start_date = (datetime.now() - timedelta(days=lookback_days)).strftime('%Y-%m-%d')
+            start_date = (datetime.now(eastern) - timedelta(days=lookback_days)).strftime('%Y-%m-%d')
 
             if last_date:
                 print(f"Last date in file: {last_date.date()}, fetching {lookback_days} days from {start_date}")
@@ -328,7 +331,8 @@ class CreditSignalsTracker:
         Args:
             lookback_days: Number of days to look back (default: 12775, ~35 years)
         """
-        print(f"Credit Signals Tracker - {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        eastern = pytz.timezone('US/Eastern')
+        print(f"Credit Signals Tracker - {datetime.now(eastern).strftime('%Y-%m-%d %H:%M:%S')} ET")
         print(f"Data directory: {self.data_dir.absolute()}")
 
         self.collect_fred_signals(lookback_days=lookback_days)

--- a/signaltrackers/dashboard.py
+++ b/signaltrackers/dashboard.py
@@ -779,8 +779,9 @@ def calculate_crisis_score():
 
 def get_dashboard_data():
     """Get all dashboard data."""
+    eastern = pytz.timezone('US/Eastern')
     data = {
-        'timestamp': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+        'timestamp': datetime.now(eastern).strftime('%Y-%m-%d %H:%M:%S'),
         'metrics': {},
         'charts': {},
         'warnings': []
@@ -1960,7 +1961,8 @@ def run_data_collection():
         if result2.returncode != 0:
             raise Exception(f"divergence_analysis.py failed: {result2.stderr}")
 
-        reload_status['last_reload'] = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        eastern = pytz.timezone('US/Eastern')
+        reload_status['last_reload'] = datetime.now(eastern).strftime('%Y-%m-%d %H:%M:%S')
         print("Data reload completed successfully!")
 
         # Generate market-specific briefings FIRST so they can be included in general summary
@@ -2845,9 +2847,10 @@ def api_debug_web_search():
 def generate_market_summary():
     """Generate a comprehensive market data summary for AI context."""
     try:
+        eastern = pytz.timezone('US/Eastern')
         summary_parts = []
         summary_parts.append("# CURRENT MARKET DATA SUMMARY")
-        summary_parts.append(f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        summary_parts.append(f"Generated: {datetime.now(eastern).strftime('%Y-%m-%d %H:%M:%S')} ET")
         summary_parts.append("")
 
         # Load all key metrics
@@ -3078,9 +3081,10 @@ def generate_market_summary():
 def generate_crypto_market_summary():
     """Generate a crypto-focused market data summary for the Crypto AI briefing."""
     try:
+        eastern = pytz.timezone('US/Eastern')
         summary_parts = []
         summary_parts.append("# CRYPTO/BITCOIN MARKET DATA SUMMARY")
-        summary_parts.append(f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        summary_parts.append(f"Generated: {datetime.now(eastern).strftime('%Y-%m-%d %H:%M:%S')} ET")
         summary_parts.append("")
 
         def get_stats(df):
@@ -3265,9 +3269,10 @@ def generate_crypto_market_summary():
 def generate_equity_market_summary():
     """Generate an equity-focused market data summary for the Equity AI briefing."""
     try:
+        eastern = pytz.timezone('US/Eastern')
         summary_parts = []
         summary_parts.append("# EQUITY MARKETS DATA SUMMARY")
-        summary_parts.append(f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        summary_parts.append(f"Generated: {datetime.now(eastern).strftime('%Y-%m-%d %H:%M:%S')} ET")
         summary_parts.append("")
 
         def get_stats(df):
@@ -3452,9 +3457,10 @@ def generate_equity_market_summary():
 def generate_rates_market_summary():
     """Generate a rates-focused market data summary for the Rates AI briefing."""
     try:
+        eastern = pytz.timezone('US/Eastern')
         summary_parts = []
         summary_parts.append("# RATES & YIELD CURVE DATA SUMMARY")
-        summary_parts.append(f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        summary_parts.append(f"Generated: {datetime.now(eastern).strftime('%Y-%m-%d %H:%M:%S')} ET")
         summary_parts.append("")
 
         def get_stats(df):
@@ -3685,9 +3691,10 @@ def generate_rates_market_summary():
 def generate_dollar_market_summary():
     """Generate a dollar-focused market data summary for the Dollar AI briefing."""
     try:
+        eastern = pytz.timezone('US/Eastern')
         summary_parts = []
         summary_parts.append("# DOLLAR & CURRENCY DATA SUMMARY")
-        summary_parts.append(f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        summary_parts.append(f"Generated: {datetime.now(eastern).strftime('%Y-%m-%d %H:%M:%S')} ET")
         summary_parts.append("")
 
         def get_stats(df):

--- a/signaltrackers/divergence_analysis.py
+++ b/signaltrackers/divergence_analysis.py
@@ -10,6 +10,7 @@ import pandas as pd
 import numpy as np
 from pathlib import Path
 from datetime import datetime
+import pytz
 
 
 class DivergenceAnalyzer:
@@ -255,9 +256,10 @@ class DivergenceAnalyzer:
         # Calculate crisis score
         crisis_score, warnings = self.calculate_crisis_score(metrics)
 
+        eastern = pytz.timezone('US/Eastern')
         print("\n" + "="*80)
         print("MARKET DIVERGENCE ANALYSIS")
-        print(f"Date: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        print(f"Date: {datetime.now(eastern).strftime('%Y-%m-%d %H:%M:%S')} ET")
         print("="*80)
 
         # Crisis Score

--- a/signaltrackers/export_for_ai.py
+++ b/signaltrackers/export_for_ai.py
@@ -8,6 +8,7 @@ import pandas as pd
 import numpy as np
 from pathlib import Path
 from datetime import datetime
+import pytz
 import json
 
 DATA_DIR = Path("data")
@@ -101,9 +102,10 @@ def generate_markdown_summary():
 
     output = []
 
+    eastern = pytz.timezone('US/Eastern')
     # Header
     output.append("# MACRO FINANCIAL DATA SUMMARY")
-    output.append(f"**Generated:** {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    output.append(f"**Generated:** {datetime.now(eastern).strftime('%Y-%m-%d %H:%M:%S')} ET")
     output.append("")
     output.append("This document contains a comprehensive summary of all tracked market metrics,")
     output.append("optimized for AI analysis. All data includes current values, trends, and recent history.")

--- a/signaltrackers/export_for_ai_neutral.py
+++ b/signaltrackers/export_for_ai_neutral.py
@@ -8,6 +8,7 @@ import pandas as pd
 import numpy as np
 from pathlib import Path
 from datetime import datetime
+import pytz
 import json
 
 DATA_DIR = Path("data")
@@ -133,9 +134,10 @@ def generate_markdown_summary():
 
     output = []
 
+    eastern = pytz.timezone('US/Eastern')
     # Header
     output.append("# MARKET DATA EXPORT")
-    output.append(f"**Export Date:** {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    output.append(f"**Export Date:** {datetime.now(eastern).strftime('%Y-%m-%d %H:%M:%S')} ET")
     output.append("")
     output.append("Comprehensive financial market data with statistics and trends.")
     output.append("All values presented as-is without interpretation.")
@@ -367,7 +369,7 @@ def generate_markdown_summary():
     output.append("")
     output.append("## METADATA")
     output.append("")
-    output.append(f"- **Export Timestamp:** {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    output.append(f"- **Export Timestamp:** {datetime.now(eastern).strftime('%Y-%m-%d %H:%M:%S')} ET")
     output.append(f"- **Data Directory:** {DATA_DIR}")
     output.append(f"- **Number of Metrics:** {len(all_stats)}")
     output.append(f"- **Total Observations:** {sum(s.get('count', 0) for s in all_stats.values())}")

--- a/signaltrackers/market_signals.py
+++ b/signaltrackers/market_signals.py
@@ -20,6 +20,7 @@ Data is appended daily to CSV files for historical tracking.
 import os
 import sys
 from datetime import datetime, timedelta
+import pytz
 import pandas as pd
 import requests
 from pathlib import Path
@@ -306,6 +307,7 @@ class MarketSignalsTracker:
         Args:
             lookback_days: Number of days to look back (default: 12775, ~35 years)
         """
+        eastern = pytz.timezone('US/Eastern')
         print("\n=== Collecting FRED Credit Data ===")
 
         for signal_name, series_id in self.fred_series.items():
@@ -315,7 +317,7 @@ class MarketSignalsTracker:
             last_date = self.get_last_date_in_file(filepath)
 
             # Always fetch based on lookback_days from today
-            start_date = (datetime.now() - timedelta(days=lookback_days)).strftime('%Y-%m-%d')
+            start_date = (datetime.now(eastern) - timedelta(days=lookback_days)).strftime('%Y-%m-%d')
 
             if last_date:
                 print(f"Last date in file: {last_date.date()}, fetching {lookback_days} days from {start_date}")
@@ -334,6 +336,7 @@ class MarketSignalsTracker:
         Args:
             lookback_days: Number of days to look back (default: 12775, ~35 years)
         """
+        eastern = pytz.timezone('US/Eastern')
         print("\n=== Collecting Market ETF Data ===")
 
         for signal_name, ticker in self.etf_tickers.items():
@@ -343,7 +346,7 @@ class MarketSignalsTracker:
             last_date = self.get_last_date_in_file(filepath)
 
             # Always fetch based on lookback_days from today
-            start_date = (datetime.now() - timedelta(days=lookback_days)).strftime('%Y-%m-%d')
+            start_date = (datetime.now(eastern) - timedelta(days=lookback_days)).strftime('%Y-%m-%d')
 
             if last_date:
                 print(f"Last date in file: {last_date.date()}, fetching {lookback_days} days from {start_date}")
@@ -630,7 +633,8 @@ class MarketSignalsTracker:
         Args:
             lookback_days: Number of days to look back (default: 12775, ~35 years)
         """
-        print(f"Market Signals Tracker - {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        eastern = pytz.timezone('US/Eastern')
+        print(f"Market Signals Tracker - {datetime.now(eastern).strftime('%Y-%m-%d %H:%M:%S')} ET")
         print(f"Data directory: {self.data_dir.absolute()}")
 
         self.collect_fred_signals(lookback_days=lookback_days)

--- a/signaltrackers/services/alert_email_service.py
+++ b/signaltrackers/services/alert_email_service.py
@@ -6,6 +6,7 @@ Supports single alerts and batching multiple alerts into one email.
 """
 
 from datetime import datetime
+import pytz
 from flask import current_app
 from services.email_service import send_email
 from models.alert import Alert
@@ -121,11 +122,12 @@ def send_alert_notification(user, alerts):
         # Get base URL from config
         base_url = current_app.config.get('BASE_URL', 'http://localhost:5000')
 
+        eastern = pytz.timezone('US/Eastern')
         # Prepare template context
         context = {
             'user': user,
             'alerts': formatted_alerts,
-            'triggered_time': datetime.now().strftime('%A, %B %d, %Y at %I:%M %p'),
+            'triggered_time': datetime.now(eastern).strftime('%A, %B %d, %Y at %I:%M %p ET'),
             'header_bg_color': colors['header_bg'],
             'header_text_color': colors['header_text'],
             'border_color': colors['border'],

--- a/signaltrackers/services/briefing_email_service.py
+++ b/signaltrackers/services/briefing_email_service.py
@@ -183,11 +183,12 @@ def send_daily_briefing_to_user(user):
         triggered_alerts = get_user_triggered_alerts(user.id)
         portfolio_analysis = get_portfolio_analysis_snippet(user)
 
+        eastern = pytz.timezone('US/Eastern')
         # Prepare template context
         base_url = current_app.config['BASE_URL']
         context = {
             'user': user,
-            'briefing_date': datetime.now().strftime('%A, %B %d, %Y'),
+            'briefing_date': datetime.now(eastern).strftime('%A, %B %d, %Y'),
             'market_briefing_html': briefing['html'],
             'market_briefing_text': briefing['text'],
             'market_synthesis': briefing['synthesis'],
@@ -201,7 +202,7 @@ def send_daily_briefing_to_user(user):
         }
 
         # Send email
-        subject = f"Your SignalTrackers Daily Briefing - {datetime.now().strftime('%b %d')}"
+        subject = f"Your SignalTrackers Daily Briefing - {datetime.now(eastern).strftime('%b %d')}"
         success = send_email(
             to=user.email,
             subject=subject,


### PR DESCRIPTION
## Summary
Fixes AI summaries and market data to display Eastern Time dates instead of UTC, resolving the issue where summaries showed tomorrow's date when generated in the evening EST.

## Problem
At **8:35 PM EST on Feb 12, 2026**:
- Container time (UTC): **1:35 AM Feb 13, 2026**
- Equity briefing showed: **"Generated on 2/13/2026"**
- Expected: **"Generated on 2/12/2026"**

## Root Cause
`datetime.now()` returns the container's timezone (UTC), not the user's timezone (EST).

## Solution
- Added `pytz` imports to all affected modules
- Converted all `datetime.now()` calls to use `pytz.timezone('US/Eastern')`
- Added "ET" suffix to timestamp displays for clarity

## Files Changed
- `ai_summary.py`: All summary generation and save functions
- `dashboard.py`: All market summary generation functions  
- `briefing_email_service.py`: Briefing date and subject
- `alert_email_service.py`: Alert trigger time
- `export_for_ai.py`, `export_for_ai_neutral.py`: Export timestamps
- `comprehensive_report.py`: Report generation timestamp
- `market_signals.py`, `credit_signals.py`, `divergence_analysis.py`: Data collection timestamps

## Testing
All affected code paths now use:
```python
eastern = pytz.timezone('US/Eastern')
datetime.now(eastern).strftime('%Y-%m-%d %H:%M:%S') + ' ET'
```

## Impact
- ✅ AI summaries show correct Eastern Time dates
- ✅ Timestamp displays include "ET" to clarify timezone
- ✅ Consistent timezone across all data collection and display
- ✅ Matches scheduled refresh time (5:30 PM ET)

Fixes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)