### PR TITLE
US-146.1: Backend data layer for recession probability panel

### DIFF
--- a/signaltrackers/recession_probability.py
+++ b/signaltrackers/recession_probability.py
@@ -1,0 +1,399 @@
+"""
+Recession Probability Module — US-146.1
+
+Fetches and processes three institutional recession probability models:
+1. NY Fed 12-month leading model (yield-curve based, FRED RECPROUSM156N)
+2. Chauvet-Piger coincident model (FRED RECPROUSM156N companion series)
+3. Richmond Fed SOS Indicator (direct from Richmond Fed website)
+
+NOTE: FRED series IDs below are per the design spec (feature-5.2-recession-probability-panel.md).
+The exact Chauvet-Piger series ID should be confirmed — spec open question #1.
+
+Caching:
+- Results stored in data/recession_probability_cache.json
+- Cache is read by Flask context processor on every request
+- Cache is refreshed by calling update_recession_probability() in run_data_collection()
+
+Graceful degradation:
+- If any individual model fetch fails, it is omitted and others still render.
+- If all models fail, get_recession_probability() returns None.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CACHE_FILE = Path(__file__).parent / 'data' / 'recession_probability_cache.json'
+
+# FRED API key sourced from environment (same as market_signals.py)
+_FRED_API_KEY = os.environ.get('FRED_API_KEY')
+
+# FRED series IDs
+# NOTE: RECPROUSM156N is "Smoothed U.S. Recession Probabilities" (Chauvet-Piger coincident model).
+# The NY Fed 12-month leading model is a separate series; confirm the correct ID.
+# Per spec: NY Fed uses RECPROUSM156N. Chauvet-Piger uses the series below.
+NY_FED_SERIES = 'RECPROUSM156N'    # NY Fed 12-month leading (spec recommendation — confirm)
+CHAUVET_PIGER_SERIES = 'RECPROUSM156N'  # Chauvet-Piger coincident (same series per spec; update when confirmed)
+
+# Richmond Fed SOS Indicator public data URL
+# NOTE: Confirm the exact Richmond Fed SOS download URL. The URL below is a placeholder
+# based on Richmond Fed's public data publishing patterns; update to confirmed URL.
+_RICHMOND_SOS_URL = (
+    'https://www.richmondfed.org/-/media/richmondfedorg/research/regional_economy/'
+    'surveys_of_business_activity/survey_of_manufacturing_activity/2024/sos_indicator.xlsx'
+)
+
+# Confidence interval: NY Fed applies ±13pp at moderate readings (per NY Fed methodology docs)
+_NY_FED_CI_WIDTH = 13.0
+
+# Divergence alert threshold (pp): alert shown when max–min spread ≥ this value
+DIVERGENCE_THRESHOLD = 15.0
+
+# ---------------------------------------------------------------------------
+# Risk classification
+# ---------------------------------------------------------------------------
+
+def _risk_label(value: float) -> str:
+    """Map a probability value (0–100) to a risk label per spec thresholds."""
+    if value < 15.0:
+        return 'Low'
+    elif value < 35.0:
+        return 'Elevated'
+    else:
+        return 'High'
+
+
+def _risk_css_class(value: float) -> str:
+    """Map a probability value to CSS modifier class (for recession-model-value)."""
+    label = _risk_label(value)
+    return label.lower()  # 'low' | 'elevated' | 'high'
+
+
+# ---------------------------------------------------------------------------
+# FRED data fetcher
+# ---------------------------------------------------------------------------
+
+def _fetch_fred_latest(series_id: str) -> tuple[Optional[float], Optional[str]]:
+    """
+    Fetch the latest non-null observation from a FRED series.
+
+    Returns:
+        (value, date_str) — e.g. (28.9, '2025-12-01') — or (None, None) on failure.
+    """
+    if not _FRED_API_KEY:
+        logger.warning('FRED_API_KEY not set — skipping series %s', series_id)
+        return None, None
+
+    url = 'https://api.stlouisfed.org/fred/series/observations'
+    params = {
+        'series_id': series_id,
+        'api_key': _FRED_API_KEY,
+        'file_type': 'json',
+        'sort_order': 'desc',
+        'limit': 10,  # Fetch last 10; iterate to find first non-null
+    }
+
+    try:
+        resp = requests.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        observations = resp.json().get('observations', [])
+        for obs in observations:
+            raw = obs.get('value', '.')
+            if raw in ('.', ''):
+                continue
+            try:
+                return float(raw), obs.get('date', '')
+            except (ValueError, TypeError):
+                continue
+        logger.warning('No valid observations found for FRED series %s', series_id)
+        return None, None
+
+    except requests.exceptions.RequestException as exc:
+        logger.warning('FRED fetch failed for %s: %s', series_id, exc)
+        return None, None
+    except Exception as exc:
+        logger.warning('Unexpected error fetching FRED series %s: %s', series_id, exc)
+        return None, None
+
+
+# ---------------------------------------------------------------------------
+# Richmond Fed SOS fetcher
+# ---------------------------------------------------------------------------
+
+def _fetch_richmond_sos() -> tuple[Optional[float], Optional[str]]:
+    """
+    Fetch the latest Richmond Fed SOS Indicator value.
+
+    The Richmond Fed SOS (Survey of Occupancy and Slack, or Survey of Special Subjects)
+    is a weekly labor/stress indicator. This function fetches from the public Richmond Fed
+    data URL and extracts the most recent probability value.
+
+    NOTE: The exact URL and data format must be confirmed with the Richmond Fed
+    (spec open question #1). This is a best-effort implementation with graceful degradation.
+
+    Returns:
+        (value, date_str) — or (None, None) on failure.
+    """
+    try:
+        resp = requests.get(_RICHMOND_SOS_URL, timeout=10)
+        resp.raise_for_status()
+
+        # Attempt to parse as Excel; fallback to CSV if needed
+        try:
+            import pandas as pd
+            from io import BytesIO
+            df = pd.read_excel(BytesIO(resp.content), header=0)
+            # Expect columns: date, value (or similar)
+            if df.empty:
+                return None, None
+            df = df.dropna(subset=[df.columns[-1]])
+            last_row = df.iloc[-1]
+            date_val = str(last_row.iloc[0])[:10]  # YYYY-MM-DD
+            prob_val = float(last_row.iloc[-1])
+            return prob_val, date_val
+        except Exception:
+            pass
+
+        # Try CSV if Excel parse failed
+        try:
+            import pandas as pd
+            from io import StringIO
+            df = pd.read_csv(StringIO(resp.text))
+            if df.empty:
+                return None, None
+            last_row = df.iloc[-1]
+            date_val = str(last_row.iloc[0])[:10]
+            prob_val = float(last_row.iloc[-1])
+            return prob_val, date_val
+        except Exception:
+            pass
+
+        logger.warning('Richmond Fed SOS: could not parse response')
+        return None, None
+
+    except requests.exceptions.RequestException as exc:
+        logger.warning('Richmond Fed SOS fetch failed: %s', exc)
+        return None, None
+    except Exception as exc:
+        logger.warning('Unexpected error fetching Richmond Fed SOS: %s', exc)
+        return None, None
+
+
+# ---------------------------------------------------------------------------
+# Interpretation string builder
+# ---------------------------------------------------------------------------
+
+def _build_interpretation(models: dict) -> str:
+    """
+    Build a rules-based 2–3 sentence plain-language interpretation.
+
+    Args:
+        models: dict with keys 'ny_fed', 'chauvet_piger', 'richmond_sos' (floats or None)
+
+    Returns:
+        2–3 sentence string per spec guidance.
+    """
+    available = {k: v for k, v in models.items() if v is not None}
+    if not available:
+        return 'Recession probability data is currently unavailable.'
+
+    values = list(available.values())
+    model_names = {
+        'ny_fed': 'NY Fed\u2019s 12-month leading model',
+        'chauvet_piger': 'Chauvet-Piger coincident model',
+        'richmond_sos': 'Richmond Fed SOS Indicator',
+    }
+
+    # Find highest-value model to lead with
+    highest_key = max(available, key=lambda k: available[k])
+    highest_val = available[highest_key]
+    highest_label = _risk_label(highest_val)
+    highest_name = model_names[highest_key]
+
+    # Sentence 1: Lead with highest-value model signal
+    if highest_label == 'High':
+        s1 = f'The {highest_name} signals high recession risk at {highest_val:.1f}%.'
+    elif highest_label == 'Elevated':
+        s1 = (
+            f'The {highest_name} suggests elevated recession risk at {highest_val:.1f}%,'
+            f' indicating growing near-term uncertainty.'
+        )
+    else:
+        s1 = (
+            f'The {highest_name} indicates low recession risk at {highest_val:.1f}%,'
+            f' consistent with continued expansion.'
+        )
+
+    # Sentence 2: Note agreement or disagreement between leading and coincident models
+    if 'ny_fed' in available and 'chauvet_piger' in available:
+        spread = abs(available['ny_fed'] - available['chauvet_piger'])
+        if spread >= DIVERGENCE_THRESHOLD:
+            s2 = (
+                f'Coincident indicators diverge from the leading model by {spread:.0f}pp \u2014'
+                f' a spread that itself signals elevated uncertainty about the near-term outlook.'
+            )
+        else:
+            if available['ny_fed'] < 15.0 and available['chauvet_piger'] < 15.0:
+                s2 = 'Leading and coincident indicators agree: current and forward-looking signals show low recession risk.'
+            else:
+                s2 = 'Leading and coincident indicators are broadly aligned, suggesting a consistent near-term signal.'
+    elif len(available) >= 2:
+        # Two or more models, but not NY Fed + Chauvet-Piger pair specifically
+        all_labels = [_risk_label(v) for v in available.values()]
+        if len(set(all_labels)) == 1:
+            s2 = f'Available models are broadly aligned at the {all_labels[0].lower()} risk level.'
+        else:
+            s2 = 'Available models show divergent signals; monitor developments across sources for confirmation.'
+    else:
+        s2 = ''
+
+    parts = [s for s in [s1, s2] if s]
+    return ' '.join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Cache helpers
+# ---------------------------------------------------------------------------
+
+def _load_cache() -> Optional[dict]:
+    """Return cached recession probability dict, or None if cache doesn't exist."""
+    try:
+        if CACHE_FILE.exists():
+            with open(CACHE_FILE, 'r') as f:
+                return json.load(f)
+    except Exception as exc:
+        logger.warning('Failed to read recession probability cache: %s', exc)
+    return None
+
+
+def _save_cache(data: dict) -> None:
+    """Persist recession probability dict to cache file."""
+    try:
+        CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with open(CACHE_FILE, 'w') as f:
+            json.dump(data, f, default=str, indent=2)
+    except Exception as exc:
+        logger.warning('Failed to write recession probability cache: %s', exc)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def get_recession_probability() -> Optional[dict]:
+    """
+    Return the cached recession probability data.
+
+    Returns None if no cache exists or cache is corrupted.
+    Called by the Flask context processor on every request.
+    """
+    return _load_cache()
+
+
+def update_recession_probability() -> None:
+    """
+    Fetch latest data from all three model sources, compute derived fields,
+    and write to the cache file.
+
+    Called once per daily data refresh cycle (run_data_collection).
+    Errors from individual model fetches are non-fatal (graceful degradation).
+    """
+    updated_at = datetime.now(timezone.utc).isoformat()
+
+    # Fetch individual models
+    ny_fed_val, ny_fed_date = _fetch_fred_latest(NY_FED_SERIES)
+    cp_val, cp_date = _fetch_fred_latest(CHAUVET_PIGER_SERIES)
+    sos_val, sos_date = _fetch_richmond_sos()
+
+    # At least one model must be available
+    available_models = {
+        k: v for k, v in [
+            ('ny_fed', ny_fed_val),
+            ('chauvet_piger', cp_val),
+            ('richmond_sos', sos_val),
+        ] if v is not None
+    }
+
+    if not available_models:
+        logger.warning('No recession probability model data available — skipping cache update')
+        return
+
+    # NY Fed confidence interval (±13pp, clamped to [0, 100])
+    ny_fed_lower = None
+    ny_fed_upper = None
+    if ny_fed_val is not None:
+        ny_fed_lower = round(max(0.0, ny_fed_val - _NY_FED_CI_WIDTH), 1)
+        ny_fed_upper = round(min(100.0, ny_fed_val + _NY_FED_CI_WIDTH), 1)
+
+    # Divergence (max–min across all available models)
+    all_values = list(available_models.values())
+    divergence_pp = round(max(all_values) - min(all_values), 1) if len(all_values) >= 2 else 0.0
+
+    # Interpretation string
+    interpretation = _build_interpretation({
+        'ny_fed': ny_fed_val,
+        'chauvet_piger': cp_val,
+        'richmond_sos': sos_val,
+    })
+
+    # Formatted update timestamp (e.g. "Feb 26, 2026")
+    try:
+        dt = datetime.fromisoformat(updated_at.replace('Z', '+00:00'))
+        updated_display = dt.strftime('%b %-d, %Y')
+    except (ValueError, AttributeError):
+        updated_display = ''
+
+    data = {
+        'updated_at': updated_at,
+        'updated': updated_display,
+    }
+
+    # Per-model fields (only include models where data is available)
+    if ny_fed_val is not None:
+        data['ny_fed'] = round(ny_fed_val, 1)
+        data['ny_fed_lower'] = ny_fed_lower
+        data['ny_fed_upper'] = ny_fed_upper
+        data['ny_fed_date'] = ny_fed_date or ''
+        data['ny_fed_risk'] = _risk_label(ny_fed_val)
+        data['ny_fed_css'] = _risk_css_class(ny_fed_val)
+
+    if cp_val is not None:
+        data['chauvet_piger'] = round(cp_val, 1)
+        data['chauvet_piger_date'] = cp_date or ''
+        data['chauvet_piger_risk'] = _risk_label(cp_val)
+        data['chauvet_piger_css'] = _risk_css_class(cp_val)
+
+    if sos_val is not None:
+        data['richmond_sos'] = round(sos_val, 1)
+        data['richmond_sos_date'] = sos_date or ''
+        data['richmond_sos_risk'] = _risk_label(sos_val)
+        data['richmond_sos_css'] = _risk_css_class(sos_val)
+
+    data['divergence_pp'] = divergence_pp
+    data['interpretation'] = interpretation
+
+    # Mobile summary: e.g. "Low–Elevated · Models diverging"
+    risk_labels = [_risk_label(v) for v in all_values]
+    unique_labels = sorted(set(risk_labels), key=['Low', 'Elevated', 'High'].index)
+    risk_summary = '\u2013'.join(unique_labels) if len(unique_labels) > 1 else unique_labels[0]
+    alignment = 'Models diverging' if divergence_pp >= DIVERGENCE_THRESHOLD else 'Models aligned'
+    data['mobile_summary'] = f'{risk_summary} \u00b7 {alignment}'
+
+    _save_cache(data)
+    logger.info(
+        'Recession probability updated: ny_fed=%s chauvet_piger=%s richmond_sos=%s divergence=%.1fpp',
+        ny_fed_val, cp_val, sos_val, divergence_pp,
+    )

--- a/tests/test_us461_recession_probability_backend.py
+++ b/tests/test_us461_recession_probability_backend.py
@@ -1,0 +1,711 @@
+"""
+Static verification tests for US-146.1: Backend data layer — fetch and process
+three recession probability models.
+
+These tests verify the implementation without requiring a live Flask server,
+external API calls, or live market data. They exercise the pure-Python logic
+directly and inspect source files for structural correctness.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SIGNALTRACKERS_DIR = os.path.join(REPO_ROOT, 'signaltrackers')
+sys.path.insert(0, SIGNALTRACKERS_DIR)
+
+
+def read_source(filename):
+    path = os.path.join(SIGNALTRACKERS_DIR, filename)
+    with open(path, 'r') as f:
+        return f.read()
+
+
+# ---------------------------------------------------------------------------
+# Module structure tests
+# ---------------------------------------------------------------------------
+
+
+class TestModuleExists(unittest.TestCase):
+    """recession_probability.py must exist in signaltrackers/."""
+
+    def test_file_exists(self):
+        path = os.path.join(SIGNALTRACKERS_DIR, 'recession_probability.py')
+        self.assertTrue(os.path.isfile(path), 'recession_probability.py not found')
+
+
+class TestModuleImports(unittest.TestCase):
+    """Module must import without error."""
+
+    def test_import_success(self):
+        import recession_probability
+        self.assertIsNotNone(recession_probability)
+
+    def test_get_recession_probability_function(self):
+        from recession_probability import get_recession_probability
+        self.assertTrue(callable(get_recession_probability))
+
+    def test_update_recession_probability_function(self):
+        from recession_probability import update_recession_probability
+        self.assertTrue(callable(update_recession_probability))
+
+
+# ---------------------------------------------------------------------------
+# Constants tests
+# ---------------------------------------------------------------------------
+
+
+class TestConstants(unittest.TestCase):
+    """Required constants must be defined with correct values."""
+
+    def setUp(self):
+        import recession_probability as rp
+        self.rp = rp
+
+    def test_ny_fed_series_defined(self):
+        self.assertTrue(hasattr(self.rp, 'NY_FED_SERIES'))
+
+    def test_ny_fed_series_is_string(self):
+        self.assertIsInstance(self.rp.NY_FED_SERIES, str)
+
+    def test_chauvet_piger_series_defined(self):
+        self.assertTrue(hasattr(self.rp, 'CHAUVET_PIGER_SERIES'))
+
+    def test_chauvet_piger_series_is_string(self):
+        self.assertIsInstance(self.rp.CHAUVET_PIGER_SERIES, str)
+
+    def test_divergence_threshold_defined(self):
+        self.assertTrue(hasattr(self.rp, 'DIVERGENCE_THRESHOLD'))
+
+    def test_divergence_threshold_value(self):
+        self.assertEqual(self.rp.DIVERGENCE_THRESHOLD, 15.0)
+
+    def test_cache_file_constant_defined(self):
+        self.assertTrue(hasattr(self.rp, 'CACHE_FILE'))
+
+    def test_cache_file_in_data_dir(self):
+        path = str(self.rp.CACHE_FILE)
+        self.assertIn('data', path)
+        self.assertIn('recession_probability', path)
+
+    def test_ny_fed_ci_width_defined(self):
+        self.assertTrue(hasattr(self.rp, '_NY_FED_CI_WIDTH'))
+
+    def test_ny_fed_ci_width_value(self):
+        self.assertAlmostEqual(self.rp._NY_FED_CI_WIDTH, 13.0)
+
+
+class TestConstantsInSource(unittest.TestCase):
+    """Key constants must appear literally in the source file."""
+
+    def setUp(self):
+        self.src = read_source('recession_probability.py')
+
+    def test_divergence_threshold_literal(self):
+        self.assertIn('DIVERGENCE_THRESHOLD', self.src)
+
+    def test_ny_fed_ci_width_literal(self):
+        self.assertIn('13.0', self.src)
+
+    def test_cache_file_literal(self):
+        self.assertIn('recession_probability_cache.json', self.src)
+
+    def test_get_recession_probability_defined(self):
+        self.assertIn('def get_recession_probability', self.src)
+
+    def test_update_recession_probability_defined(self):
+        self.assertIn('def update_recession_probability', self.src)
+
+
+# ---------------------------------------------------------------------------
+# Risk label tests
+# ---------------------------------------------------------------------------
+
+
+class TestRiskLabel(unittest.TestCase):
+    """_risk_label() must classify values per spec thresholds."""
+
+    def setUp(self):
+        from recession_probability import _risk_label
+        self.fn = _risk_label
+
+    def test_zero_is_low(self):
+        self.assertEqual(self.fn(0.0), 'Low')
+
+    def test_below_15_is_low(self):
+        self.assertEqual(self.fn(14.9), 'Low')
+
+    def test_exactly_15_is_elevated(self):
+        self.assertEqual(self.fn(15.0), 'Elevated')
+
+    def test_between_15_and_35_is_elevated(self):
+        self.assertEqual(self.fn(28.9), 'Elevated')
+
+    def test_below_35_is_elevated(self):
+        self.assertEqual(self.fn(34.9), 'Elevated')
+
+    def test_exactly_35_is_high(self):
+        self.assertEqual(self.fn(35.0), 'High')
+
+    def test_above_35_is_high(self):
+        self.assertEqual(self.fn(60.0), 'High')
+
+    def test_100_is_high(self):
+        self.assertEqual(self.fn(100.0), 'High')
+
+
+class TestRiskCssClass(unittest.TestCase):
+    """_risk_css_class() must return lowercase risk label."""
+
+    def setUp(self):
+        from recession_probability import _risk_css_class
+        self.fn = _risk_css_class
+
+    def test_low_returns_low(self):
+        self.assertEqual(self.fn(5.0), 'low')
+
+    def test_elevated_returns_elevated(self):
+        self.assertEqual(self.fn(20.0), 'elevated')
+
+    def test_high_returns_high(self):
+        self.assertEqual(self.fn(40.0), 'high')
+
+
+# ---------------------------------------------------------------------------
+# Confidence interval tests
+# ---------------------------------------------------------------------------
+
+
+class TestNyFedConfidenceInterval(unittest.TestCase):
+    """NY Fed confidence interval must be ±13pp, clamped to [0, 100]."""
+
+    def _run_update_with_values(self, ny_val, cp_val=None, sos_val=None):
+        """Run update_recession_probability with mocked fetch functions."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / 'recession_probability_cache.json'
+            with patch('recession_probability.CACHE_FILE', cache_path):
+                with patch('recession_probability._fetch_fred_latest') as mock_fred:
+                    with patch('recession_probability._fetch_richmond_sos') as mock_sos:
+                        # Set NY Fed return
+                        ny_return = (ny_val, '2025-12-01') if ny_val is not None else (None, None)
+                        cp_return = (cp_val, '2025-12-01') if cp_val is not None else (None, None)
+                        mock_fred.side_effect = [ny_return, cp_return]
+                        mock_sos.return_value = (sos_val, '2026-01-10') if sos_val is not None else (None, None)
+
+                        from recession_probability import update_recession_probability
+                        update_recession_probability()
+
+                        if cache_path.exists():
+                            with open(cache_path) as f:
+                                return json.load(f)
+                        return None
+
+    def test_ny_fed_lower_is_minus_13(self):
+        data = self._run_update_with_values(ny_val=28.9, cp_val=4.2)
+        self.assertIsNotNone(data)
+        self.assertAlmostEqual(data['ny_fed_lower'], 28.9 - 13.0, places=0)
+
+    def test_ny_fed_upper_is_plus_13(self):
+        data = self._run_update_with_values(ny_val=28.9, cp_val=4.2)
+        self.assertIsNotNone(data)
+        self.assertAlmostEqual(data['ny_fed_upper'], 28.9 + 13.0, places=0)
+
+    def test_ny_fed_lower_clamped_to_zero(self):
+        # Value 5.0 → lower = max(0, 5.0 - 13.0) = 0.0
+        data = self._run_update_with_values(ny_val=5.0, cp_val=4.2)
+        self.assertIsNotNone(data)
+        self.assertEqual(data['ny_fed_lower'], 0.0)
+
+    def test_ny_fed_upper_clamped_to_100(self):
+        # Value 95.0 → upper = min(100, 95.0 + 13.0) = 100.0
+        data = self._run_update_with_values(ny_val=95.0, cp_val=4.2)
+        self.assertIsNotNone(data)
+        self.assertEqual(data['ny_fed_upper'], 100.0)
+
+
+# ---------------------------------------------------------------------------
+# Divergence computation tests
+# ---------------------------------------------------------------------------
+
+
+class TestDivergenceComputation(unittest.TestCase):
+    """divergence_pp must equal max–min across all available models (1 decimal)."""
+
+    def _run_update_with_values(self, ny_val, cp_val=None, sos_val=None):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / 'recession_probability_cache.json'
+            with patch('recession_probability.CACHE_FILE', cache_path):
+                with patch('recession_probability._fetch_fred_latest') as mock_fred:
+                    with patch('recession_probability._fetch_richmond_sos') as mock_sos:
+                        ny_return = (ny_val, '2025-12-01') if ny_val is not None else (None, None)
+                        cp_return = (cp_val, '2025-12-01') if cp_val is not None else (None, None)
+                        mock_fred.side_effect = [ny_return, cp_return]
+                        mock_sos.return_value = (sos_val, '2026-01-10') if sos_val is not None else (None, None)
+
+                        from recession_probability import update_recession_probability
+                        update_recession_probability()
+
+                        if cache_path.exists():
+                            with open(cache_path) as f:
+                                return json.load(f)
+                        return None
+
+    def test_divergence_three_models(self):
+        # max=28.9, min=0.8, spread=28.1
+        data = self._run_update_with_values(ny_val=28.9, cp_val=4.2, sos_val=0.8)
+        self.assertIsNotNone(data)
+        self.assertAlmostEqual(data['divergence_pp'], 28.1, places=0)
+
+    def test_divergence_two_models(self):
+        # max=28.9, min=4.2, spread=24.7
+        data = self._run_update_with_values(ny_val=28.9, cp_val=4.2)
+        self.assertIsNotNone(data)
+        self.assertAlmostEqual(data['divergence_pp'], 24.7, places=0)
+
+    def test_divergence_single_model_is_zero(self):
+        # Only one model available — no spread
+        data = self._run_update_with_values(ny_val=28.9, cp_val=None)
+        self.assertIsNotNone(data)
+        self.assertEqual(data['divergence_pp'], 0.0)
+
+    def test_divergence_same_values_is_zero(self):
+        data = self._run_update_with_values(ny_val=10.0, cp_val=10.0)
+        self.assertIsNotNone(data)
+        self.assertEqual(data['divergence_pp'], 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation tests
+# ---------------------------------------------------------------------------
+
+
+class TestGracefulDegradation(unittest.TestCase):
+    """Individual model failures must not prevent others from rendering."""
+
+    def _run_update(self, ny_val, cp_val, sos_val):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / 'recession_probability_cache.json'
+            with patch('recession_probability.CACHE_FILE', cache_path):
+                with patch('recession_probability._fetch_fred_latest') as mock_fred:
+                    with patch('recession_probability._fetch_richmond_sos') as mock_sos:
+                        ny_return = (ny_val, '2025-12-01') if ny_val is not None else (None, None)
+                        cp_return = (cp_val, '2025-12-01') if cp_val is not None else (None, None)
+                        mock_fred.side_effect = [ny_return, cp_return]
+                        mock_sos.return_value = (sos_val, '2026-01-10') if sos_val is not None else (None, None)
+
+                        from recession_probability import update_recession_probability
+                        update_recession_probability()
+
+                        if cache_path.exists():
+                            with open(cache_path) as f:
+                                return json.load(f)
+                        return None
+
+    def test_cp_missing_ny_fed_still_present(self):
+        data = self._run_update(ny_val=28.9, cp_val=None, sos_val=None)
+        self.assertIsNotNone(data)
+        self.assertIn('ny_fed', data)
+        self.assertNotIn('chauvet_piger', data)
+
+    def test_ny_fed_missing_cp_still_present(self):
+        data = self._run_update(ny_val=None, cp_val=4.2, sos_val=None)
+        self.assertIsNotNone(data)
+        self.assertIn('chauvet_piger', data)
+        self.assertNotIn('ny_fed', data)
+        self.assertNotIn('ny_fed_lower', data)
+        self.assertNotIn('ny_fed_upper', data)
+
+    def test_sos_present_when_available(self):
+        data = self._run_update(ny_val=28.9, cp_val=4.2, sos_val=0.8)
+        self.assertIsNotNone(data)
+        self.assertIn('richmond_sos', data)
+
+    def test_all_fail_cache_not_written(self):
+        # All models return None — cache should NOT be written
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / 'recession_probability_cache.json'
+            with patch('recession_probability.CACHE_FILE', cache_path):
+                with patch('recession_probability._fetch_fred_latest', return_value=(None, None)):
+                    with patch('recession_probability._fetch_richmond_sos', return_value=(None, None)):
+                        from recession_probability import update_recession_probability
+                        update_recession_probability()
+            self.assertFalse(cache_path.exists(), 'Cache should not be written if all models fail')
+
+    def test_ny_fed_fields_absent_when_model_unavailable(self):
+        data = self._run_update(ny_val=None, cp_val=4.2, sos_val=None)
+        self.assertNotIn('ny_fed', data)
+        self.assertNotIn('ny_fed_lower', data)
+        self.assertNotIn('ny_fed_upper', data)
+
+
+# ---------------------------------------------------------------------------
+# Risk label per-model field tests
+# ---------------------------------------------------------------------------
+
+
+class TestPerModelRiskFields(unittest.TestCase):
+    """Each available model must include risk label and CSS class in cache."""
+
+    def _run_update(self, ny_val, cp_val, sos_val):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / 'recession_probability_cache.json'
+            with patch('recession_probability.CACHE_FILE', cache_path):
+                with patch('recession_probability._fetch_fred_latest') as mock_fred:
+                    with patch('recession_probability._fetch_richmond_sos') as mock_sos:
+                        ny_return = (ny_val, '2025-12-01') if ny_val is not None else (None, None)
+                        cp_return = (cp_val, '2025-12-01') if cp_val is not None else (None, None)
+                        mock_fred.side_effect = [ny_return, cp_return]
+                        mock_sos.return_value = (sos_val, '2026-01-10') if sos_val is not None else (None, None)
+
+                        from recession_probability import update_recession_probability
+                        update_recession_probability()
+
+                        if cache_path.exists():
+                            with open(cache_path) as f:
+                                return json.load(f)
+                        return None
+
+    def test_ny_fed_risk_label_present(self):
+        data = self._run_update(ny_val=28.9, cp_val=4.2, sos_val=None)
+        self.assertIn('ny_fed_risk', data)
+        self.assertEqual(data['ny_fed_risk'], 'Elevated')
+
+    def test_ny_fed_css_class_present(self):
+        data = self._run_update(ny_val=28.9, cp_val=4.2, sos_val=None)
+        self.assertIn('ny_fed_css', data)
+        self.assertEqual(data['ny_fed_css'], 'elevated')
+
+    def test_chauvet_piger_risk_label_low(self):
+        data = self._run_update(ny_val=28.9, cp_val=4.2, sos_val=None)
+        self.assertEqual(data['chauvet_piger_risk'], 'Low')
+
+    def test_chauvet_piger_css_class_low(self):
+        data = self._run_update(ny_val=28.9, cp_val=4.2, sos_val=None)
+        self.assertEqual(data['chauvet_piger_css'], 'low')
+
+    def test_richmond_sos_risk_high(self):
+        data = self._run_update(ny_val=28.9, cp_val=4.2, sos_val=40.0)
+        self.assertEqual(data['richmond_sos_risk'], 'High')
+
+    def test_richmond_sos_css_high(self):
+        data = self._run_update(ny_val=28.9, cp_val=4.2, sos_val=40.0)
+        self.assertEqual(data['richmond_sos_css'], 'high')
+
+
+# ---------------------------------------------------------------------------
+# Interpretation string tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildInterpretation(unittest.TestCase):
+    """Interpretation string must follow rules-based spec guidance."""
+
+    def setUp(self):
+        from recession_probability import _build_interpretation
+        self.fn = _build_interpretation
+
+    def test_returns_string(self):
+        result = self.fn({'ny_fed': 28.9, 'chauvet_piger': 4.2, 'richmond_sos': 0.8})
+        self.assertIsInstance(result, str)
+
+    def test_non_empty(self):
+        result = self.fn({'ny_fed': 28.9, 'chauvet_piger': 4.2})
+        self.assertGreater(len(result), 10)
+
+    def test_all_none_returns_unavailable_message(self):
+        result = self.fn({'ny_fed': None, 'chauvet_piger': None, 'richmond_sos': None})
+        self.assertIn('unavailable', result.lower())
+
+    def test_low_risk_interpretation_contains_low_language(self):
+        result = self.fn({'ny_fed': 5.0, 'chauvet_piger': 3.0})
+        result_lower = result.lower()
+        self.assertTrue(
+            'low' in result_lower or 'expansion' in result_lower,
+            f'Expected low-risk language in: {result}',
+        )
+
+    def test_elevated_risk_interpretation_contains_elevated_language(self):
+        result = self.fn({'ny_fed': 28.9, 'chauvet_piger': 4.2})
+        result_lower = result.lower()
+        self.assertTrue(
+            'elevated' in result_lower or 'growing' in result_lower or 'uncertainty' in result_lower,
+            f'Expected elevated-risk language in: {result}',
+        )
+
+    def test_high_risk_interpretation_contains_high_language(self):
+        result = self.fn({'ny_fed': 50.0, 'chauvet_piger': 45.0})
+        result_lower = result.lower()
+        self.assertTrue(
+            'high' in result_lower or 'risk' in result_lower,
+            f'Expected high-risk language in: {result}',
+        )
+
+    def test_divergent_models_noted_in_interpretation(self):
+        # 28pp spread between models should trigger divergence note
+        result = self.fn({'ny_fed': 30.0, 'chauvet_piger': 2.0})
+        result_lower = result.lower()
+        self.assertTrue(
+            'diverg' in result_lower or 'disagree' in result_lower or 'uncertainty' in result_lower,
+            f'Expected divergence language in: {result}',
+        )
+
+    def test_aligned_models_noted_in_interpretation(self):
+        # Low spread should note alignment
+        result = self.fn({'ny_fed': 5.0, 'chauvet_piger': 6.0})
+        result_lower = result.lower()
+        self.assertTrue(
+            'align' in result_lower or 'agree' in result_lower or 'low' in result_lower,
+            f'Expected alignment language in: {result}',
+        )
+
+    def test_avoids_absolute_language_will(self):
+        result = self.fn({'ny_fed': 28.9, 'chauvet_piger': 4.2})
+        self.assertNotIn(' will ', result.lower())
+
+    def test_single_model_returns_non_empty(self):
+        result = self.fn({'ny_fed': 28.9, 'chauvet_piger': None})
+        self.assertGreater(len(result), 10)
+
+
+# ---------------------------------------------------------------------------
+# Mobile summary string tests
+# ---------------------------------------------------------------------------
+
+
+class TestMobileSummary(unittest.TestCase):
+    """mobile_summary field must follow spec format."""
+
+    def _run_update(self, ny_val, cp_val, sos_val=None):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / 'recession_probability_cache.json'
+            with patch('recession_probability.CACHE_FILE', cache_path):
+                with patch('recession_probability._fetch_fred_latest') as mock_fred:
+                    with patch('recession_probability._fetch_richmond_sos') as mock_sos:
+                        ny_return = (ny_val, '2025-12-01') if ny_val is not None else (None, None)
+                        cp_return = (cp_val, '2025-12-01') if cp_val is not None else (None, None)
+                        mock_fred.side_effect = [ny_return, cp_return]
+                        mock_sos.return_value = (sos_val, '2026-01-10') if sos_val is not None else (None, None)
+
+                        from recession_probability import update_recession_probability
+                        update_recession_probability()
+
+                        if cache_path.exists():
+                            with open(cache_path) as f:
+                                return json.load(f)
+                        return None
+
+    def test_mobile_summary_present(self):
+        data = self._run_update(ny_val=28.9, cp_val=4.2)
+        self.assertIn('mobile_summary', data)
+
+    def test_diverging_summary_label(self):
+        # 24.7pp spread ≥ 15 → "diverging"
+        data = self._run_update(ny_val=28.9, cp_val=4.2)
+        self.assertIn('diverging', data['mobile_summary'].lower())
+
+    def test_aligned_summary_label(self):
+        # Small spread → "aligned"
+        data = self._run_update(ny_val=5.0, cp_val=6.0)
+        self.assertIn('aligned', data['mobile_summary'].lower())
+
+    def test_multiple_risk_levels_shown_with_separator(self):
+        # ny_fed=28.9 (Elevated), cp_val=4.2 (Low) → "Low–Elevated"
+        data = self._run_update(ny_val=28.9, cp_val=4.2)
+        summary = data['mobile_summary']
+        self.assertTrue(
+            'Low' in summary and 'Elevated' in summary,
+            f'Expected both risk levels in: {summary}',
+        )
+
+    def test_single_risk_level_no_separator(self):
+        # Both low → just "Low"
+        data = self._run_update(ny_val=5.0, cp_val=7.0)
+        summary = data['mobile_summary']
+        self.assertTrue(
+            summary.startswith('Low'),
+            f'Expected single risk level prefix in: {summary}',
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cache round-trip tests
+# ---------------------------------------------------------------------------
+
+
+class TestCacheRoundTrip(unittest.TestCase):
+    """get_recession_probability() must return what update_recession_probability() wrote."""
+
+    def test_cache_round_trip_all_models(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / 'recession_probability_cache.json'
+            with patch('recession_probability.CACHE_FILE', cache_path):
+                with patch('recession_probability._fetch_fred_latest') as mock_fred:
+                    with patch('recession_probability._fetch_richmond_sos') as mock_sos:
+                        mock_fred.side_effect = [
+                            (28.9, '2025-12-01'),
+                            (4.2, '2025-12-01'),
+                        ]
+                        mock_sos.return_value = (0.8, '2026-01-10')
+
+                        from recession_probability import (
+                            update_recession_probability,
+                            get_recession_probability,
+                        )
+                        update_recession_probability()
+                        result = get_recession_probability()
+
+            self.assertIsNotNone(result)
+            self.assertAlmostEqual(result['ny_fed'], 28.9, places=0)
+            self.assertAlmostEqual(result['chauvet_piger'], 4.2, places=0)
+            self.assertAlmostEqual(result['richmond_sos'], 0.8, places=0)
+            self.assertIn('updated', result)
+            self.assertIn('interpretation', result)
+
+    def test_get_returns_none_when_no_cache(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / 'recession_probability_cache.json'
+            with patch('recession_probability.CACHE_FILE', cache_path):
+                from recession_probability import get_recession_probability
+                result = get_recession_probability()
+        self.assertIsNone(result)
+
+
+# ---------------------------------------------------------------------------
+# FRED fetcher structure tests (source inspection)
+# ---------------------------------------------------------------------------
+
+
+class TestFredFetcherSource(unittest.TestCase):
+    """_fetch_fred_latest must follow FRED API patterns established in market_signals.py."""
+
+    def setUp(self):
+        self.src = read_source('recession_probability.py')
+
+    def test_uses_fred_api_url(self):
+        self.assertIn('fred/series/observations', self.src)
+
+    def test_uses_fred_api_key_env_var(self):
+        self.assertIn('FRED_API_KEY', self.src)
+
+    def test_has_timeout(self):
+        self.assertIn('timeout=', self.src)
+
+    def test_handles_request_exception(self):
+        self.assertIn('RequestException', self.src)
+
+    def test_skips_missing_values(self):
+        # FRED uses '.' for missing values — must be handled
+        self.assertIn("'.'", self.src)
+
+    def test_sort_order_desc_for_latest(self):
+        self.assertIn('desc', self.src)
+
+
+# ---------------------------------------------------------------------------
+# Dashboard integration tests (source inspection)
+# ---------------------------------------------------------------------------
+
+
+class TestDashboardIntegration(unittest.TestCase):
+    """dashboard.py must import and wire up the recession probability module."""
+
+    def setUp(self):
+        self.src = read_source('dashboard.py')
+
+    def test_imports_get_recession_probability(self):
+        self.assertIn('get_recession_probability', self.src)
+
+    def test_imports_update_recession_probability(self):
+        self.assertIn('update_recession_probability', self.src)
+
+    def test_imports_from_recession_probability_module(self):
+        self.assertIn('from recession_probability import', self.src)
+
+    def test_context_processor_defined(self):
+        self.assertIn('inject_recession_probability', self.src)
+
+    def test_context_processor_returns_recession_probability(self):
+        self.assertIn("'recession_probability'", self.src)
+
+    def test_update_called_in_run_data_collection(self):
+        # update_recession_probability() must be called inside run_data_collection
+        # Check it appears after the update_macro_regime call (order matters)
+        macro_pos = self.src.find('update_macro_regime()')
+        recession_pos = self.src.find('update_recession_probability()')
+        self.assertGreater(macro_pos, 0, 'update_macro_regime() not found in dashboard.py')
+        self.assertGreater(recession_pos, 0, 'update_recession_probability() not found in dashboard.py')
+        self.assertGreater(
+            recession_pos, macro_pos,
+            'update_recession_probability() must be called AFTER update_macro_regime()',
+        )
+
+    def test_update_wrapped_in_try_except(self):
+        # The update call must be non-fatal (same pattern as update_macro_regime)
+        # Check there's a try block close to the update call
+        src_slice = self.src[max(0, self.src.find('update_recession_probability()') - 200):]
+        self.assertIn('try:', src_slice[:400])
+
+    def test_context_processor_has_try_except(self):
+        # inject_recession_probability must have graceful error handling
+        proc_src = self.src[self.src.find('def inject_recession_probability'):]
+        proc_src = proc_src[:proc_src.find('\ndef ', 5)]
+        self.assertIn('try:', proc_src)
+        self.assertIn('except', proc_src)
+
+
+# ---------------------------------------------------------------------------
+# Per-model update date tests
+# ---------------------------------------------------------------------------
+
+
+class TestPerModelDates(unittest.TestCase):
+    """Per-model update dates must be stored in cache (spec requirement)."""
+
+    def _run_update(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / 'recession_probability_cache.json'
+            with patch('recession_probability.CACHE_FILE', cache_path):
+                with patch('recession_probability._fetch_fred_latest') as mock_fred:
+                    with patch('recession_probability._fetch_richmond_sos') as mock_sos:
+                        mock_fred.side_effect = [
+                            (28.9, '2025-12-01'),
+                            (4.2, '2025-11-01'),
+                        ]
+                        mock_sos.return_value = (0.8, '2026-01-10')
+
+                        from recession_probability import update_recession_probability
+                        update_recession_probability()
+
+                        if cache_path.exists():
+                            with open(cache_path) as f:
+                                return json.load(f)
+                        return None
+
+    def test_ny_fed_date_stored(self):
+        data = self._run_update()
+        self.assertIn('ny_fed_date', data)
+        self.assertIn('2025-12-01', data['ny_fed_date'])
+
+    def test_chauvet_piger_date_stored(self):
+        data = self._run_update()
+        self.assertIn('chauvet_piger_date', data)
+        self.assertIn('2025-11-01', data['chauvet_piger_date'])
+
+    def test_richmond_sos_date_stored(self):
+        data = self._run_update()
+        self.assertIn('richmond_sos_date', data)
+        self.assertIn('2026-01-10', data['richmond_sos_date'])
+
+    def test_updated_display_formatted(self):
+        data = self._run_update()
+        self.assertIn('updated', data)
+        self.assertGreater(len(data['updated']), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #148

## Summary
Implements the backend data layer for the recession probability panel (Feature 5.2). Fetches three institutional recession probability models, computes divergence/confidence intervals, generates a rules-based interpretation string, and injects all data into the template context via a non-fatal context processor.

## Changes
- **Engineer:** New `signaltrackers/recession_probability.py` module — FRED fetcher for NY Fed (RECPROUSM156N) and Chauvet-Piger models; Richmond Fed SOS best-effort direct fetch; risk classification (<15% Low, 15–35% Elevated, ≥35% High); NY Fed ±13pp CI with [0,100] clamp; divergence_pp computation; rules-based interpretation string; cache read/write via `data/recession_probability_cache.json`; graceful degradation if any model unavailable
- **Engineer:** `signaltrackers/dashboard.py` — `inject_recession_probability()` context processor; `update_recession_probability()` called in `run_data_collection()` after `update_macro_regime()`
- **QA:** 84 new tests in `tests/test_us461_recession_probability_backend.py`; 1012 total passing

## Testing
- ✅ All unit tests passing (1012 total)
- ✅ Design review not required (backend-only story)
- ✅ QA verification complete

## Design Spec
Implements [docs/specs/feature-5.2-recession-probability-panel.md](docs/specs/feature-5.2-recession-probability-panel.md)

## ⚠️ Open Questions for Human Review Before Production
1. **FRED series IDs:** Both `NY_FED_SERIES` and `CHAUVET_PIGER_SERIES` are currently set to `RECPROUSM156N` (the spec flagged this as an open question). The correct Chauvet-Piger companion series ID needs confirmation. Until confirmed, the two model values will be identical (same FRED call). Graceful degradation handles this — no crash, just duplicate values.
2. **Richmond Fed SOS URL:** The URL in `recession_probability.py` is a best-effort implementation. If the URL is wrong, the SOS model gracefully degrades to None — no page crash. The correct URL needs verification before Feature 5.2 is considered production-ready.