### PR TITLE
Fix #198: Add static regression guards for chatbot-close removal

### DIFF
--- a/tests/test_chatbot_widget.py
+++ b/tests/test_chatbot_widget.py
@@ -10,8 +10,12 @@ Requires the application to be running at http://localhost:5000.
 Run with: python3 -m pytest tests/test_chatbot_widget.py -v
 """
 
+import os
 import pytest
 import requests
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_BASE_HTML = os.path.join(_REPO_ROOT, 'signaltrackers', 'templates', 'base.html')
 
 BASE_URL = "http://localhost:5000"
 
@@ -197,3 +201,27 @@ class TestOldChatbotRemoved:
         """New chatbot CSS classes are present."""
         assert 'chatbot-fab' in page
         assert 'chatbot-panel' in page
+
+
+# ---------------------------------------------------------------------------
+# Static Regression Guards (no live app required — Bug #198)
+# ---------------------------------------------------------------------------
+
+class TestChatbotControlsStatic:
+    """Static guards that run without a live app.
+
+    These ensure the chatbot-close class removed in US-144.1 cannot be
+    silently reintroduced. Reads base.html directly.
+    """
+
+    def setup_method(self):
+        with open(_BASE_HTML, 'r') as f:
+            self.html = f.read()
+
+    def test_no_chatbot_close_class_in_base_html(self):
+        """chatbot-close must not appear in base.html (US-144.1)."""
+        assert 'class="chatbot-close"' not in self.html
+
+    def test_chatbot_minimize_present_in_base_html(self):
+        """chatbot-minimize is the single close control (US-144.1)."""
+        assert 'class="chatbot-minimize"' in self.html


### PR DESCRIPTION
Fixes #198

## Summary
- Investigation confirmed `class="chatbot-close"` is absent from all templates and CSS — the US-144.1 removal was already complete
- The existing `test_no_separate_close_button` in `test_chatbot_widget.py` silently **skips** when the live app is not running, providing no protection in offline CI runs
- Added `TestChatbotControlsStatic` with two static tests that read `base.html` directly (no live app required)

## Changes
- `tests/test_chatbot_widget.py`: added `TestChatbotControlsStatic` class with `test_no_chatbot_close_class_in_base_html` and `test_chatbot_minimize_present_in_base_html`

## Testing
- ✅ Both new static tests pass
- ✅ All 126 chatbot tests pass (39 skip — require live app, unchanged)
- ✅ Full suite: 1974 passed, 1 pre-existing failure (test_same_date_not_duplicated on main), 39 skipped
- ✅ Design review N/A (test-only change)
- ✅ QA verification complete (static verification confirms class absent)