### PR TITLE
US-4.1.1: Backend macro regime calculation engine

### DIFF
--- a/signaltrackers/regime_config.py
+++ b/signaltrackers/regime_config.py
@@ -1,0 +1,257 @@
+"""
+Static configuration for macro regime detection.
+
+Stores regime metadata, plain-language summaries, category context sentences,
+signal annotations, and highlighted signal definitions for all four regime states.
+
+All strings are constrained to character limits per design spec:
+- Plain-language summaries: max 200 chars
+- Category context sentences: max 100 chars per category × regime
+- Signal annotations: max 100 chars per signal × regime
+"""
+
+# ---------------------------------------------------------------------------
+# Regime metadata: icons, colors, summaries
+# ---------------------------------------------------------------------------
+
+REGIME_METADATA = {
+    'Bull': {
+        'icon': 'bi-arrow-up-circle-fill',
+        'css_class': 'regime-bull',
+        # Summary: max 200 chars
+        'summary': (
+            'Growth is accelerating and credit markets are calm. '
+            'Risk assets are broadly supported. Momentum favors equities and credit.'
+        ),
+        # Highlighted signals (2-3): signal keys matching CSV filenames / metric keys
+        'highlighted_signals': ['sp500', 'high_yield_spread', 'initial_claims'],
+    },
+    'Neutral': {
+        'icon': 'bi-dash-circle-fill',
+        'css_class': 'regime-neutral',
+        'summary': (
+            'Mixed macro signals with no clear directional trend. '
+            'Credit and growth indicators are balanced. Selective positioning is warranted.'
+        ),
+        'highlighted_signals': ['yield_curve_10y2y', 'nfci', 'initial_claims'],
+    },
+    'Bear': {
+        'icon': 'bi-arrow-down-circle-fill',
+        'css_class': 'regime-bear',
+        'summary': (
+            'Growth is decelerating and credit spreads are widening. '
+            'Risk assets face headwinds. Watch credit and safe haven signals closely.'
+        ),
+        'highlighted_signals': ['high_yield_spread', 'vix', 'gold'],
+    },
+    'Recession Watch': {
+        'icon': 'bi-exclamation-circle-fill',
+        'css_class': 'regime-recession',
+        'summary': (
+            'Contraction indicators are active. Credit stress is elevated '
+            'and labor markets are weakening. Defensive positioning is prudent.'
+        ),
+        'highlighted_signals': ['high_yield_spread', 'yield_curve_10y2y', 'initial_claims'],
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Category context sentences for the compact regime strip on detail pages.
+# 6 categories × 4 regimes = 24 strings. Max 100 chars each.
+# ---------------------------------------------------------------------------
+
+CATEGORY_REGIME_CONTEXT = {
+    'Credit': {
+        'Bull': 'Spreads are tight; credit is a carry trade in this regime.',
+        'Neutral': 'Spreads near historic median; selective credit is viable.',
+        'Bear': 'Spreads widening; credit stress is building here.',
+        'Recession Watch': 'Spreads at distress levels; avoid lower-rated credit.',
+    },
+    'Rates': {
+        'Bull': 'Curve steepening; duration risk is elevated.',
+        'Neutral': 'Curve mixed; duration calls depend on inflation data.',
+        'Bear': 'Yield curve inversions carry higher recession predictive weight.',
+        'Recession Watch': 'Front-end rates may fall; long-duration bonds attract safety bids.',
+    },
+    'Equities': {
+        'Bull': 'Breadth and momentum favor equities broadly.',
+        'Neutral': 'Rotation between sectors; earnings quality matters most.',
+        'Bear': 'Multiple compression underway; focus on earnings resilience.',
+        'Recession Watch': 'Defensive sectors outperform; avoid cyclicals and small caps.',
+    },
+    'Dollar': {
+        'Bull': 'Risk-on flows weaken the dollar; EM assets benefit.',
+        'Neutral': 'Dollar range-bound; watch Fed signals for direction.',
+        'Bear': 'Dollar may strengthen as a haven; watch carry unwinds.',
+        'Recession Watch': 'Safe-haven dollar demand typically spikes in contraction.',
+    },
+    'Crypto': {
+        'Bull': 'Risk-on regime supports crypto; beta to equities is high.',
+        'Neutral': 'Crypto follows equities; no regime-specific edge here.',
+        'Bear': 'Liquidity tightens; crypto faces outsized drawdown risk.',
+        'Recession Watch': 'Crypto is a high-risk asset; severe drawdowns are likely.',
+    },
+    'Safe Havens': {
+        'Bull': 'Gold and bonds underperform as risk appetite dominates.',
+        'Neutral': 'Safe havens are range-bound; hedge selectively.',
+        'Bear': 'Gold and long-duration bonds outperform; hedge here.',
+        'Recession Watch': 'Safe havens are primary defense; overweight gold and Treasuries.',
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Signal regime annotations: brief text shown on expanded metric cards.
+# Max 100 chars each.
+# ---------------------------------------------------------------------------
+
+SIGNAL_REGIME_ANNOTATIONS = {
+    'high_yield_spread': {
+        'Bull': '▲ Tight spreads confirm risk-on sentiment.',
+        'Neutral': '─ Spreads near median; no strong credit signal.',
+        'Bear': '▲ Widening spreads signal rising default risk.',
+        'Recession Watch': '▲ Distress-level spreads; credit crisis risk is elevated.',
+    },
+    'investment_grade_spread': {
+        'Bull': '✓ IG spreads tight; investment-grade credit supported.',
+        'Neutral': '─ IG spreads near median; carry trade viable.',
+        'Bear': '▲ IG spreads widening; quality credit under pressure.',
+        'Recession Watch': '▲ IG spreads at stress levels; quality flight underway.',
+    },
+    'ccc_spread': {
+        'Bull': '✓ CCC spreads tight; risk appetite is elevated.',
+        'Neutral': '─ CCC spreads near median; selective risk taking.',
+        'Bear': '▲ CCC spreads widening; high default risk ahead.',
+        'Recession Watch': '▲ CCC spreads at extreme levels; avoid distressed credit.',
+    },
+    'yield_curve_10y2y': {
+        'Bull': '▲ Steepening curve supports growth outlook.',
+        'Neutral': '─ Flat curve; mixed growth vs inflation signals.',
+        'Bear': '▲ Inversion deepening; recession risk rising.',
+        'Recession Watch': '▲ Deeply inverted; contraction historically follows.',
+    },
+    'yield_curve_10y3m': {
+        'Bull': '✓ Positive slope confirms expansion continues.',
+        'Neutral': '─ Slope near flat; watch for inversion.',
+        'Bear': '▲ Inversion signals growth concerns ahead.',
+        'Recession Watch': '▲ Deep inversion; historically high recession probability.',
+    },
+    'treasury_10y': {
+        'Bull': '▲ Rising yields reflect strong growth expectations.',
+        'Neutral': '─ Yields stable; inflation and growth in balance.',
+        'Bear': '▲ Rising yields here signal growth concerns, not inflation.',
+        'Recession Watch': '✓ Falling yields reflect flight to safety and rate cut bets.',
+    },
+    'nfci': {
+        'Bull': '✓ Loose financial conditions fuel risk asset demand.',
+        'Neutral': '─ Financial conditions near neutral; no directional edge.',
+        'Bear': '▲ Tightening conditions restrict credit and growth.',
+        'Recession Watch': '▲ Severely tight; systemic risk is elevated.',
+    },
+    'initial_claims': {
+        'Bull': '✓ Low claims confirm healthy labor market.',
+        'Neutral': '─ Claims near trend; labor market stable.',
+        'Bear': '▲ Rising claims signal labor market softening.',
+        'Recession Watch': '▲ Spiking claims; labor market contraction underway.',
+    },
+    'continuing_claims': {
+        'Bull': '✓ Low continuing claims; job-finders market persists.',
+        'Neutral': '─ Continuing claims stable; no labor market alarm.',
+        'Bear': '▲ Continuing claims rising; re-employment harder.',
+        'Recession Watch': '▲ Elevated continuing claims; broad job losses underway.',
+    },
+    'consumer_confidence': {
+        'Bull': '✓ High consumer confidence supports spending growth.',
+        'Neutral': '─ Consumer confidence near historic median.',
+        'Bear': '▲ Fading confidence signals spending pullback ahead.',
+        'Recession Watch': '▲ Low confidence; demand destruction risk is high.',
+    },
+    'vix': {
+        'Bull': '✓ Low VIX reflects market complacency.',
+        'Neutral': '─ VIX in normal range; no elevated fear.',
+        'Bear': '▲ Elevated VIX signals investor anxiety.',
+        'Recession Watch': '▲ Extreme VIX; capitulation conditions possible.',
+    },
+    'gold': {
+        'Bull': '─ Gold underperforms in risk-on regimes.',
+        'Neutral': '─ Gold range-bound without a clear regime catalyst.',
+        'Bear': '✓ Gold outperforms as a defensive hedge here.',
+        'Recession Watch': '✓ Gold confirming flight-to-safety demand.',
+    },
+    'real_yield_10y': {
+        'Bull': '▲ Rising real yields constrain gold and credit multiples.',
+        'Neutral': '─ Real yields near neutral; balanced macro backdrop.',
+        'Bear': '✓ Falling real yields support gold and duration.',
+        'Recession Watch': '✓ Deeply negative real yields favor gold and long bonds.',
+    },
+    'breakeven_inflation_10y': {
+        'Bull': '▲ Rising breakevens reflect growth-driven inflation expectations.',
+        'Neutral': '─ Breakevens anchored near Fed target.',
+        'Bear': '─ Breakevens falling; disinflation risk building.',
+        'Recession Watch': '─ Breakevens collapsing; deflation risk elevated.',
+    },
+    'sp500': {
+        'Bull': '✓ Equities in uptrend; momentum is your friend.',
+        'Neutral': '─ Equities range-bound; sector rotation active.',
+        'Bear': '▲ Equities correcting; downside risk elevated.',
+        'Recession Watch': '▲ Deep drawdowns possible; preserve capital.',
+    },
+    'fed_funds_rate': {
+        'Bull': '▲ Accommodative rate supports risk appetite.',
+        'Neutral': '─ Rates near neutral; Fed in wait-and-see mode.',
+        'Bear': '▲ Restrictive rate weighs on growth and credit.',
+        'Recession Watch': '✓ Rate cuts incoming or underway; watch pace.',
+    },
+    'fed_balance_sheet': {
+        'Bull': '✓ Expanding balance sheet adds liquidity to markets.',
+        'Neutral': '─ Balance sheet stable; QE/QT roughly balanced.',
+        'Bear': '▲ Shrinking balance sheet removes market liquidity.',
+        'Recession Watch': '✓ Expect QE restart; liquidity injection likely.',
+    },
+    'm2_money_supply': {
+        'Bull': '✓ Expanding M2 supports asset prices and growth.',
+        'Neutral': '─ M2 growth near trend; liquidity conditions normal.',
+        'Bear': '▲ Slowing M2 growth signals tightening liquidity.',
+        'Recession Watch': '▲ Contracting M2 historically precedes deep recessions.',
+    },
+    'dollar_index': {
+        'Bull': '─ Weak dollar supports EM and commodities.',
+        'Neutral': '─ Dollar near fair value; no regime-driven signal.',
+        'Bear': '▲ Strengthening dollar tightens global financial conditions.',
+        'Recession Watch': '▲ Dollar safe-haven bid; EM assets face pressure.',
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Category regime relevance: which categories are elevated in each regime.
+# Only categories in this list get the regime-relevance dot on badge-cards.
+# ---------------------------------------------------------------------------
+
+REGIME_CATEGORY_RELEVANCE = {
+    'Bull': ['Equities', 'Credit'],
+    'Neutral': ['Rates', 'Equities'],
+    'Bear': ['Credit', 'Rates', 'Safe Havens'],
+    'Recession Watch': ['Credit', 'Rates', 'Safe Havens', 'Equities'],
+}
+
+# ---------------------------------------------------------------------------
+# FRED series used for regime classification
+# These must match the series IDs in market_signals.py
+# ---------------------------------------------------------------------------
+
+REGIME_CLASSIFICATION_FEATURES = {
+    # Key: local CSV filename stem / metric key
+    # Value: FRED series ID
+    'high_yield_spread': 'BAMLH0A0HYM2',
+    'yield_curve_10y2y': 'T10Y2Y',
+    'nfci': 'NFCI',
+    'initial_claims': 'ICSA',
+    'fed_funds_rate': 'FEDFUNDS',
+}
+
+# Valid regime state names
+VALID_REGIMES = ('Bull', 'Neutral', 'Bear', 'Recession Watch')
+
+# Confidence thresholds (as fraction of median intra-cluster distance)
+# Below LOW_THRESHOLD: High confidence; above HIGH_THRESHOLD: Low confidence
+CONFIDENCE_LOW_THRESHOLD = 0.5
+CONFIDENCE_HIGH_THRESHOLD = 1.5

--- a/signaltrackers/regime_detection.py
+++ b/signaltrackers/regime_detection.py
@@ -1,0 +1,430 @@
+"""
+Macro regime detection engine.
+
+Derives the current Bull / Neutral / Bear / Recession Watch macro regime
+state from FRED economic data using a modified k-means clustering approach
+inspired by Oliveira et al. (arXiv 2503.11499).
+
+Data sourcing priority:
+1. Read from local CSV files (populated by market_signals.py daily run)
+2. Fetch from FRED API directly if CSV files are unavailable
+3. Fall back to rule-based classification if no data can be obtained
+
+Caching:
+- Result is stored in data/macro_regime_cache.json after each calculation
+- Cache is read by the Flask context processor on every request
+- Cache is refreshed by calling update_macro_regime() in run_data_collection()
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+from regime_config import (
+    CONFIDENCE_HIGH_THRESHOLD,
+    CONFIDENCE_LOW_THRESHOLD,
+    REGIME_CLASSIFICATION_FEATURES,
+    REGIME_METADATA,
+    VALID_REGIMES,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CACHE_FILE = Path(__file__).parent / 'data' / 'macro_regime_cache.json'
+DATA_DIR = Path(__file__).parent / 'data'
+
+# Number of months of history to use for k-means fitting
+HISTORY_MONTHS = 60  # 5 years
+
+# Feature column names used in the model (order matters for centroid mapping)
+_FEATURES = list(REGIME_CLASSIFICATION_FEATURES.keys())
+
+# ---------------------------------------------------------------------------
+# Cache helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_cache() -> Optional[dict]:
+    """Return cached regime dict, or None if cache doesn't exist."""
+    try:
+        if CACHE_FILE.exists():
+            with open(CACHE_FILE, 'r') as f:
+                return json.load(f)
+    except Exception as exc:
+        logger.warning('Failed to read regime cache: %s', exc)
+    return None
+
+
+def _save_cache(regime_dict: dict) -> None:
+    """Persist regime dict to cache file."""
+    try:
+        CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with open(CACHE_FILE, 'w') as f:
+            json.dump(regime_dict, f, default=str, indent=2)
+    except Exception as exc:
+        logger.warning('Failed to write regime cache: %s', exc)
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+
+def _load_csv_series(metric_key: str) -> Optional[pd.Series]:
+    """
+    Load a time series from an existing CSV data file.
+
+    Returns a pandas Series indexed by date, or None if the file doesn't
+    exist or can't be read.
+    """
+    csv_path = DATA_DIR / f'{metric_key}.csv'
+    if not csv_path.exists():
+        return None
+    try:
+        df = pd.read_csv(csv_path)
+        if df.empty or len(df.columns) < 2:
+            return None
+        df['date'] = pd.to_datetime(df['date'])
+        value_col = df.columns[1]
+        df = df.dropna(subset=[value_col]).set_index('date')
+        return df[value_col].astype(float)
+    except Exception as exc:
+        logger.warning('Failed to read CSV for %s: %s', metric_key, exc)
+        return None
+
+
+def _fetch_fred_series(fred_series_id: str, fred_api_key: str) -> Optional[pd.Series]:
+    """Fetch a FRED series via API. Returns Series indexed by date or None."""
+    import requests
+
+    url = 'https://api.stlouisfed.org/fred/series/observations'
+    params = {
+        'series_id': fred_series_id,
+        'api_key': fred_api_key,
+        'file_type': 'json',
+        'observation_start': '2000-01-01',
+        'sort_order': 'asc',
+        'units': 'lin',
+    }
+    try:
+        resp = requests.get(url, params=params, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        obs = data.get('observations', [])
+        if not obs:
+            return None
+        rows = [
+            (o['date'], float(o['value']))
+            for o in obs
+            if o['value'] != '.'
+        ]
+        if not rows:
+            return None
+        dates, values = zip(*rows)
+        return pd.Series(values, index=pd.to_datetime(dates), dtype=float)
+    except Exception as exc:
+        logger.warning('FRED fetch failed for %s: %s', fred_series_id, exc)
+        return None
+
+
+def _load_feature_data() -> Optional[pd.DataFrame]:
+    """
+    Build a DataFrame of feature columns, sourced from CSV files first
+    and FRED API as fallback.
+
+    Returns a monthly-resampled DataFrame, or None if insufficient data.
+    """
+    fred_api_key = os.environ.get('FRED_API_KEY', '')
+    series_map: dict[str, pd.Series] = {}
+
+    for metric_key, fred_id in REGIME_CLASSIFICATION_FEATURES.items():
+        # Try local CSV first
+        series = _load_csv_series(metric_key)
+        if series is None or len(series) < 12:
+            # Fall back to FRED API
+            if fred_api_key:
+                series = _fetch_fred_series(fred_id, fred_api_key)
+            else:
+                logger.warning(
+                    'No local data for %s and FRED_API_KEY not set; skipping.',
+                    metric_key,
+                )
+        if series is not None and not series.empty:
+            series_map[metric_key] = series
+
+    if len(series_map) < 2:
+        logger.warning('Insufficient feature data for regime classification.')
+        return None
+
+    # Align to monthly frequency (end of month)
+    df = pd.DataFrame(series_map)
+    df = df.resample('ME').last()
+    df = df.dropna(how='all')
+    return df
+
+
+# ---------------------------------------------------------------------------
+# Rule-based fallback classifier
+# ---------------------------------------------------------------------------
+
+
+def _rule_based_regime(latest: dict) -> str:
+    """
+    Simple threshold-based regime classification.
+
+    Used when there is insufficient historical data for k-means.
+    """
+    hy = latest.get('high_yield_spread', None)
+    curve = latest.get('yield_curve_10y2y', None)
+    nfci = latest.get('nfci', None)
+    claims = latest.get('initial_claims', None)
+
+    stress_score = 0
+
+    if hy is not None:
+        if hy > 600:
+            stress_score += 3
+        elif hy > 450:
+            stress_score += 2
+        elif hy > 300:
+            stress_score += 1
+
+    if curve is not None:
+        if curve < -0.5:
+            stress_score += 3
+        elif curve < 0:
+            stress_score += 1
+
+    if nfci is not None:
+        if nfci > 0.5:
+            stress_score += 2
+        elif nfci > 0:
+            stress_score += 1
+
+    if claims is not None:
+        # Claims > 300k is elevated; >400k is severe
+        if claims > 400:
+            stress_score += 2
+        elif claims > 300:
+            stress_score += 1
+
+    if stress_score >= 7:
+        return 'Recession Watch'
+    elif stress_score >= 4:
+        return 'Bear'
+    elif stress_score >= 2:
+        return 'Neutral'
+    else:
+        return 'Bull'
+
+
+# ---------------------------------------------------------------------------
+# K-means classification
+# ---------------------------------------------------------------------------
+
+
+def _kmeans_regime(df: pd.DataFrame) -> tuple[str, str]:
+    """
+    Classify the most recent data point using k-means clustering (k=4).
+
+    Returns (regime_name, confidence_level).
+
+    Cluster-to-regime mapping is determined by sorting cluster centroids
+    by a macro stress composite score:
+        stress = HY_spread_norm + (-yield_curve_norm) + NFCI_norm + claims_norm
+
+    Highest stress centroid → Recession Watch, then Bear, Neutral, Bull.
+    """
+    from sklearn.cluster import KMeans
+    from sklearn.preprocessing import StandardScaler
+
+    # Use available columns only
+    available = [col for col in _FEATURES if col in df.columns]
+    df_feat = df[available].copy()
+
+    # Use at most HISTORY_MONTHS of monthly data
+    if len(df_feat) > HISTORY_MONTHS:
+        df_feat = df_feat.iloc[-HISTORY_MONTHS:]
+
+    # Forward-fill then back-fill to handle gaps in monthly data
+    df_feat = df_feat.ffill().bfill()
+
+    # Drop rows with any remaining NaN (strict: need all features)
+    df_clean = df_feat.dropna()
+
+    if len(df_clean) < 24:  # Need at least 2 years to fit meaningfully
+        return 'Neutral', None  # Fallback
+
+    # Normalise features
+    scaler = StandardScaler()
+    X = scaler.fit_transform(df_clean.values)
+
+    # Fit k-means with k=4 and a fixed random seed for reproducibility
+    n_clusters = 4
+    kmeans = KMeans(n_clusters=n_clusters, random_state=42, n_init=20)
+    kmeans.fit(X)
+
+    # Map clusters to regime names via stress score of centroids
+    centroids = kmeans.cluster_centers_  # shape (4, n_features)
+    stress_scores = _centroid_stress_scores(centroids, available)
+    # Sort cluster indices by ascending stress → [0=lowest=Bull, 3=highest=Recession]
+    sorted_clusters = np.argsort(stress_scores)  # ascending
+    regime_labels = ['Bull', 'Neutral', 'Bear', 'Recession Watch']
+    cluster_to_regime = {
+        sorted_clusters[i]: regime_labels[i]
+        for i in range(n_clusters)
+    }
+
+    # Classify the most recent data point
+    latest_raw = df_feat.iloc[-1:].ffill().bfill().dropna()
+    if latest_raw.empty:
+        return 'Neutral', None
+
+    latest_scaled = scaler.transform(latest_raw.values)
+    predicted_cluster = kmeans.predict(latest_scaled)[0]
+    regime = cluster_to_regime[predicted_cluster]
+
+    # Confidence: distance from assigned centroid vs. average intra-cluster distance
+    centroid_dist = np.linalg.norm(latest_scaled - kmeans.cluster_centers_[predicted_cluster])
+    # Approximate typical distance as sqrt of per-cluster inertia / cluster count
+    cluster_mask = kmeans.labels_ == predicted_cluster
+    cluster_points = X[cluster_mask]
+    if len(cluster_points) > 1:
+        avg_dist = np.mean(
+            np.linalg.norm(cluster_points - kmeans.cluster_centers_[predicted_cluster], axis=1)
+        )
+    else:
+        avg_dist = centroid_dist  # edge case
+
+    if avg_dist > 0:
+        ratio = centroid_dist / avg_dist
+    else:
+        ratio = 1.0
+
+    if ratio <= CONFIDENCE_LOW_THRESHOLD:
+        confidence = 'High'
+    elif ratio <= CONFIDENCE_HIGH_THRESHOLD:
+        confidence = 'Medium'
+    else:
+        confidence = 'Low'
+
+    return regime, confidence
+
+
+def _centroid_stress_scores(centroids: np.ndarray, features: list[str]) -> np.ndarray:
+    """
+    Compute a macro stress score for each k-means centroid.
+
+    Score = HY_norm + (-yield_curve_norm) + NFCI_norm + claims_norm
+    Higher score → higher stress → closer to Recession Watch.
+    """
+    scores = np.zeros(len(centroids))
+    feature_weights = {
+        'high_yield_spread': +1.5,   # Higher spread = more stress
+        'yield_curve_10y2y': -1.5,   # More negative curve = more stress
+        'nfci': +1.0,                # Higher NFCI = tighter conditions = stress
+        'initial_claims': +1.0,      # More claims = weaker labor = stress
+        'fed_funds_rate': +0.5,      # Higher rates = more restrictive (mild weight)
+    }
+    for i, feature in enumerate(features):
+        weight = feature_weights.get(feature, 0.0)
+        if weight != 0.0:
+            scores += weight * centroids[:, i]
+    return scores
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def get_macro_regime() -> Optional[dict]:
+    """
+    Return the current macro regime from cache.
+
+    Returns a dict with keys:
+        - state: str — one of VALID_REGIMES
+        - updated_at: str — ISO 8601 timestamp
+        - confidence: str|None — 'High', 'Medium', 'Low', or None
+    Or None if no cache exists.
+    """
+    return _load_cache()
+
+
+def update_macro_regime() -> Optional[dict]:
+    """
+    Run regime classification and update the cache.
+
+    Called by run_data_collection() after daily market data is refreshed.
+    Returns the new regime dict, or None on failure.
+    """
+    logger.info('Running macro regime classification...')
+
+    try:
+        df = _load_feature_data()
+
+        if df is None or df.empty:
+            # No data available — try rule-based with whatever is in cache
+            logger.warning('No feature data for regime classification; skipping update.')
+            return None
+
+        # Try k-means first; fall back to rule-based if sklearn is unavailable
+        try:
+            regime_name, confidence = _kmeans_regime(df)
+        except ImportError:
+            logger.warning('scikit-learn not available; using rule-based regime classification.')
+            latest_vals = {}
+            for col in _FEATURES:
+                if col in df.columns:
+                    series = df[col].dropna()
+                    if not series.empty:
+                        latest_vals[col] = float(series.iloc[-1])
+            regime_name = _rule_based_regime(latest_vals)
+            confidence = None
+
+        assert regime_name in VALID_REGIMES, f'Invalid regime: {regime_name}'
+
+        regime_dict = {
+            'state': regime_name,
+            'updated_at': datetime.now(timezone.utc).isoformat(),
+            'confidence': confidence,
+        }
+        _save_cache(regime_dict)
+        logger.info('Macro regime updated: %s (confidence: %s)', regime_name, confidence)
+        return regime_dict
+
+    except Exception as exc:
+        logger.error('Regime classification failed: %s', exc, exc_info=True)
+        return None
+
+
+def get_regime_config() -> dict:
+    """
+    Return the full static config for all regimes.
+
+    Convenience accessor so templates/tests can import a single module.
+    """
+    from regime_config import (
+        CATEGORY_REGIME_CONTEXT,
+        REGIME_CATEGORY_RELEVANCE,
+        SIGNAL_REGIME_ANNOTATIONS,
+    )
+    return {
+        'REGIME_METADATA': REGIME_METADATA,
+        'CATEGORY_REGIME_CONTEXT': CATEGORY_REGIME_CONTEXT,
+        'SIGNAL_REGIME_ANNOTATIONS': SIGNAL_REGIME_ANNOTATIONS,
+        'REGIME_CATEGORY_RELEVANCE': REGIME_CATEGORY_RELEVANCE,
+        'VALID_REGIMES': VALID_REGIMES,
+    }

--- a/signaltrackers/requirements.txt
+++ b/signaltrackers/requirements.txt
@@ -25,3 +25,6 @@ anthropic>=0.40.0
 apscheduler>=3.10.0
 pytz>=2024.1
 tzdata>=2024.1
+
+# Machine Learning (regime classification)
+scikit-learn>=1.3.0

--- a/tests/test_us411_regime_backend.py
+++ b/tests/test_us411_regime_backend.py
@@ -1,0 +1,510 @@
+"""
+Static verification tests for US-4.1.1: Backend — Macro regime calculation engine.
+
+These tests verify the implementation without requiring a live Flask server,
+external API calls, or a trained k-means model. They inspect source files and
+exercise the pure-Python logic directly.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SIGNALTRACKERS_DIR = os.path.join(REPO_ROOT, 'signaltrackers')
+sys.path.insert(0, SIGNALTRACKERS_DIR)
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def read_file(path):
+    with open(path, 'r') as f:
+        return f.read()
+
+
+# ---------------------------------------------------------------------------
+# regime_config.py tests
+# ---------------------------------------------------------------------------
+
+class TestRegimeConfigFileExists(unittest.TestCase):
+    """regime_config.py must exist."""
+
+    def test_regime_config_file_exists(self):
+        path = os.path.join(SIGNALTRACKERS_DIR, 'regime_config.py')
+        self.assertTrue(os.path.exists(path), f"Missing: {path}")
+
+
+class TestRegimeConfigStructure(unittest.TestCase):
+    """regime_config.py must define all required constants."""
+
+    def setUp(self):
+        import regime_config as rc
+        self.rc = rc
+
+    def test_valid_regimes_tuple(self):
+        """VALID_REGIMES must be a tuple of exactly 4 states."""
+        self.assertIsInstance(self.rc.VALID_REGIMES, tuple)
+        self.assertEqual(len(self.rc.VALID_REGIMES), 4)
+        self.assertIn('Bull', self.rc.VALID_REGIMES)
+        self.assertIn('Neutral', self.rc.VALID_REGIMES)
+        self.assertIn('Bear', self.rc.VALID_REGIMES)
+        self.assertIn('Recession Watch', self.rc.VALID_REGIMES)
+
+    def test_regime_metadata_has_all_states(self):
+        """REGIME_METADATA must have entries for all four regime states."""
+        for state in self.rc.VALID_REGIMES:
+            self.assertIn(state, self.rc.REGIME_METADATA, f"Missing state: {state}")
+
+    def test_regime_metadata_has_required_keys(self):
+        """Each entry in REGIME_METADATA must have icon, css_class, summary, highlighted_signals."""
+        for state, meta in self.rc.REGIME_METADATA.items():
+            self.assertIn('icon', meta, f"{state} missing 'icon'")
+            self.assertIn('css_class', meta, f"{state} missing 'css_class'")
+            self.assertIn('summary', meta, f"{state} missing 'summary'")
+            self.assertIn('highlighted_signals', meta, f"{state} missing 'highlighted_signals'")
+
+    def test_regime_summaries_max_200_chars(self):
+        """Plain-language summaries must be ≤ 200 characters."""
+        for state, meta in self.rc.REGIME_METADATA.items():
+            summary = meta['summary']
+            self.assertLessEqual(
+                len(summary), 200,
+                f"{state} summary too long ({len(summary)} chars): {summary}"
+            )
+
+    def test_highlighted_signals_count(self):
+        """Each regime must have 2–4 highlighted signals."""
+        for state, meta in self.rc.REGIME_METADATA.items():
+            signals = meta['highlighted_signals']
+            self.assertGreaterEqual(len(signals), 2, f"{state}: too few highlighted signals")
+            self.assertLessEqual(len(signals), 4, f"{state}: too many highlighted signals")
+
+    def test_highlighted_signals_never_empty_list(self):
+        """Highlighted signals must never be an empty list."""
+        for state, meta in self.rc.REGIME_METADATA.items():
+            self.assertTrue(len(meta['highlighted_signals']) > 0, f"{state} has no signals")
+
+    def test_category_regime_context_has_all_categories(self):
+        """CATEGORY_REGIME_CONTEXT must have 6 categories."""
+        expected = {'Credit', 'Rates', 'Equities', 'Dollar', 'Crypto', 'Safe Havens'}
+        actual = set(self.rc.CATEGORY_REGIME_CONTEXT.keys())
+        self.assertEqual(actual, expected)
+
+    def test_category_regime_context_has_all_regimes(self):
+        """Each category must have context for all 4 regimes."""
+        for category, contexts in self.rc.CATEGORY_REGIME_CONTEXT.items():
+            for state in self.rc.VALID_REGIMES:
+                self.assertIn(state, contexts, f"Missing regime '{state}' in category '{category}'")
+
+    def test_category_context_strings_max_100_chars(self):
+        """Category context sentences must be ≤ 100 characters."""
+        for category, contexts in self.rc.CATEGORY_REGIME_CONTEXT.items():
+            for state, sentence in contexts.items():
+                self.assertLessEqual(
+                    len(sentence), 100,
+                    f"{category}/{state} context too long ({len(sentence)}): {sentence}"
+                )
+
+    def test_category_context_count(self):
+        """Must have exactly 6 × 4 = 24 category context strings."""
+        count = sum(len(v) for v in self.rc.CATEGORY_REGIME_CONTEXT.values())
+        self.assertEqual(count, 24)
+
+    def test_signal_annotations_max_100_chars(self):
+        """Signal annotation strings must be ≤ 100 characters."""
+        for signal, annotations in self.rc.SIGNAL_REGIME_ANNOTATIONS.items():
+            for state, annotation in annotations.items():
+                self.assertLessEqual(
+                    len(annotation), 100,
+                    f"{signal}/{state} annotation too long ({len(annotation)}): {annotation}"
+                )
+
+    def test_signal_annotations_has_all_four_regimes(self):
+        """Each signal annotation entry must have all four regime states."""
+        for signal, annotations in self.rc.SIGNAL_REGIME_ANNOTATIONS.items():
+            for state in self.rc.VALID_REGIMES:
+                self.assertIn(
+                    state, annotations,
+                    f"Signal '{signal}' missing annotation for regime '{state}'"
+                )
+
+    def test_regime_category_relevance_has_all_states(self):
+        """REGIME_CATEGORY_RELEVANCE must have entries for all four regime states."""
+        for state in self.rc.VALID_REGIMES:
+            self.assertIn(state, self.rc.REGIME_CATEGORY_RELEVANCE)
+
+    def test_regime_category_relevance_values_are_lists(self):
+        """REGIME_CATEGORY_RELEVANCE values must be lists of category names."""
+        valid_categories = {'Credit', 'Rates', 'Equities', 'Dollar', 'Crypto', 'Safe Havens'}
+        for state, categories in self.rc.REGIME_CATEGORY_RELEVANCE.items():
+            self.assertIsInstance(categories, list, f"{state} relevance is not a list")
+            for cat in categories:
+                self.assertIn(cat, valid_categories, f"Unknown category '{cat}' in {state}")
+
+    def test_regime_category_relevance_not_all_six(self):
+        """Not all six categories should be flagged for Bull or Neutral (threshold-based)."""
+        for state in ('Bull', 'Neutral'):
+            categories = self.rc.REGIME_CATEGORY_RELEVANCE[state]
+            self.assertLess(
+                len(categories), 6,
+                f"{state} regime should not flag all 6 categories"
+            )
+
+    def test_regime_classification_features_defined(self):
+        """REGIME_CLASSIFICATION_FEATURES must map metric keys to FRED series IDs."""
+        features = self.rc.REGIME_CLASSIFICATION_FEATURES
+        self.assertIsInstance(features, dict)
+        self.assertGreater(len(features), 0)
+        for key, fred_id in features.items():
+            self.assertIsInstance(key, str)
+            self.assertIsInstance(fred_id, str)
+            self.assertTrue(len(fred_id) > 0, f"Empty FRED ID for {key}")
+
+
+# ---------------------------------------------------------------------------
+# regime_detection.py tests
+# ---------------------------------------------------------------------------
+
+class TestRegimeDetectionFileExists(unittest.TestCase):
+    """regime_detection.py must exist."""
+
+    def test_regime_detection_file_exists(self):
+        path = os.path.join(SIGNALTRACKERS_DIR, 'regime_detection.py')
+        self.assertTrue(os.path.exists(path), f"Missing: {path}")
+
+
+class TestGetMacroRegime(unittest.TestCase):
+    """get_macro_regime() must return correct structure or None."""
+
+    def test_returns_none_when_no_cache(self):
+        """get_macro_regime() returns None when cache file doesn't exist."""
+        from regime_detection import get_macro_regime, CACHE_FILE
+        with patch.object(Path, 'exists', return_value=False):
+            result = get_macro_regime()
+        self.assertIsNone(result)
+
+    def test_returns_dict_when_cache_exists(self):
+        """get_macro_regime() returns a dict from cache."""
+        import regime_detection as rd
+        sample = {
+            'state': 'Bear',
+            'updated_at': datetime.now(timezone.utc).isoformat(),
+            'confidence': 'High',
+        }
+        with patch.object(rd, '_load_cache', return_value=sample):
+            result = rd.get_macro_regime()
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['state'], 'Bear')
+
+    def test_returned_dict_has_required_keys(self):
+        """get_macro_regime() result must have state, updated_at, confidence."""
+        import regime_detection as rd
+        sample = {
+            'state': 'Neutral',
+            'updated_at': '2026-02-24T00:00:00+00:00',
+            'confidence': 'Medium',
+        }
+        with patch.object(rd, '_load_cache', return_value=sample):
+            result = rd.get_macro_regime()
+        self.assertIn('state', result)
+        self.assertIn('updated_at', result)
+        self.assertIn('confidence', result)
+
+    def test_state_must_be_valid_regime(self):
+        """state in cached dict must be one of the four valid regimes."""
+        import regime_detection as rd
+        from regime_config import VALID_REGIMES
+        sample = {
+            'state': 'Bull',
+            'updated_at': '2026-02-24T00:00:00+00:00',
+            'confidence': 'Low',
+        }
+        with patch.object(rd, '_load_cache', return_value=sample):
+            result = rd.get_macro_regime()
+        self.assertIn(result['state'], VALID_REGIMES)
+
+    def test_confidence_is_none_or_valid_string(self):
+        """confidence field must be 'High', 'Medium', 'Low', or None."""
+        import regime_detection as rd
+        for conf in ('High', 'Medium', 'Low', None):
+            sample = {
+                'state': 'Bull',
+                'updated_at': '2026-02-24T00:00:00+00:00',
+                'confidence': conf,
+            }
+            with patch.object(rd, '_load_cache', return_value=sample):
+                result = rd.get_macro_regime()
+            self.assertEqual(result['confidence'], conf)
+
+
+class TestRuleBasedRegime(unittest.TestCase):
+    """_rule_based_regime() must produce correct classifications."""
+
+    def setUp(self):
+        from regime_detection import _rule_based_regime
+        self.classify = _rule_based_regime
+
+    def test_high_stress_is_recession(self):
+        """Very high HY spread + inverted curve → Recession Watch."""
+        result = self.classify({
+            'high_yield_spread': 750,   # >600 → +3
+            'yield_curve_10y2y': -1.0,  # <-0.5 → +3
+            'nfci': 0.8,               # >0.5 → +2
+        })
+        self.assertEqual(result, 'Recession Watch')
+
+    def test_moderate_stress_is_bear(self):
+        """Moderate stress indicators → Bear."""
+        result = self.classify({
+            'high_yield_spread': 500,   # >450 → +2
+            'yield_curve_10y2y': -0.3,  # <0 → +1
+            'nfci': 0.3,               # >0 → +1
+        })
+        self.assertEqual(result, 'Bear')
+
+    def test_low_stress_is_bull(self):
+        """Low stress indicators → Bull."""
+        result = self.classify({
+            'high_yield_spread': 250,   # <300 → 0
+            'yield_curve_10y2y': 1.5,   # >0 → 0
+            'nfci': -0.5,              # <0 → 0
+            'initial_claims': 200,     # <300 → 0
+        })
+        self.assertEqual(result, 'Bull')
+
+    def test_handles_missing_fields_gracefully(self):
+        """_rule_based_regime must handle missing dict keys without raising."""
+        # Partial data — should still return a valid state
+        result = self.classify({'high_yield_spread': 400})
+        self.assertIn(result, ('Bull', 'Neutral', 'Bear', 'Recession Watch'))
+
+    def test_returns_one_of_four_valid_states(self):
+        """Rule-based classification always returns one of the four valid states."""
+        from regime_config import VALID_REGIMES
+        for scenario in [
+            {},
+            {'high_yield_spread': 300},
+            {'yield_curve_10y2y': -0.5},
+            {'high_yield_spread': 700, 'yield_curve_10y2y': -1.5},
+        ]:
+            result = self.classify(scenario)
+            self.assertIn(result, VALID_REGIMES, f"Invalid state '{result}' for {scenario}")
+
+
+class TestUpdateMacroRegime(unittest.TestCase):
+    """update_macro_regime() must update the cache correctly."""
+
+    def test_returns_none_on_no_data(self):
+        """update_macro_regime() returns None when no data is available."""
+        import regime_detection as rd
+        with patch.object(rd, '_load_feature_data', return_value=None):
+            result = rd.update_macro_regime()
+        self.assertIsNone(result)
+
+    def test_returns_regime_dict_on_success(self):
+        """update_macro_regime() returns a valid regime dict on success."""
+        import pandas as pd
+        import numpy as np
+        import regime_detection as rd
+        from regime_config import VALID_REGIMES
+
+        # Generate synthetic 5-year monthly data for all features
+        dates = pd.date_range('2021-01-31', periods=60, freq='ME')
+        np.random.seed(42)
+        synthetic_data = pd.DataFrame({
+            'high_yield_spread': np.abs(np.random.normal(400, 100, 60)),
+            'yield_curve_10y2y': np.random.normal(0, 0.5, 60),
+            'nfci': np.random.normal(0, 0.3, 60),
+            'initial_claims': np.abs(np.random.normal(250, 50, 60)),
+            'fed_funds_rate': np.random.uniform(0, 5.5, 60),
+        }, index=dates)
+
+        with patch.object(rd, '_load_feature_data', return_value=synthetic_data), \
+             patch.object(rd, '_save_cache', return_value=None):
+            result = rd.update_macro_regime()
+
+        self.assertIsNotNone(result)
+        self.assertIn('state', result)
+        self.assertIn('updated_at', result)
+        self.assertIn('confidence', result)
+        self.assertIn(result['state'], VALID_REGIMES)
+
+    def test_regime_calculation_isolates_failure(self):
+        """Failure in regime calculation should not crash — returns None."""
+        import regime_detection as rd
+        with patch.object(rd, '_load_feature_data', side_effect=RuntimeError('test error')):
+            result = rd.update_macro_regime()
+        self.assertIsNone(result)
+
+    def test_cache_is_written_on_success(self):
+        """update_macro_regime() must call _save_cache on success."""
+        import pandas as pd
+        import numpy as np
+        import regime_detection as rd
+
+        dates = pd.date_range('2021-01-31', periods=60, freq='ME')
+        np.random.seed(7)
+        synthetic_data = pd.DataFrame({
+            'high_yield_spread': np.abs(np.random.normal(350, 80, 60)),
+            'yield_curve_10y2y': np.random.normal(0.2, 0.4, 60),
+            'nfci': np.random.normal(-0.1, 0.3, 60),
+            'initial_claims': np.abs(np.random.normal(230, 40, 60)),
+            'fed_funds_rate': np.random.uniform(0, 5, 60),
+        }, index=dates)
+
+        with patch.object(rd, '_load_feature_data', return_value=synthetic_data), \
+             patch.object(rd, '_save_cache') as mock_save:
+            rd.update_macro_regime()
+
+        mock_save.assert_called_once()
+        saved_arg = mock_save.call_args[0][0]
+        self.assertIn('state', saved_arg)
+        self.assertIn('updated_at', saved_arg)
+
+
+class TestCacheRoundTrip(unittest.TestCase):
+    """_save_cache and _load_cache must round-trip correctly."""
+
+    def test_cache_round_trip(self):
+        """Saved regime dict should be identical to loaded dict."""
+        import regime_detection as rd
+
+        sample = {
+            'state': 'Neutral',
+            'updated_at': '2026-02-24T12:00:00+00:00',
+            'confidence': 'High',
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_cache = rd.CACHE_FILE
+            rd.CACHE_FILE = Path(tmpdir) / 'macro_regime_cache.json'
+            try:
+                rd._save_cache(sample)
+                loaded = rd._load_cache()
+            finally:
+                rd.CACHE_FILE = original_cache
+
+        self.assertEqual(loaded, sample)
+
+    def test_load_cache_returns_none_on_missing_file(self):
+        """_load_cache returns None when the cache file does not exist."""
+        import regime_detection as rd
+        original = rd.CACHE_FILE
+        rd.CACHE_FILE = Path('/tmp/nonexistent_regime_cache_xyz.json')
+        try:
+            result = rd._load_cache()
+        finally:
+            rd.CACHE_FILE = original
+        self.assertIsNone(result)
+
+    def test_load_cache_handles_corrupt_json(self):
+        """_load_cache returns None on malformed JSON."""
+        import regime_detection as rd
+        with tempfile.TemporaryDirectory() as tmpdir:
+            corrupt_path = Path(tmpdir) / 'macro_regime_cache.json'
+            corrupt_path.write_text('NOT VALID JSON {{{')
+            original = rd.CACHE_FILE
+            rd.CACHE_FILE = corrupt_path
+            try:
+                result = rd._load_cache()
+            finally:
+                rd.CACHE_FILE = original
+        self.assertIsNone(result)
+
+
+class TestGetRegimeConfig(unittest.TestCase):
+    """get_regime_config() must return complete config for all regimes."""
+
+    def test_returns_dict_with_all_keys(self):
+        """get_regime_config() must return all required config keys."""
+        from regime_detection import get_regime_config
+        config = get_regime_config()
+        required = {
+            'REGIME_METADATA', 'CATEGORY_REGIME_CONTEXT',
+            'SIGNAL_REGIME_ANNOTATIONS', 'REGIME_CATEGORY_RELEVANCE', 'VALID_REGIMES'
+        }
+        for key in required:
+            self.assertIn(key, config, f"Missing key: {key}")
+
+    def test_valid_regimes_has_four_states(self):
+        """VALID_REGIMES in returned config must have exactly four states."""
+        from regime_detection import get_regime_config
+        config = get_regime_config()
+        self.assertEqual(len(config['VALID_REGIMES']), 4)
+
+
+class TestDashboardIntegration(unittest.TestCase):
+    """dashboard.py must import and call regime functions."""
+
+    def test_regime_detection_imported_in_dashboard(self):
+        """dashboard.py must import get_macro_regime and update_macro_regime."""
+        dashboard_path = os.path.join(SIGNALTRACKERS_DIR, 'dashboard.py')
+        content = read_file(dashboard_path)
+        self.assertIn('get_macro_regime', content)
+        self.assertIn('update_macro_regime', content)
+
+    def test_inject_macro_regime_context_processor_present(self):
+        """dashboard.py must have inject_macro_regime context processor."""
+        dashboard_path = os.path.join(SIGNALTRACKERS_DIR, 'dashboard.py')
+        content = read_file(dashboard_path)
+        self.assertIn('inject_macro_regime', content)
+        self.assertIn('@app.context_processor', content)
+
+    def test_update_macro_regime_called_in_run_data_collection(self):
+        """run_data_collection must call update_macro_regime."""
+        dashboard_path = os.path.join(SIGNALTRACKERS_DIR, 'dashboard.py')
+        content = read_file(dashboard_path)
+        self.assertIn('update_macro_regime()', content)
+
+    def test_macro_regime_in_context(self):
+        """inject_macro_regime must inject 'macro_regime' key."""
+        dashboard_path = os.path.join(SIGNALTRACKERS_DIR, 'dashboard.py')
+        content = read_file(dashboard_path)
+        self.assertIn("'macro_regime'", content)
+
+
+class TestSecurityConstraints(unittest.TestCase):
+    """Security checks for the regime detection implementation."""
+
+    def test_no_user_input_in_regime_calculation(self):
+        """regime_detection.py must not use request object or user input."""
+        detection_path = os.path.join(SIGNALTRACKERS_DIR, 'regime_detection.py')
+        content = read_file(detection_path)
+        # No Flask request object — this is a backend-only calculation
+        self.assertNotIn('from flask import', content,
+                         "regime_detection.py should not import Flask directly")
+
+    def test_static_config_has_no_eval_calls(self):
+        """regime_config.py must not contain eval() or exec() calls."""
+        config_path = os.path.join(SIGNALTRACKERS_DIR, 'regime_config.py')
+        content = read_file(config_path)
+        self.assertNotIn('eval(', content)
+        self.assertNotIn('exec(', content)
+
+    def test_detection_has_no_eval_calls(self):
+        """regime_detection.py must not contain eval() or exec() calls."""
+        detection_path = os.path.join(SIGNALTRACKERS_DIR, 'regime_detection.py')
+        content = read_file(detection_path)
+        self.assertNotIn('eval(', content)
+        self.assertNotIn('exec(', content)
+
+
+class TestRequirementsUpdated(unittest.TestCase):
+    """requirements.txt must include scikit-learn."""
+
+    def test_scikit_learn_in_requirements(self):
+        """requirements.txt must include scikit-learn."""
+        req_path = os.path.join(SIGNALTRACKERS_DIR, 'requirements.txt')
+        content = read_file(req_path)
+        self.assertIn('scikit-learn', content)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #114

## Summary
Implements the backend macro regime calculation engine for the SignalTrackers macro regime detection feature. Establishes the data layer that all frontend US-4.1.x stories will consume.

## Changes
- **Engineer:** Created `signaltrackers/regime_config.py` — static config for 4 regime states (Bull, Neutral, Bear, Recession Watch): plain-language summaries ≤200 chars, 24 category context sentences (6×4, ≤100 chars), signal annotations for 19 signals ×4 regimes, 2–3 highlighted signals per regime, category relevance lists, FRED series mappings
- **Engineer:** Created `signaltrackers/regime_detection.py` — k-means clustering on 5 FRED features (HY spread, yield curve 10Y–2Y, NFCI, initial claims, fed funds rate). Reads from local CSVs first, FRED API fallback, rule-based fallback if sklearn unavailable. Caches to `data/macro_regime_cache.json`. Public API: `get_macro_regime()` + `update_macro_regime()`
- **Engineer:** Modified `signaltrackers/dashboard.py` — added `inject_macro_regime()` context processor exposing `macro_regime` dict to all templates; called `update_macro_regime()` in `run_data_collection()` (non-fatal, pipeline-safe)
- **Engineer:** Added `scikit-learn>=1.3.0` to `requirements.txt`
- **Engineer:** Added 45 unit tests in `tests/test_us411_regime_backend.py`

## Testing
- ✅ 45/45 unit tests passing (US-4.1.1)
- ✅ 226/226 regression tests passing (no regressions)
- ✅ Manual config audit — all strings within char limits
- ✅ QA verification complete — all acceptance criteria confirmed

## Design Spec
Implements [docs/specs/feature-3.3-macro-regime-detection.md](docs/specs/feature-3.3-macro-regime-detection.md)

## Notes for Reviewers
- `macro_regime` context variable can be `None` when cache is absent on first boot — frontend stories (US-4.1.2, US-4.1.3) must guard against `None`, which is correctly deferred to those stories
- Confidence is derived from centroid distance ratio (not manufactured): High ≤0.5, Medium ≤1.5, Low >1.5
- Cluster-to-regime mapping uses stress score: `stress = HY_norm + (-curve_norm) + NFCI_norm + claims_norm`, sorted ascending: Bull < Neutral < Bear < Recession Watch