### PR TITLE
Fix Bug #153: NY Fed recession probability fetches direct XLS instead of FRED

### DIFF
--- a/signaltrackers/requirements.txt
+++ b/signaltrackers/requirements.txt
@@ -1,5 +1,6 @@
 # Core
 pandas>=2.0.0
+xlrd>=2.0.0
 numpy>=1.24.0
 requests>=2.31.0
 yfinance>=0.2.0


### PR DESCRIPTION
Fixes #153

## Summary
Corrects the NY Fed recession probability data source: the NY Fed yield-curve model is **not on FRED** — it is published as an Excel file directly from `newyorkfed.org`. Previously, both NY Fed and Chauvet-Piger were reading the same FRED series (`RECPROUSM156N`), so their values were always identical and divergence was meaningless.

## Changes
- **Removed** `NY_FED_SERIES` constant (was pointing to wrong FRED series)
- **Added** `_NY_FED_DIRECT_URL` module-level constant → `https://www.newyorkfed.org/medialibrary/media/research/capital_markets/allmonth.xls`
- **Added** `_fetch_ny_fed_direct()` — fetches XLS, reads `Rec_prob` column (0–1 scale), multiplies ×100 for percent, returns `(value, date_str)` with graceful degradation on any failure
- **Updated** `update_recession_probability()` to call `_fetch_ny_fed_direct()` instead of `_fetch_fred_latest(NY_FED_SERIES)`
- **Added** `xlrd>=2.0.0` to `requirements.txt` for legacy `.xls` (BIFF format) support
- **34 new tests** covering URL constant, value conversion (0.062→6.2%, 1.0→100.0%), date parsing, network errors, HTTP errors, missing column, empty DataFrame, all-NaN graceful degradation

## Testing
- ✅ 141/141 story tests passing
- ✅ 1030 full suite passing
- ✅ Design review N/A (backend-only fix)
- ✅ QA verification complete (all 14 acceptance criteria met)