### PR TITLE
Fix context processor crash in background jobs

### DIFF
--- a/signaltrackers/dashboard.py
+++ b/signaltrackers/dashboard.py
@@ -121,13 +121,20 @@ def format_number(value):
 @app.context_processor
 def inject_unread_alerts():
     """Inject unread alert count into all templates."""
-    if current_user.is_authenticated:
-        from models.alert import Alert
-        count = Alert.query.filter_by(
-            user_id=current_user.id,
-            read=False
-        ).count()
-        return {'unread_alert_count': count}
+    # Handle case where current_user doesn't exist (background jobs, email rendering)
+    try:
+        from flask_login import current_user
+        if current_user and current_user.is_authenticated:
+            from models.alert import Alert
+            count = Alert.query.filter_by(
+                user_id=current_user.id,
+                read=False
+            ).count()
+            return {'unread_alert_count': count}
+    except (AttributeError, RuntimeError):
+        # current_user doesn't exist in this context (background jobs)
+        pass
+
     return {'unread_alert_count': 0}
 
 


### PR DESCRIPTION
## Summary

Fixes #66

The `inject_unread_alerts()` context processor was crashing when rendering email templates in background jobs because `current_user` is `None` outside of Flask request contexts.

### Changes Made

- Added try/except block to gracefully handle cases where `current_user` doesn't exist
- Added explicit check for `current_user is not None` before accessing attributes
- Import `current_user` from `flask_login` within the try block
- Return default value (`unread_alert_count: 0`) when in background job context

### Root Cause

Background scheduled jobs (like `send_daily_briefings()`) run without a Flask request context. In this context, `current_user` from `flask_login` is `None`, not even `AnonymousUser`. Accessing `current_user.is_authenticated` when `current_user` is `None` raised `AttributeError`.

### Files Changed

- [signaltrackers/dashboard.py:121-138](signaltrackers/dashboard.py#L121-L138) - Fixed context processor

### Testing

- [x] Manually triggered daily briefing job - no AttributeError
- [x] Verified the context processor returns correct default in background context
- [x] Code review - follows proposed fix from issue description

### Impact

- **Before:** Daily briefing emails failed to send (P0 critical bug)
- **After:** Emails render successfully in background jobs while maintaining unread alert count functionality in web contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)