### PR TITLE
US-4.1.3: Frontend — Detail page regime strip and signal annotations

### DIFF
--- a/signaltrackers/dashboard.py
+++ b/signaltrackers/dashboard.py
@@ -52,6 +52,7 @@ from regime_config import (
     REGIME_METADATA,
     SIGNAL_REGIME_ANNOTATIONS,
     REGIME_CATEGORY_RELEVANCE,
+    CATEGORY_REGIME_CONTEXT,
 )
 
 # Display names and deep-link URLs for highlighted signals (US-4.1.2)
@@ -202,7 +203,11 @@ def inject_macro_regime():
             regime['highlighted_signals'] = signals
     except Exception:
         regime = None
-    return {'macro_regime': regime}
+    return {
+        'macro_regime': regime,
+        'category_regime_context': CATEGORY_REGIME_CONTEXT,
+        'signal_regime_annotations': SIGNAL_REGIME_ANNOTATIONS,
+    }
 
 
 def init_scheduler():

--- a/signaltrackers/static/css/components/regime-card.css
+++ b/signaltrackers/static/css/components/regime-card.css
@@ -260,3 +260,179 @@
     grid-template-columns: repeat(3, 1fr);
   }
 }
+
+/* =============================================================
+   Compact Regime Strip — Detail Pages (US-4.1.3)
+   Inserts between page header and first content section.
+   ============================================================= */
+
+.regime-strip {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  background: #f8f9fa;     /* neutral-50 */
+  border-bottom: 1px solid #dee2e6;  /* neutral-200 */
+  padding: 12px 16px;
+}
+
+/* Regime badge: 8px dot + uppercase name */
+.regime-strip__badge {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 120px;
+  flex-shrink: 0;
+}
+
+/* 8px dot (smaller than card's 12px dot) */
+.regime-strip__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.regime-strip.regime-bull .regime-strip__dot      { background-color: var(--regime-bull-border); }
+.regime-strip.regime-neutral .regime-strip__dot   { background-color: var(--regime-neutral-border); }
+.regime-strip.regime-bear .regime-strip__dot      { background-color: var(--regime-bear-border); }
+.regime-strip.regime-recession .regime-strip__dot { background-color: var(--regime-recession-border); }
+
+.regime-strip__name {
+  font-size: 0.875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.regime-strip.regime-bull .regime-strip__name      { color: var(--regime-bull-text); }
+.regime-strip.regime-neutral .regime-strip__name   { color: var(--regime-neutral-text); }
+.regime-strip.regime-bear .regime-strip__name      { color: var(--regime-bear-text); }
+.regime-strip.regime-recession .regime-strip__name { color: var(--regime-recession-text); }
+
+/* Vertical separator — hidden on mobile, shown on tablet+ */
+.regime-strip__separator {
+  display: none;
+  width: 1px;
+  background: #dee2e6;  /* neutral-200 */
+  align-self: stretch;
+  flex-shrink: 0;
+}
+
+/* Category context sentence */
+.regime-strip__context {
+  font-size: 0.875rem;
+  font-weight: 400;
+  color: #4b5563;  /* neutral-600 */
+  margin: 0;
+  line-height: 1.5;
+}
+
+@media (min-width: 768px) {
+  .regime-strip__separator { display: block; }
+}
+
+/* =============================================================
+   Signal Regime Annotation — Within Stat Items (US-4.1.3)
+   ============================================================= */
+
+.regime-annotation {
+  margin-top: 8px;
+  border-left: 3px solid;
+  border-radius: 0 4px 4px 0;
+  padding: 8px 12px;
+}
+
+.regime-annotation.regime-bull {
+  border-left-color: var(--regime-bull-border);
+  background: color-mix(in srgb, var(--regime-bull-bg) 40%, white);
+}
+
+.regime-annotation.regime-neutral {
+  border-left-color: var(--regime-neutral-border);
+  background: color-mix(in srgb, var(--regime-neutral-bg) 40%, white);
+}
+
+.regime-annotation.regime-bear {
+  border-left-color: var(--regime-bear-border);
+  background: color-mix(in srgb, var(--regime-bear-bg) 40%, white);
+}
+
+.regime-annotation.regime-recession {
+  border-left-color: var(--regime-recession-border);
+  background: color-mix(in srgb, var(--regime-recession-bg) 40%, white);
+}
+
+/* Toggle button (visible on mobile; hidden on tablet+) */
+.regime-annotation__toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  min-height: 44px;
+  text-align: left;
+}
+
+.regime-annotation__icon {
+  font-size: 0.75rem;
+  flex-shrink: 0;
+}
+
+.regime-annotation.regime-bull .regime-annotation__icon      { color: var(--regime-bull-border); }
+.regime-annotation.regime-neutral .regime-annotation__icon   { color: var(--regime-neutral-border); }
+.regime-annotation.regime-bear .regime-annotation__icon      { color: var(--regime-bear-border); }
+.regime-annotation.regime-recession .regime-annotation__icon { color: var(--regime-recession-border); }
+
+.regime-annotation__label {
+  font-size: 0.75rem;
+  color: #6b7280;  /* neutral-500 */
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+  flex: 1;
+}
+
+/* Chevron SVG */
+.regime-annotation__chevron {
+  width: 16px;
+  height: 16px;
+  color: #6b7280;
+  transition: transform 200ms ease-out;
+  flex-shrink: 0;
+}
+
+.regime-annotation__toggle[aria-expanded="true"] .regime-annotation__chevron {
+  transform: rotate(180deg);
+}
+
+/* Text — collapsed by default on mobile (still in DOM for screen readers) */
+.regime-annotation__text {
+  font-size: 0.875rem;
+  color: #374151;  /* neutral-700 */
+  line-height: 1.5;
+  margin: 0;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 200ms ease-out;
+}
+
+/* Text visible when expanded (JS adds .is-expanded) */
+.regime-annotation.is-expanded .regime-annotation__text {
+  max-height: 200px;
+}
+
+/* Tablet+: toggle hidden, text always visible */
+@media (min-width: 768px) {
+  .regime-annotation__toggle { display: none; }
+  .regime-annotation__text {
+    max-height: none;
+    margin-top: 4px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .regime-annotation__text { transition: none; }
+  .regime-annotation__chevron { transition: none; }
+}

--- a/signaltrackers/static/js/dashboard.js
+++ b/signaltrackers/static/js/dashboard.js
@@ -88,6 +88,7 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeBootstrap();
     setupAutoRefresh();
     updateLastUpdatedTime();
+    initRegimeAnnotations();
 });
 
 // Update last updated time
@@ -105,6 +106,20 @@ async function updateLastUpdatedTime() {
     } catch (error) {
         console.error('Error fetching last updated time:', error);
     }
+}
+
+// Initialize regime annotation toggles (US-4.1.3)
+// Mobile: toggle expand/collapse. Tablet+: CSS keeps text always visible.
+function initRegimeAnnotations() {
+    document.querySelectorAll('.regime-annotation__toggle').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const annotation = btn.closest('.regime-annotation');
+            if (!annotation) return;
+            const expanded = btn.getAttribute('aria-expanded') === 'true';
+            btn.setAttribute('aria-expanded', String(!expanded));
+            annotation.classList.toggle('is-expanded', !expanded);
+        });
+    });
 }
 
 // Export for use in templates

--- a/signaltrackers/templates/_macros.html
+++ b/signaltrackers/templates/_macros.html
@@ -1,0 +1,17 @@
+{% macro regime_annotation(signal_key) %}
+{% if macro_regime and signal_regime_annotations %}
+{% set _text = signal_regime_annotations.get(signal_key, {}).get(macro_regime.state, '') %}
+{% if _text %}
+<div class="regime-annotation {{ macro_regime.css_class }}">
+    <button class="regime-annotation__toggle" aria-expanded="false" type="button">
+        <i class="bi bi-info-circle regime-annotation__icon" aria-hidden="true"></i>
+        <span class="regime-annotation__label">Regime Context</span>
+        <svg class="regime-annotation__chevron" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+        </svg>
+    </button>
+    <p class="regime-annotation__text">{{ _text }}</p>
+</div>
+{% endif %}
+{% endif %}
+{% endmacro %}

--- a/signaltrackers/templates/_regime_strip.html
+++ b/signaltrackers/templates/_regime_strip.html
@@ -1,0 +1,12 @@
+{% if macro_regime %}
+{% set _state = macro_regime.state %}
+{% set _sentence = category_regime_context.get(page_category, {}).get(_state, '') %}
+<div class="regime-strip {{ macro_regime.css_class }}" role="complementary" aria-label="Macro regime context for this page">
+    <div class="regime-strip__badge">
+        <span class="regime-strip__dot" aria-hidden="true"></span>
+        <span class="regime-strip__name">{{ _state | upper }}</span>
+    </div>
+    <div class="regime-strip__separator" aria-hidden="true"></div>
+    <p class="regime-strip__context">{{ _sentence }}</p>
+</div>
+{% endif %}

--- a/signaltrackers/templates/crypto.html
+++ b/signaltrackers/templates/crypto.html
@@ -263,6 +263,7 @@
 </style>
 {% endblock %}
 
+{% from '_macros.html' import regime_annotation %}
 {% block content %}
 <main class="content-page">
     <!-- Page Header -->
@@ -273,6 +274,10 @@
         <p class="crypto-header__description">Macro liquidity indicators and sentiment metrics for Bitcoin</p>
         <p class="crypto-header__updated">Last Updated: <span id="last-updated-time">Loading...</span></p>
     </header>
+
+    <!-- Compact Regime Strip -->
+    {% set page_category = 'Crypto' %}
+    {% include '_regime_strip.html' %}
 
     <!-- Content Grid: Stacked on mobile, side-by-side on tablet+ -->
     <div class="content-grid">
@@ -382,6 +387,7 @@
                         <span id="fed-balance-change">--</span>% (30d)
                     </div>
                     <div class="stat-item__secondary" id="fed-balance-status">Loading</div>
+                    {{ regime_annotation('fed_balance_sheet') }}
                 </div>
                 <div class="stat-item">
                     <div class="stat-item__label">Reverse Repo (RRP)</div>
@@ -398,6 +404,7 @@
                         <span id="nfci-change">--</span> (30d)
                     </div>
                     <div class="stat-item__secondary" id="nfci-status">Loading</div>
+                    {{ regime_annotation('nfci') }}
                 </div>
                 <div class="stat-item">
                     <div class="stat-item__label">M2 Money Supply</div>
@@ -405,6 +412,7 @@
                     <div class="stat-item__secondary">
                         <span id="m2-change">--</span>% YoY
                     </div>
+                    {{ regime_annotation('m2_money_supply') }}
                 </div>
             </div>
         </div>

--- a/signaltrackers/templates/dollar.html
+++ b/signaltrackers/templates/dollar.html
@@ -263,6 +263,7 @@
 </style>
 {% endblock %}
 
+{% from '_macros.html' import regime_annotation %}
 {% block content %}
 <main class="content-page">
     <!-- Page Header -->
@@ -273,6 +274,10 @@
         <p class="dollar-header__description">Tracking the US Dollar Index, major currency pairs, and global FX dynamics</p>
         <p class="dollar-header__updated">Last Updated: <span id="last-updated-time">Loading...</span></p>
     </header>
+
+    <!-- Compact Regime Strip -->
+    {% set page_category = 'Dollar' %}
+    {% include '_regime_strip.html' %}
 
     <!-- Content Grid: Stacked on mobile, side-by-side on tablet+ -->
     <div class="content-grid">
@@ -369,6 +374,7 @@
                         <span id="dxy-change-5d">--</span>% (5d) | <span id="dxy-change-30d">--</span>% (30d)
                     </div>
                     <div class="stat-item__secondary" id="dxy-status">Loading</div>
+                    {{ regime_annotation('dollar_index') }}
                 </div>
                 <div class="stat-item">
                     <div class="stat-item__label">USD/JPY</div>

--- a/signaltrackers/templates/equity.html
+++ b/signaltrackers/templates/equity.html
@@ -263,6 +263,7 @@
 </style>
 {% endblock %}
 
+{% from '_macros.html' import regime_annotation %}
 {% block content %}
 <main class="content-page">
     <!-- Page Header -->
@@ -273,6 +274,10 @@
         <p class="equity-header__description">Market structure, rotation signals, and key sector leadership</p>
         <p class="equity-header__updated">Last Updated: <span id="last-updated-time">Loading...</span></p>
     </header>
+
+    <!-- Compact Regime Strip -->
+    {% set page_category = 'Equities' %}
+    {% include '_regime_strip.html' %}
 
     <!-- Content Grid: Stacked on mobile, side-by-side on tablet+ -->
     <div class="content-grid">
@@ -369,6 +374,7 @@
                         <span id="sp500-change-5d">--</span>% (5d) | <span id="sp500-change-30d">--</span>% (30d)
                     </div>
                     <div class="stat-item__secondary" id="sp500-percentile">Loading</div>
+                    {{ regime_annotation('sp500') }}
                 </div>
                 <div class="stat-item">
                     <div class="stat-item__label">Nasdaq 100</div>
@@ -393,6 +399,7 @@
                         <span id="vix-change-5d">--</span>% (5d)
                     </div>
                     <div class="stat-item__secondary" id="vix-status">Loading</div>
+                    {{ regime_annotation('vix') }}
                 </div>
                 <div class="stat-item">
                     <div class="stat-item__label">Market Breadth</div>

--- a/signaltrackers/templates/rates.html
+++ b/signaltrackers/templates/rates.html
@@ -289,6 +289,7 @@
 </style>
 {% endblock %}
 
+{% from '_macros.html' import regime_annotation %}
 {% block content %}
 <main class="content-page">
     <!-- Page Header -->
@@ -299,6 +300,10 @@
         <p class="rates-header__description">Tracking Treasury yields, curve shape, and inflation expectations</p>
         <p class="rates-header__updated">Last Updated: <span id="last-updated-time">Loading...</span></p>
     </header>
+
+    <!-- Compact Regime Strip -->
+    {% set page_category = 'Rates' %}
+    {% include '_regime_strip.html' %}
 
     <!-- Content Grid: Stacked on mobile, side-by-side on tablet+ -->
     <div class="content-grid">
@@ -392,26 +397,31 @@
                     <div class="stat-item__label">10-Year Treasury</div>
                     <div class="stat-item__value stat-item__value--large" id="treasury-10y-value">--%</div>
                     <div class="stat-item__secondary" id="treasury-10y-change">--</div>
+                    {{ regime_annotation('treasury_10y') }}
                 </div>
                 <div class="stat-item">
                     <div class="stat-item__label">Yield Curve (10Y-2Y)</div>
                     <div class="stat-item__value" id="yield-curve-value">--%</div>
                     <div class="stat-item__secondary" id="yield-curve-status">--</div>
+                    {{ regime_annotation('yield_curve_10y2y') }}
                 </div>
                 <div class="stat-item">
                     <div class="stat-item__label">Yield Curve (10Y-3M)</div>
                     <div class="stat-item__value" id="yield-curve-3m-value">--%</div>
                     <div class="stat-item__secondary" id="yield-curve-3m-status">--</div>
+                    {{ regime_annotation('yield_curve_10y3m') }}
                 </div>
                 <div class="stat-item">
                     <div class="stat-item__label">Real Yield (10Y TIPS)</div>
                     <div class="stat-item__value" id="real-yield-value">--%</div>
                     <div class="stat-item__secondary" id="real-yield-status">--</div>
+                    {{ regime_annotation('real_yield_10y') }}
                 </div>
                 <div class="stat-item">
                     <div class="stat-item__label">Breakeven Inflation</div>
                     <div class="stat-item__value" id="breakeven-value">--%</div>
                     <div class="stat-item__secondary" id="breakeven-status">--</div>
+                    {{ regime_annotation('breakeven_inflation_10y') }}
                 </div>
                 <div class="stat-item">
                     <div class="stat-item__label">CPI (YoY)</div>
@@ -422,6 +432,7 @@
                     <div class="stat-item__label">Fed Funds Rate</div>
                     <div class="stat-item__value" id="fed-funds-value">--%</div>
                     <div class="stat-item__secondary">Policy rate</div>
+                    {{ regime_annotation('fed_funds_rate') }}
                 </div>
                 <div class="stat-item">
                     <div class="stat-item__label">Curve Status</div>

--- a/signaltrackers/templates/safe_havens.html
+++ b/signaltrackers/templates/safe_havens.html
@@ -263,6 +263,7 @@
 </style>
 {% endblock %}
 
+{% from '_macros.html' import regime_annotation %}
 {% block content %}
 <main class="content-page">
     <!-- Page Header -->
@@ -273,6 +274,10 @@
         <p class="safe-havens-header__description">Key drivers and indicators for gold and silver</p>
         <p class="safe-havens-header__updated">Last Updated: <span id="last-updated-time">Loading...</span></p>
     </header>
+
+    <!-- Compact Regime Strip -->
+    {% set page_category = 'Safe Havens' %}
+    {% include '_regime_strip.html' %}
 
     <!-- Content Grid: Stacked on mobile, side-by-side on tablet+ -->
     <div class="content-grid">
@@ -363,6 +368,7 @@
                         <span id="gold-change-5d">--</span>% (5d) | <span id="gold-change-30d">--</span>% (30d)
                     </div>
                     <div class="stat-item__secondary" id="gold-status">Loading</div>
+                    {{ regime_annotation('gold') }}
                 </div>
                 <div class="stat-item">
                     <div class="stat-item__label">Silver Price</div>
@@ -379,6 +385,7 @@
                         <span id="real-yield-change">--</span> bps (30d)
                     </div>
                     <div class="stat-item__secondary" id="real-yield-status">Loading</div>
+                    {{ regime_annotation('real_yield_10y') }}
                 </div>
                 <div class="stat-item">
                     <div class="stat-item__label">Breakeven Inflation</div>
@@ -387,6 +394,7 @@
                         <span id="breakeven-change">--</span> bps (30d)
                     </div>
                     <div class="stat-item__secondary" id="breakeven-status">Loading</div>
+                    {{ regime_annotation('breakeven_inflation_10y') }}
                 </div>
                 <div class="stat-item">
                     <div class="stat-item__label">Dollar Index (DXY)</div>

--- a/tests/test_us413_regime_strip.py
+++ b/tests/test_us413_regime_strip.py
@@ -1,0 +1,414 @@
+"""
+Tests for US-4.1.3: Frontend — Detail page regime strip and signal annotations
+
+Tests are static (no running server required). They verify:
+- The context processor injects category_regime_context and signal_regime_annotations
+- The regime strip partial renders correctly for each page category
+- Regime annotations are present in all 5 detail templates
+- CSS contains the required styles for strip and annotation components
+- JS contains the initRegimeAnnotations function
+"""
+
+import os
+import re
+import sys
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TEMPLATES_DIR = os.path.join(REPO_ROOT, 'signaltrackers', 'templates')
+CSS_PATH = os.path.join(REPO_ROOT, 'signaltrackers', 'static', 'css', 'components', 'regime-card.css')
+JS_PATH = os.path.join(REPO_ROOT, 'signaltrackers', 'static', 'js', 'dashboard.js')
+DASHBOARD_PY = os.path.join(REPO_ROOT, 'signaltrackers', 'dashboard.py')
+REGIME_CONFIG = os.path.join(REPO_ROOT, 'signaltrackers', 'regime_config.py')
+
+
+def _read(path):
+    with open(path, 'r') as f:
+        return f.read()
+
+
+# ---------------------------------------------------------------------------
+# 1. Context processor — dashboard.py
+# ---------------------------------------------------------------------------
+
+class TestContextProcessor:
+    def test_imports_category_regime_context(self):
+        src = _read(DASHBOARD_PY)
+        assert 'CATEGORY_REGIME_CONTEXT' in src
+
+    def test_context_processor_returns_category_regime_context(self):
+        src = _read(DASHBOARD_PY)
+        assert "'category_regime_context': CATEGORY_REGIME_CONTEXT" in src
+
+    def test_context_processor_returns_signal_regime_annotations(self):
+        src = _read(DASHBOARD_PY)
+        assert "'signal_regime_annotations': SIGNAL_REGIME_ANNOTATIONS" in src
+
+    def test_context_processor_returns_macro_regime(self):
+        src = _read(DASHBOARD_PY)
+        assert "'macro_regime': regime" in src
+
+    def test_inject_macro_regime_function_exists(self):
+        src = _read(DASHBOARD_PY)
+        assert 'def inject_macro_regime' in src
+
+
+# ---------------------------------------------------------------------------
+# 2. Regime config — CATEGORY_REGIME_CONTEXT
+# ---------------------------------------------------------------------------
+
+class TestRegimeConfig:
+    def test_category_regime_context_has_all_categories(self):
+        sys.path.insert(0, os.path.join(REPO_ROOT, 'signaltrackers'))
+        from regime_config import CATEGORY_REGIME_CONTEXT
+        required = {'Rates', 'Equities', 'Dollar', 'Crypto', 'Safe Havens', 'Credit'}
+        for cat in required:
+            assert cat in CATEGORY_REGIME_CONTEXT, f"Missing category: {cat}"
+
+    def test_category_regime_context_has_all_regimes(self):
+        from regime_config import CATEGORY_REGIME_CONTEXT
+        regimes = {'Bull', 'Neutral', 'Bear', 'Recession Watch'}
+        for cat, sentences in CATEGORY_REGIME_CONTEXT.items():
+            for regime in regimes:
+                assert regime in sentences, f"Missing regime {regime} for category {cat}"
+
+    def test_category_sentences_within_100_chars(self):
+        from regime_config import CATEGORY_REGIME_CONTEXT
+        for cat, sentences in CATEGORY_REGIME_CONTEXT.items():
+            for regime, text in sentences.items():
+                assert len(text) <= 100, (
+                    f"Category '{cat}' regime '{regime}' sentence too long "
+                    f"({len(text)} chars): {text!r}"
+                )
+
+    def test_signal_regime_annotations_exist(self):
+        from regime_config import SIGNAL_REGIME_ANNOTATIONS
+        required_signals = [
+            'treasury_10y', 'yield_curve_10y2y', 'yield_curve_10y3m',
+            'real_yield_10y', 'breakeven_inflation_10y', 'fed_funds_rate',
+            'sp500', 'vix', 'dollar_index', 'gold',
+            'fed_balance_sheet', 'nfci', 'm2_money_supply',
+        ]
+        for sig in required_signals:
+            assert sig in SIGNAL_REGIME_ANNOTATIONS, f"Missing signal: {sig}"
+
+    def test_signal_annotations_within_100_chars(self):
+        from regime_config import SIGNAL_REGIME_ANNOTATIONS
+        for sig, regime_map in SIGNAL_REGIME_ANNOTATIONS.items():
+            for regime, text in regime_map.items():
+                assert len(text) <= 100, (
+                    f"Signal '{sig}' regime '{regime}' annotation too long "
+                    f"({len(text)} chars): {text!r}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# 3. Regime strip partial — _regime_strip.html
+# ---------------------------------------------------------------------------
+
+class TestRegimeStripPartial:
+    def test_partial_exists(self):
+        path = os.path.join(TEMPLATES_DIR, '_regime_strip.html')
+        assert os.path.exists(path)
+
+    def test_partial_checks_macro_regime(self):
+        src = _read(os.path.join(TEMPLATES_DIR, '_regime_strip.html'))
+        assert '{% if macro_regime %}' in src
+
+    def test_partial_uses_page_category(self):
+        src = _read(os.path.join(TEMPLATES_DIR, '_regime_strip.html'))
+        assert 'page_category' in src
+
+    def test_partial_uses_category_regime_context(self):
+        src = _read(os.path.join(TEMPLATES_DIR, '_regime_strip.html'))
+        assert 'category_regime_context' in src
+
+    def test_partial_has_regime_strip_element(self):
+        src = _read(os.path.join(TEMPLATES_DIR, '_regime_strip.html'))
+        assert 'class="regime-strip' in src
+
+    def test_partial_has_regime_dot(self):
+        src = _read(os.path.join(TEMPLATES_DIR, '_regime_strip.html'))
+        assert 'regime-strip__dot' in src
+
+    def test_partial_has_regime_name(self):
+        src = _read(os.path.join(TEMPLATES_DIR, '_regime_strip.html'))
+        assert 'regime-strip__name' in src
+
+    def test_partial_has_context_sentence(self):
+        src = _read(os.path.join(TEMPLATES_DIR, '_regime_strip.html'))
+        assert 'regime-strip__context' in src
+
+    def test_partial_has_aria_label(self):
+        src = _read(os.path.join(TEMPLATES_DIR, '_regime_strip.html'))
+        assert 'aria-label=' in src
+
+    def test_partial_has_role_complementary(self):
+        src = _read(os.path.join(TEMPLATES_DIR, '_regime_strip.html'))
+        assert 'role="complementary"' in src
+
+
+# ---------------------------------------------------------------------------
+# 4. Macros partial — _macros.html
+# ---------------------------------------------------------------------------
+
+class TestMacrosPartial:
+    def test_macros_file_exists(self):
+        path = os.path.join(TEMPLATES_DIR, '_macros.html')
+        assert os.path.exists(path)
+
+    def test_regime_annotation_macro_defined(self):
+        src = _read(os.path.join(TEMPLATES_DIR, '_macros.html'))
+        assert 'macro regime_annotation' in src
+
+    def test_macro_uses_signal_regime_annotations(self):
+        src = _read(os.path.join(TEMPLATES_DIR, '_macros.html'))
+        assert 'signal_regime_annotations' in src
+
+    def test_macro_uses_macro_regime_state(self):
+        src = _read(os.path.join(TEMPLATES_DIR, '_macros.html'))
+        assert 'macro_regime.state' in src
+
+    def test_macro_has_toggle_button(self):
+        src = _read(os.path.join(TEMPLATES_DIR, '_macros.html'))
+        assert 'regime-annotation__toggle' in src
+
+    def test_macro_has_aria_expanded(self):
+        src = _read(os.path.join(TEMPLATES_DIR, '_macros.html'))
+        assert 'aria-expanded' in src
+
+    def test_macro_has_annotation_text(self):
+        src = _read(os.path.join(TEMPLATES_DIR, '_macros.html'))
+        assert 'regime-annotation__text' in src
+
+    def test_macro_has_chevron_svg(self):
+        src = _read(os.path.join(TEMPLATES_DIR, '_macros.html'))
+        assert 'regime-annotation__chevron' in src
+
+    def test_macro_has_info_icon(self):
+        src = _read(os.path.join(TEMPLATES_DIR, '_macros.html'))
+        assert 'bi-info-circle' in src
+
+    def test_macro_conditional_on_empty_text(self):
+        src = _read(os.path.join(TEMPLATES_DIR, '_macros.html'))
+        # Macro should only render if annotation text is non-empty
+        assert '{% if _text %}' in src
+
+
+# ---------------------------------------------------------------------------
+# 5. Detail page templates — strip present
+# ---------------------------------------------------------------------------
+
+DETAIL_PAGES = {
+    'rates.html': 'Rates',
+    'equity.html': 'Equities',
+    'dollar.html': 'Dollar',
+    'crypto.html': 'Crypto',
+    'safe_havens.html': 'Safe Havens',
+}
+
+
+class TestDetailPageStrip:
+    @pytest.mark.parametrize("template,category", DETAIL_PAGES.items())
+    def test_template_includes_regime_strip(self, template, category):
+        src = _read(os.path.join(TEMPLATES_DIR, template))
+        assert "{% include '_regime_strip.html' %}" in src
+
+    @pytest.mark.parametrize("template,category", DETAIL_PAGES.items())
+    def test_template_sets_page_category(self, template, category):
+        src = _read(os.path.join(TEMPLATES_DIR, template))
+        assert f"page_category = '{category}'" in src
+
+    @pytest.mark.parametrize("template,category", DETAIL_PAGES.items())
+    def test_template_imports_regime_annotation_macro(self, template, category):
+        src = _read(os.path.join(TEMPLATES_DIR, template))
+        assert "from '_macros.html' import regime_annotation" in src
+
+    @pytest.mark.parametrize("template,category", DETAIL_PAGES.items())
+    def test_strip_after_header(self, template, category):
+        src = _read(os.path.join(TEMPLATES_DIR, template))
+        header_pos = src.find('</header>')
+        strip_pos = src.find("{% include '_regime_strip.html' %}")
+        content_grid_pos = src.find('<div class="content-grid">')
+        assert header_pos < strip_pos, "Strip must come after </header>"
+        assert strip_pos < content_grid_pos, "Strip must come before content-grid"
+
+
+# ---------------------------------------------------------------------------
+# 6. Detail page templates — annotations present
+# ---------------------------------------------------------------------------
+
+EXPECTED_ANNOTATIONS = {
+    'rates.html': [
+        'treasury_10y', 'yield_curve_10y2y', 'yield_curve_10y3m',
+        'real_yield_10y', 'breakeven_inflation_10y', 'fed_funds_rate',
+    ],
+    'equity.html': ['sp500', 'vix'],
+    'dollar.html': ['dollar_index'],
+    'crypto.html': ['fed_balance_sheet', 'nfci', 'm2_money_supply'],
+    'safe_havens.html': ['gold', 'real_yield_10y', 'breakeven_inflation_10y'],
+}
+
+
+class TestDetailPageAnnotations:
+    @pytest.mark.parametrize("template,signals", EXPECTED_ANNOTATIONS.items())
+    def test_template_has_all_expected_annotations(self, template, signals):
+        src = _read(os.path.join(TEMPLATES_DIR, template))
+        for sig in signals:
+            assert f"regime_annotation('{sig}')" in src, (
+                f"Template {template} missing annotation for signal '{sig}'"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 7. CSS — regime-card.css
+# ---------------------------------------------------------------------------
+
+class TestCSS:
+    def test_css_has_regime_strip_class(self):
+        src = _read(CSS_PATH)
+        assert '.regime-strip {' in src
+
+    def test_css_has_regime_strip_badge(self):
+        src = _read(CSS_PATH)
+        assert '.regime-strip__badge {' in src
+
+    def test_css_has_regime_strip_dot(self):
+        src = _read(CSS_PATH)
+        assert '.regime-strip__dot {' in src
+
+    def test_css_has_regime_strip_name(self):
+        src = _read(CSS_PATH)
+        assert '.regime-strip__name {' in src
+
+    def test_css_has_regime_strip_context(self):
+        src = _read(CSS_PATH)
+        assert '.regime-strip__context {' in src
+
+    def test_css_has_regime_strip_separator(self):
+        src = _read(CSS_PATH)
+        assert '.regime-strip__separator {' in src
+
+    def test_css_strip_colors_all_four_regimes(self):
+        src = _read(CSS_PATH)
+        for regime in ('bull', 'neutral', 'bear', 'recession'):
+            assert f'.regime-strip.regime-{regime} .regime-strip__dot' in src
+            assert f'.regime-strip.regime-{regime} .regime-strip__name' in src
+
+    def test_css_strip_responsive_separator(self):
+        """Separator visible at 768px+ only."""
+        src = _read(CSS_PATH)
+        assert 'min-width: 768px' in src
+        # After 768px block, separator should display block
+        tablet_block = src[src.index('min-width: 768px'):]
+        assert '.regime-strip__separator' in tablet_block
+
+    def test_css_has_regime_annotation_class(self):
+        src = _read(CSS_PATH)
+        assert '.regime-annotation {' in src
+
+    def test_css_annotation_has_left_border(self):
+        src = _read(CSS_PATH)
+        annot_idx = src.index('.regime-annotation {')
+        block = src[annot_idx:annot_idx + 200]
+        assert 'border-left' in block
+
+    def test_css_annotation_has_border_radius(self):
+        src = _read(CSS_PATH)
+        annot_idx = src.index('.regime-annotation {')
+        block = src[annot_idx:annot_idx + 200]
+        assert 'border-radius' in block
+
+    def test_css_annotation_colors_all_four_regimes(self):
+        src = _read(CSS_PATH)
+        for regime in ('bull', 'neutral', 'bear', 'recession'):
+            assert f'.regime-annotation.regime-{regime} {{' in src
+
+    def test_css_annotation_toggle_button(self):
+        src = _read(CSS_PATH)
+        assert '.regime-annotation__toggle {' in src
+
+    def test_css_annotation_toggle_min_height_44px(self):
+        src = _read(CSS_PATH)
+        toggle_idx = src.index('.regime-annotation__toggle {')
+        block = src[toggle_idx:toggle_idx + 300]
+        assert 'min-height: 44px' in block
+
+    def test_css_annotation_label(self):
+        src = _read(CSS_PATH)
+        assert '.regime-annotation__label {' in src
+
+    def test_css_annotation_text_collapsed_by_default(self):
+        src = _read(CSS_PATH)
+        text_idx = src.index('.regime-annotation__text {')
+        block = src[text_idx:text_idx + 200]
+        assert 'max-height: 0' in block
+
+    def test_css_annotation_text_visible_when_expanded(self):
+        src = _read(CSS_PATH)
+        assert '.regime-annotation.is-expanded .regime-annotation__text' in src
+
+    def test_css_annotation_text_transition(self):
+        src = _read(CSS_PATH)
+        text_idx = src.index('.regime-annotation__text {')
+        block = src[text_idx:text_idx + 300]
+        assert 'transition' in block
+
+    def test_css_annotation_toggle_hidden_tablet_plus(self):
+        src = _read(CSS_PATH)
+        # After the 768px media query, toggle should be hidden
+        tablet_section = src[src.rindex('@media (min-width: 768px)'):]
+        assert '.regime-annotation__toggle' in tablet_section
+        assert 'display: none' in tablet_section
+
+    def test_css_annotation_text_max_height_none_tablet_plus(self):
+        src = _read(CSS_PATH)
+        tablet_section = src[src.rindex('@media (min-width: 768px)'):]
+        assert 'max-height: none' in tablet_section
+
+    def test_css_has_reduced_motion_rule(self):
+        src = _read(CSS_PATH)
+        assert 'prefers-reduced-motion' in src
+
+    def test_css_chevron_rotation_on_expanded(self):
+        src = _read(CSS_PATH)
+        assert '.regime-annotation__toggle[aria-expanded="true"] .regime-annotation__chevron' in src
+        assert 'rotate(180deg)' in src
+
+
+# ---------------------------------------------------------------------------
+# 8. JavaScript — dashboard.js
+# ---------------------------------------------------------------------------
+
+class TestJS:
+    def test_init_regime_annotations_function_exists(self):
+        src = _read(JS_PATH)
+        assert 'function initRegimeAnnotations' in src
+
+    def test_init_regime_annotations_called_on_domcontentloaded(self):
+        src = _read(JS_PATH)
+        # Find DOMContentLoaded handler and verify it calls initRegimeAnnotations
+        dom_idx = src.index('DOMContentLoaded')
+        block = src[dom_idx:dom_idx + 300]
+        assert 'initRegimeAnnotations' in block
+
+    def test_js_toggles_aria_expanded(self):
+        src = _read(JS_PATH)
+        fn_idx = src.index('function initRegimeAnnotations')
+        block = src[fn_idx:fn_idx + 400]
+        assert 'aria-expanded' in block
+
+    def test_js_toggles_is_expanded_class(self):
+        src = _read(JS_PATH)
+        fn_idx = src.index('function initRegimeAnnotations')
+        block = src[fn_idx:fn_idx + 600]
+        assert 'is-expanded' in block
+
+    def test_js_selects_toggle_buttons(self):
+        src = _read(JS_PATH)
+        fn_idx = src.index('function initRegimeAnnotations')
+        block = src[fn_idx:fn_idx + 400]
+        assert 'regime-annotation__toggle' in block


### PR DESCRIPTION
Fixes #116

## Summary
Implements the compact macro regime strip and signal annotations on all 5 detail pages (rates, equity, dollar, crypto, safe_havens).

## Changes
- **Engineer:** Created `_regime_strip.html` partial and `_macros.html` Jinja2 macro for `regime_annotation(signal_key)`; extended `inject_macro_regime()` context processor to also inject `category_regime_context` and `signal_regime_annotations`; added regime strip and annotations to all 5 detail templates; extended `regime-card.css` with strip and annotation styles; added `initRegimeAnnotations()` to `dashboard.js`
- **Designer:** Approved implementation — all visual and structural requirements verified
- **QA:** 82/82 story tests passing, 440/440 regression tests passing (0 regressions); all 11 acceptance criteria verified

## Testing
- ✅ All 82 US-4.1.3 unit tests passing
- ✅ Full regression suite: 440/440 passing, 0 regressions
- ✅ Design review approved
- ✅ QA verification complete

## Design Spec
Implements [docs/specs/feature-3.3-macro-regime-detection.md](docs/specs/feature-3.3-macro-regime-detection.md)