### PR TITLE
US-144.1: Remove bottom-strip, simplify chatbot to binary FAB/expanded model

### DIFF
--- a/signaltrackers/static/css/components/chatbot.css
+++ b/signaltrackers/static/css/components/chatbot.css
@@ -143,8 +143,7 @@
     gap: 8px; /* space-2 */
 }
 
-.chatbot-minimize,
-.chatbot-close {
+.chatbot-minimize {
     width: 44px;
     height: 44px;
     border: none;
@@ -158,13 +157,11 @@
     justify-content: center;
 }
 
-.chatbot-minimize:hover,
-.chatbot-close:hover {
+.chatbot-minimize:hover {
     color: #1F2937; /* neutral-800 */
 }
 
-.chatbot-minimize:focus,
-.chatbot-close:focus {
+.chatbot-minimize:focus {
     outline: 2px solid #6366F1; /* brand-indigo-500 */
     outline-offset: 2px;
 }
@@ -628,125 +625,3 @@
     }
 }
 
-/* ============================================
-   FAB: Hidden state (Minimized — strip is the trigger)
-   Feature 4.2: US-4.2.1 Three-State Model
-   ============================================ */
-.chatbot-fab[data-chatbot-hidden] {
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 150ms ease;
-}
-
-/* ============================================
-   Bottom Strip (Minimized State)
-   Feature 4.2: US-4.2.1 Three-State Model
-   ============================================ */
-.chatbot-strip {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    height: 48px;
-    background-color: #1F2937; /* neutral-800 */
-    border-top: 1px solid #4B5563; /* neutral-600 */
-    border-left: none;
-    border-right: none;
-    border-bottom: none;
-    border-radius: 0;
-    z-index: 999;
-    display: flex;
-    align-items: center;
-    padding: 0 16px; /* space-4 */
-    gap: 8px; /* space-2 */
-    cursor: pointer;
-    font-family: inherit;
-    color: white;
-    text-align: left;
-    /* Fade-in animation: starts invisible, transitions to visible via JS class */
-    opacity: 0;
-    transition: opacity 200ms ease 50ms; /* 50ms delay per spec */
-}
-
-.chatbot-strip[hidden] {
-    display: none;
-}
-
-/* Strip visible state (class added by JS after removing hidden) */
-.chatbot-strip.chatbot-strip--visible {
-    opacity: 1;
-}
-
-.chatbot-strip:hover {
-    background-color: #374151; /* neutral-700 — subtle hover */
-}
-
-.chatbot-strip:focus {
-    outline: 2px solid #6366F1; /* brand-indigo-500 */
-    outline-offset: -2px; /* inset since strip is full-width */
-}
-
-/* Strip icon (chat icon, 20px, white) */
-.chatbot-strip-icon {
-    font-size: 20px;
-    flex-shrink: 0;
-    color: white;
-}
-
-/* Strip label: "AI Chatbot", text-sm, weight 500 */
-.chatbot-strip-label {
-    font-size: 14px; /* text-sm */
-    font-weight: 500;
-    color: white;
-    flex: 1;
-}
-
-/* Strip unread badge (same spec as FAB badge) */
-.chatbot-strip-badge {
-    min-width: 20px;
-    height: 20px;
-    padding: 0 6px;
-    background-color: #DC2626; /* danger-600 */
-    color: white;
-    font-size: 12px; /* text-xs */
-    font-weight: 700;
-    border-radius: 10px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-}
-
-.chatbot-strip-badge[hidden] {
-    display: none;
-}
-
-/* Strip expand chevron (▲, rightmost) */
-.chatbot-strip-chevron {
-    font-size: 20px;
-    flex-shrink: 0;
-    color: white;
-    margin-left: auto;
-}
-
-/* ============================================
-   Bottom Strip: Tablet (768px+)
-   Strip aligns with panel width (right side)
-   ============================================ */
-@media (min-width: 768px) {
-    .chatbot-strip {
-        left: auto;
-        right: 0;
-        width: 360px; /* matches panel width */
-    }
-}
-
-/* ============================================
-   Bottom Strip: Desktop (1024px+)
-   Strip aligns with wider panel width
-   ============================================ */
-@media (min-width: 1024px) {
-    .chatbot-strip {
-        width: 440px; /* matches panel width */
-    }
-}

--- a/signaltrackers/templates/base.html
+++ b/signaltrackers/templates/base.html
@@ -164,19 +164,6 @@
         <span class="chatbot-badge" aria-label=""></span>
     </button>
 
-    <!-- Chatbot Widget: Bottom Strip (Minimized State) -->
-    <button
-        id="chatbot-strip"
-        class="chatbot-strip"
-        aria-label="AI Chatbot — tap to expand"
-        aria-expanded="false"
-        hidden>
-        <i class="bi bi-chat-dots chatbot-strip-icon" aria-hidden="true"></i>
-        <span class="chatbot-strip-label">AI Chatbot</span>
-        <span class="chatbot-strip-badge" aria-label="" hidden></span>
-        <i class="bi bi-chevron-up chatbot-strip-chevron" aria-hidden="true"></i>
-    </button>
-
     <!-- Chatbot Widget: Panel (Expanded State) -->
     <aside
         id="chatbot-panel"
@@ -191,12 +178,6 @@
             <div class="chatbot-header-actions">
                 <button
                     class="chatbot-minimize"
-                    aria-label="Minimize chatbot"
-                    aria-controls="chatbot-panel">
-                    <span aria-hidden="true">−</span>
-                </button>
-                <button
-                    class="chatbot-close"
                     aria-label="Close chatbot"
                     aria-controls="chatbot-panel">
                     <span aria-hidden="true">×</span>

--- a/tests/test_chatbot_widget.py
+++ b/tests/test_chatbot_widget.py
@@ -83,17 +83,17 @@ class TestChatbotPanel:
 # ---------------------------------------------------------------------------
 
 class TestChatbotControls:
-    def test_minimize_button_present(self, page):
+    def test_single_close_button_present(self, page):
+        # US-144.1: single button only, uses chatbot-minimize class
         assert 'class="chatbot-minimize"' in page
 
-    def test_minimize_button_aria_label(self, page):
-        assert 'aria-label="Minimize chatbot"' in page
-
-    def test_close_button_present(self, page):
-        assert 'class="chatbot-close"' in page
-
-    def test_close_button_aria_label(self, page):
+    def test_single_close_button_aria_label(self, page):
+        # US-144.1: single button closes to FAB
         assert 'aria-label="Close chatbot"' in page
+
+    def test_no_separate_close_button(self, page):
+        # US-144.1: the separate chatbot-close button was removed
+        assert 'class="chatbot-close"' not in page
 
     def test_minimize_has_aria_controls(self, page):
         assert 'aria-controls="chatbot-panel"' in page

--- a/tests/test_us323_chatbot_persistence.py
+++ b/tests/test_us323_chatbot_persistence.py
@@ -366,29 +366,32 @@ class TestPerformanceBanner(unittest.TestCase):
         self.assertIn('showPerformanceBanner()', func_body)
 
 
-class TestXButtonBehavior(unittest.TestCase):
-    """Verify X button closes to FAB (does not clear) the conversation."""
+class TestSingleButtonBehavior(unittest.TestCase):
+    """Verify the single header button closes to FAB (does not clear) the conversation."""
 
     def setUp(self):
         self.js = read_file(CHATBOT_JS_PATH)
         self.html = read_file(BASE_HTML_PATH)
 
-    def test_close_button_calls_close_not_clear(self):
-        """Close button (X) must call closeChatbot() (closes to FAB), not clear conversation."""
-        # US-4.2.1: × now calls closeChatbot() (closes to FAB only, not minimizes to strip)
-        idx = self.js.find('closeBtn.addEventListener')
+    def test_minimize_btn_calls_close_chatbot(self):
+        """Single header button (chatbot-minimize) must call closeChatbot() (closes to FAB)."""
+        # US-144.1: single button; minimize btn now maps to closeChatbot()
+        idx = self.js.find('minimizeBtn.addEventListener')
         self.assertGreater(idx, 0)
         handler = self.js[idx:idx + 150]
         self.assertIn('this.closeChatbot()', handler)
         self.assertNotIn('clearConversation', handler)
 
-    def test_close_button_in_html(self):
-        """base.html must include the close button with chatbot-close class."""
-        self.assertIn('class="chatbot-close"', self.html)
+    def test_single_button_in_html(self):
+        """base.html must have the single close button with chatbot-minimize class."""
+        self.assertIn('class="chatbot-minimize"', self.html)
+
+    def test_separate_close_button_removed_from_html(self):
+        """base.html must NOT have a separate chatbot-close button (US-144.1 removal)."""
+        self.assertNotIn('class="chatbot-close"', self.html)
 
     def test_close_method_does_not_clear_conversation(self):
         """closeChatbot() method must not touch conversation data."""
-        # US-4.2.1: close() renamed to closeChatbot() in three-state model
         idx = self.js.find('closeChatbot() {')
         self.assertGreater(idx, 0)
         # Find end of closeChatbot() method (next method definition)


### PR DESCRIPTION
Fixes #150

## Summary
Simplifies the chatbot from a three-state model (expanded → strip → FAB) to a clean binary model (expanded ↔ FAB). Removes the 48px persistent bottom bar that was blocking page content whenever the chatbot was minimized.

## Changes
- **Engineer — `base.html`:** Removed `chatbot-strip` button block entirely; removed `chatbot-close` button; unified to a single `chatbot-minimize` button that collapses to FAB
- **Engineer — `chatbot.js`:** State machine simplified from `'closed' | 'minimized' | 'expanded'` to `'closed' | 'expanded'`; removed `minimize()` method; `minimizeBtn` now calls `closeChatbot()`; Escape key calls `closeChatbot()`; `showBadge()`/`clearBadge()` always target FAB badge; removed all strip/`data-chatbot-hidden` references
- **Engineer — `chatbot.css`:** Removed `.chatbot-fab[data-chatbot-hidden]` rule; removed all `.chatbot-strip*` rules and media query blocks; split combined `.chatbot-minimize, .chatbot-close` selector to `.chatbot-minimize` only
- **Engineer — `tests/test_us421_three_state_chatbot.py`:** Replaced with binary-model tests covering strip removal (HTML/CSS/JS), single-button HTML, binary CSS, binary JS state machine, state transitions, Escape key, badge routing, and regression guards
- **Engineer — `tests/test_us323_chatbot_persistence.py`:** Updated `TestXButtonBehavior` → `TestSingleButtonBehavior`; updated tests to reference minimize btn + `closeChatbot()`
- **Engineer — `tests/test_chatbot_widget.py`:** Removed `chatbot-close` assertions; added assertion close class is absent

## Testing
- ✅ 889 static tests passing
- ✅ No design review needed (simplification/removal, no new UI design)
- ✅ QA verification complete

## Design Spec
No spec — this is a simplification of Feature 4.2 per parent feature #144.