### PR TITLE
Fix: cache ordering and FRED incremental fetch (Bugs #174, #175)

### DIFF
--- a/signaltrackers/dashboard.py
+++ b/signaltrackers/dashboard.py
@@ -2076,7 +2076,7 @@ def run_data_collection():
         reload_status['success'] = None
         reload_status['status'] = 'Collecting market data...'
 
-        # Run market_signals.py (default 30-day lookback)
+        # Run market_signals.py (default ~35-year lookback, 12775 days in market_signals.py)
         print("Running market_signals.py...")
         result1 = subprocess.run(
             ['python', 'market_signals.py'],
@@ -2100,6 +2100,23 @@ def run_data_collection():
 
         if result2.returncode != 0:
             raise Exception(f"divergence_analysis.py failed: {result2.stderr}")
+
+        # Update macro regime and recession probability BEFORE generating briefings
+        # so briefings use same-day cache values (not yesterday's stale data)
+        reload_status['status'] = 'Updating macro regime state...'
+        print("Updating macro regime state...")
+        try:
+            update_macro_regime()
+        except Exception as regime_error:
+            print(f"Macro regime update error (non-fatal): {regime_error}")
+
+        # Update recession probability panel data (US-146.1)
+        reload_status['status'] = 'Updating recession probability data...'
+        print("Updating recession probability data...")
+        try:
+            update_recession_probability()
+        except Exception as recession_error:
+            print(f"Recession probability update error (non-fatal): {recession_error}")
 
         eastern = pytz.timezone('US/Eastern')
         reload_status['last_reload'] = datetime.now(eastern).strftime('%Y-%m-%d %H:%M:%S')
@@ -2171,22 +2188,6 @@ def run_data_collection():
                 print(f"Market synthesis generation failed: {synthesis_result['error']}")
         except Exception as synthesis_error:
             print(f"Market synthesis error (non-fatal): {synthesis_error}")
-
-        # Update macro regime state (runs after market data is refreshed)
-        reload_status['status'] = 'Updating macro regime state...'
-        print("Updating macro regime state...")
-        try:
-            update_macro_regime()
-        except Exception as regime_error:
-            print(f"Macro regime update error (non-fatal): {regime_error}")
-
-        # Update recession probability panel data (US-146.1)
-        reload_status['status'] = 'Updating recession probability data...'
-        print("Updating recession probability data...")
-        try:
-            update_recession_probability()
-        except Exception as recession_error:
-            print(f"Recession probability update error (non-fatal): {recession_error}")
 
         # Update sector management tone data (US-123.1)
         # Note: this pipeline is intentionally skipped during the daily refresh

--- a/signaltrackers/market_signals.py
+++ b/signaltrackers/market_signals.py
@@ -316,12 +316,11 @@ class MarketSignalsTracker:
             filepath = self.data_dir / f"{signal_name}.csv"
             last_date = self.get_last_date_in_file(filepath)
 
-            # Always fetch based on lookback_days from today
-            start_date = (datetime.now(eastern) - timedelta(days=lookback_days)).strftime('%Y-%m-%d')
-
             if last_date:
-                print(f"Last date in file: {last_date.date()}, fetching {lookback_days} days from {start_date}")
+                start_date = (last_date + timedelta(days=1)).strftime('%Y-%m-%d')
+                print(f"Last date in file: {last_date.date()}, fetching from {start_date}")
             else:
+                start_date = (datetime.now(eastern) - timedelta(days=lookback_days)).strftime('%Y-%m-%d')
                 print(f"No existing data, fetching {lookback_days} days from {start_date}")
 
             df = self.fetch_fred_data(series_id, start_date=start_date)
@@ -345,12 +344,11 @@ class MarketSignalsTracker:
             filepath = self.data_dir / f"{signal_name}_price.csv"
             last_date = self.get_last_date_in_file(filepath)
 
-            # Always fetch based on lookback_days from today
-            start_date = (datetime.now(eastern) - timedelta(days=lookback_days)).strftime('%Y-%m-%d')
-
             if last_date:
-                print(f"Last date in file: {last_date.date()}, fetching {lookback_days} days from {start_date}")
+                start_date = (last_date + timedelta(days=1)).strftime('%Y-%m-%d')
+                print(f"Last date in file: {last_date.date()}, fetching from {start_date}")
             else:
+                start_date = (datetime.now(eastern) - timedelta(days=lookback_days)).strftime('%Y-%m-%d')
                 print(f"No existing data, fetching {lookback_days} days from {start_date}")
 
             df = self.fetch_etf_data(ticker, start_date=start_date)


### PR DESCRIPTION
Fixes #174
Fixes #175

## Summary
- **Bug #174:** `update_macro_regime()` and `update_recession_probability()` were called *after* all briefing generation, meaning every daily AI briefing used yesterday's stale regime/recession cache. Both cache updates now run immediately after CSV data collection, before any briefing generation.
- **Bug #175:** `collect_fred_signals()` and `collect_etf_signals()` always fetched 35 years of history (~12,775 days) on every daily refresh. They now call `get_last_date_in_file()` and fetch only from `last_date + 1 day` forward. First-run fallback (no CSV or empty file) still uses the full 35-year lookback.
- **Shared comment fix:** Corrected misleading `"default 30-day lookback"` comment in `dashboard.py` to reflect the actual ~35-year default.

## Changes
- `signaltrackers/dashboard.py`: move regime/recession update blocks ~70 lines earlier in `run_data_collection()`; fix comment
- `signaltrackers/market_signals.py`: incremental `start_date` logic in `collect_fred_signals()` and `collect_etf_signals()`

## Testing
- ✅ 1858 tests passing, 39 skipped (pre-existing)
- ✅ QA test plan verified (both issues)
- ✅ No logic changes to briefing generation or append_to_csv deduplication

## Preview
Preview image pushed to `ghcr.io/ericmaibach/financial:preview`