### PR TITLE
US-206.1: Global Trade Pulse backend

### DIFF
--- a/signaltrackers/dashboard.py
+++ b/signaltrackers/dashboard.py
@@ -53,6 +53,7 @@ from recession_probability import get_recession_probability, update_recession_pr
 from regime_implications_config import REGIME_IMPLICATIONS, REGIME_STATE_TO_KEY
 from sector_tone_pipeline import get_sector_management_tone, update_sector_management_tone
 from credit_interpretation_config import get_credit_interpretation
+from trade_interpretation_config import get_trade_interpretation
 from regime_config import (
     REGIME_METADATA,
     SIGNAL_REGIME_ANNOTATIONS,
@@ -1581,10 +1582,104 @@ def logout():
 # Page Routes
 # =============================================================================
 
+def _get_trade_balance_context():
+    """Build the template context dict for the Global Trade Pulse panel (US-206.1).
+
+    Loads trade_balance.csv, computes current value, reading period, YoY change,
+    10-year rolling percentile, and trade condition, then looks up the regime-
+    conditioned interpretation copy.
+
+    Returns a dict with all trade_* keys; values default to None on any error.
+    """
+    ctx = {
+        'trade_balance_value': None,
+        'trade_balance_period': None,
+        'trade_yoy_change': None,
+        'trade_yoy_direction': None,
+        'trade_percentile': None,
+        'trade_condition': None,
+        'trade_interpretation_label': None,
+        'trade_interpretation_body': None,
+        'trade_last_updated': None,
+    }
+    try:
+        df = load_csv_data('trade_balance.csv')
+        if df is None or len(df) < 2:
+            return ctx
+
+        df = df.dropna(subset=['trade_balance'])
+        if len(df) < 2:
+            return ctx
+
+        df = df.sort_values('date').reset_index(drop=True)
+        df['date'] = pd.to_datetime(df['date'])
+
+        current_row = df.iloc[-1]
+        current_value = float(current_row['trade_balance'])
+        current_date = current_row['date']
+
+        ctx['trade_balance_value'] = round(current_value, 1)
+        ctx['trade_balance_period'] = current_date.strftime('%b %Y')
+        ctx['trade_last_updated'] = current_date.strftime('%b %Y')
+
+        # YoY: find the row with the same month in the prior year
+        prior_year = current_date.year - 1
+        prior_month = current_date.month
+        prior_rows = df[(df['date'].dt.year == prior_year) & (df['date'].dt.month == prior_month)]
+        if not prior_rows.empty:
+            prior_value = float(prior_rows.iloc[-1]['trade_balance'])
+            yoy_change = round(current_value - prior_value, 1)
+            ctx['trade_yoy_change'] = yoy_change
+            ctx['trade_yoy_direction'] = 'up' if yoy_change >= 0 else 'down'
+        else:
+            yoy_change = None
+
+        # 10-year rolling percentile
+        series = df.set_index('date')['trade_balance']
+        cutoff = pd.Timestamp.today() - pd.DateOffset(years=10)
+        try:
+            windowed = series[series.index >= cutoff]
+            if len(windowed) < 2:
+                windowed = series
+        except TypeError:
+            windowed = series
+
+        count_below = int((windowed < current_value).sum())
+        percentile = round(float(count_below / len(windowed) * 100), 1)
+        ctx['trade_percentile'] = percentile
+
+        # Trade condition
+        if yoy_change is not None:
+            if current_value < 0:
+                condition = 'widening_deficit' if yoy_change < 0 else 'narrowing_deficit'
+            else:
+                condition = 'widening_surplus' if yoy_change > 0 else 'narrowing_surplus'
+            ctx['trade_condition'] = condition
+        else:
+            condition = None
+
+        # Regime-conditioned interpretation
+        try:
+            regime = get_macro_regime()
+            regime_state = regime.get('state') if regime else None
+        except Exception:
+            regime_state = None
+
+        label, body = get_trade_interpretation(regime_state, condition, percentile)
+        ctx['trade_interpretation_label'] = label
+        ctx['trade_interpretation_body'] = body
+
+    except Exception:
+        pass  # Graceful empty state — missing CSV returns None values
+
+    return ctx
+
+
 @app.route('/')
 def index():
     """Main dashboard page."""
-    return render_template('index.html')
+    ctx = _get_trade_balance_context()
+    return render_template('index.html', **ctx)
 
 
 @app.route('/equity')

--- a/signaltrackers/market_signals.py
+++ b/signaltrackers/market_signals.py
@@ -86,7 +86,9 @@ class MarketSignalsTracker:
             'breakeven_inflation_10y': 'T10YIE',  # 10-Year Breakeven Inflation Rate
             'treasury_10y': 'DGS10',  # 10-Year Treasury Constant Maturity Rate (nominal yield)
             # Federal Reserve Policy Rate
-            'fed_funds_rate': 'FEDFUNDS'  # Effective Federal Funds Rate (Monthly)
+            'fed_funds_rate': 'FEDFUNDS',  # Effective Federal Funds Rate (Monthly)
+            # Trade Balance (US-206.1)
+            'trade_balance': 'BOPGSTB',  # US Goods Trade Balance, monthly SA (billions USD)
         }
 
         # ETF tickers organized by category

--- a/signaltrackers/trade_interpretation_config.py
+++ b/signaltrackers/trade_interpretation_config.py
@@ -1,0 +1,195 @@
+"""
+Trade Balance Interpretation Configuration (US-206.1)
+
+Regime-conditioned interpretation texts for the Global Trade Pulse homepage panel.
+Keyed by (regime_state, trade_condition) tuples.
+
+Regime states match regime_detection.py output:
+  'Bull', 'Neutral', 'Bear', 'Recession Watch'
+
+Trade conditions:
+  'widening_deficit'   — current value negative, YoY change negative (deficit growing)
+  'narrowing_deficit'  — current value negative, YoY change positive (deficit shrinking)
+  'widening_surplus'   — current value positive, YoY change positive (surplus growing)
+  'narrowing_surplus'  — current value positive, YoY change negative (surplus shrinking)
+
+Fallback key ('unknown', condition) used when regime data is unavailable.
+Each entry is a dict with 'label' (uppercase header) and 'body' (1-2 sentence copy).
+"""
+
+TRADE_INTERPRETATIONS = {
+    # ─── Bull (Expansion) Regime ──────────────────────────────────────────────
+    ("Bull", "widening_deficit"): {
+        "label": "EXPANSION REGIME \u00b7 WIDENING DEFICIT",
+        "body": (
+            "Trade volumes are growing but the goods deficit is widening — a typical pattern "
+            "in expansion as US import demand rises faster than exports. Watch for USD softness "
+            "if the deficit widens materially."
+        ),
+    },
+    ("Bull", "narrowing_deficit"): {
+        "label": "EXPANSION REGIME \u00b7 NARROWING DEFICIT",
+        "body": (
+            "Trade conditions are improving alongside the expansion — a narrowing goods deficit "
+            "reduces external drag and supports the USD. This is a constructive signal for the "
+            "macro backdrop."
+        ),
+    },
+    ("Bull", "widening_surplus"): {
+        "label": "EXPANSION REGIME \u00b7 WIDENING SURPLUS",
+        "body": (
+            "The goods trade balance is improving materially in an expansion — export demand is "
+            "strong. This is a positive signal for trade-sensitive sectors and USD stability."
+        ),
+    },
+    ("Bull", "narrowing_surplus"): {
+        "label": "EXPANSION REGIME \u00b7 NARROWING SURPLUS",
+        "body": (
+            "Export surplus is narrowing in an expansion phase — import demand is picking up, "
+            "which is consistent with strong domestic consumption. Monitor for future current "
+            "account pressure."
+        ),
+    },
+
+    # ─── Bear (Contraction) Regime ────────────────────────────────────────────
+    ("Bear", "widening_deficit"): {
+        "label": "CONTRACTION REGIME \u00b7 WIDENING DEFICIT",
+        "body": (
+            "Trade volumes are contracting and the goods deficit is widening — a pressure pattern "
+            "that adds headwinds for the USD and may weigh on export-sensitive sectors in an "
+            "already-weak macro environment."
+        ),
+    },
+    ("Bear", "narrowing_deficit"): {
+        "label": "CONTRACTION REGIME \u00b7 NARROWING DEFICIT",
+        "body": (
+            "The goods deficit is narrowing in a contraction — typically because import demand is "
+            "falling faster than export weakness. This may provide modest USD support but reflects "
+            "weak domestic demand, not trade strength."
+        ),
+    },
+    ("Bear", "widening_surplus"): {
+        "label": "CONTRACTION REGIME \u00b7 IMPROVING BALANCE",
+        "body": (
+            "Trade balance is improving in a contraction — falling imports are reducing the "
+            "deficit. This provides some buffer for the USD but the signal reflects demand "
+            "weakness, not export-driven strength."
+        ),
+    },
+    ("Bear", "narrowing_surplus"): {
+        "label": "CONTRACTION REGIME \u00b7 MIXED SIGNAL",
+        "body": (
+            "Export surplus is narrowing as the contraction weighs on global trade. External "
+            "demand is softening — watch for further deterioration in export-heavy sectors."
+        ),
+    },
+
+    # ─── Neutral Regime ──────────────────────────────────────────────────────
+    ("Neutral", "widening_deficit"): {
+        "label": "NEUTRAL REGIME \u00b7 WIDENING DEFICIT",
+        "body": (
+            "The goods trade deficit is widening in a neutral macro environment — modest negative "
+            "signal for the USD and external balance. No immediate implication for domestic growth."
+        ),
+    },
+    ("Neutral", "narrowing_deficit"): {
+        "label": "NEUTRAL REGIME \u00b7 NARROWING DEFICIT",
+        "body": (
+            "Trade balance is improving slightly in a neutral regime — a positive but non-decisive "
+            "signal. External drag on growth is easing gradually."
+        ),
+    },
+    ("Neutral", "widening_surplus"): {
+        "label": "NEUTRAL REGIME \u00b7 WIDENING SURPLUS",
+        "body": (
+            "Trade balance is strengthening in a neutral regime — modest positive for USD and "
+            "reduced external drag. Not a regime-moving signal on its own."
+        ),
+    },
+    ("Neutral", "narrowing_surplus"): {
+        "label": "NEUTRAL REGIME \u00b7 STABLE TRADE",
+        "body": (
+            "Trade balance is relatively stable in a neutral macro environment. No significant "
+            "trade flow signal at this time."
+        ),
+    },
+
+    # ─── Recession Watch Regime ───────────────────────────────────────────────
+    ("Recession Watch", "widening_deficit"): {
+        "label": "RECESSION WATCH \u00b7 WIDENING DEFICIT",
+        "body": (
+            "Trade conditions are deteriorating alongside elevated recession risk. A widening "
+            "goods deficit in a recession-watch environment adds external pressure — this "
+            "combination has historically preceded USD stress and tightening financial conditions."
+        ),
+    },
+    ("Recession Watch", "narrowing_deficit"): {
+        "label": "RECESSION WATCH \u00b7 NARROWING DEFICIT",
+        "body": (
+            "The goods deficit is narrowing in a recession-watch environment — likely reflecting "
+            "falling import demand as businesses and consumers pull back. This is a defensive, "
+            "not constructive, signal."
+        ),
+    },
+    ("Recession Watch", "widening_surplus"): {
+        "label": "RECESSION WATCH \u00b7 IMPROVING BALANCE",
+        "body": (
+            "Trade balance is improving as import demand contracts in a recession-watch "
+            "environment. The improvement is driven by weakness, not export strength — "
+            "treat cautiously."
+        ),
+    },
+    ("Recession Watch", "narrowing_surplus"): {
+        "label": "RECESSION WATCH \u00b7 WEAKENING TRADE",
+        "body": (
+            "Export surplus is narrowing as global demand softens — a leading indicator of "
+            "further trade deterioration consistent with elevated recession risk."
+        ),
+    },
+}
+
+# Fallback entries for all conditions when regime data is unavailable
+for _condition in ("widening_deficit", "narrowing_deficit", "widening_surplus", "narrowing_surplus"):
+    TRADE_INTERPRETATIONS[("unknown", _condition)] = {
+        "label": "TRADE BALANCE",
+        "body": None,  # Filled by get_trade_interpretation using percentile fallback
+    }
+
+
+def get_trade_interpretation(regime_state, trade_condition, trade_percentile=None):
+    """Return the interpretation label and body for the given regime and trade condition.
+
+    Args:
+        regime_state: str or None — e.g. 'Bull', 'Bear', 'Neutral', 'Recession Watch'
+        trade_condition: str or None — one of the four trade condition constants
+        trade_percentile: float or None — used for fallback copy when regime unavailable
+
+    Returns:
+        tuple: (label, body) where either may be None
+    """
+    if trade_condition is None:
+        return None, None
+
+    if regime_state and regime_state not in ('Unknown', 'unknown', ''):
+        key = (regime_state, trade_condition)
+    else:
+        key = ('unknown', trade_condition)
+
+    entry = TRADE_INTERPRETATIONS.get(key)
+    if entry is None:
+        return None, None
+
+    label = entry['label']
+    body = entry['body']
+
+    # Fallback body when regime is unknown — use percentile-based generic text
+    if body is None and trade_percentile is not None:
+        pct_int = int(round(trade_percentile))
+        body = (
+            f"US goods trade balance is at the {pct_int}th percentile of the past 10 years. "
+            "A reading below the 33rd percentile indicates below-average trade flow conditions."
+        )
+    elif body is None:
+        return None, None
+
+    return label, body

--- a/tests/test_us2061_trade_balance_backend.py
+++ b/tests/test_us2061_trade_balance_backend.py
@@ -1,0 +1,447 @@
+"""
+Tests for US-206.1: Global Trade Pulse — Backend.
+
+Covers:
+- trade_interpretation_config.py: all 16 regime×condition entries + fallback
+- get_trade_interpretation(): correct label/body selection, fallback copy
+- Trade condition determination logic (via dashboard helpers)
+- YoY calculation
+- 10-year rolling percentile computation
+- dashboard.py imports and index route context
+- market_signals.py BOPGSTB registration
+
+No Flask server, database, or external APIs required.
+"""
+
+import os
+import sys
+import unittest
+import pandas as pd
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SIGNALTRACKERS_DIR = os.path.join(REPO_ROOT, 'signaltrackers')
+sys.path.insert(0, SIGNALTRACKERS_DIR)
+
+
+def read_file(path):
+    with open(path, 'r') as f:
+        return f.read()
+
+
+def get_dashboard_src():
+    return read_file(os.path.join(SIGNALTRACKERS_DIR, 'dashboard.py'))
+
+
+def get_market_signals_src():
+    return read_file(os.path.join(SIGNALTRACKERS_DIR, 'market_signals.py'))
+
+
+# ---------------------------------------------------------------------------
+# trade_interpretation_config.py — module-level tests
+# ---------------------------------------------------------------------------
+
+class TestTradeInterpretationConfigExists(unittest.TestCase):
+    def test_config_file_exists(self):
+        path = os.path.join(SIGNALTRACKERS_DIR, 'trade_interpretation_config.py')
+        self.assertTrue(os.path.isfile(path), "trade_interpretation_config.py not found")
+
+    def test_config_importable(self):
+        from trade_interpretation_config import TRADE_INTERPRETATIONS  # noqa: F401
+
+    def test_get_trade_interpretation_importable(self):
+        from trade_interpretation_config import get_trade_interpretation  # noqa: F401
+
+
+class TestTradeInterpretationsDict(unittest.TestCase):
+    def setUp(self):
+        from trade_interpretation_config import TRADE_INTERPRETATIONS
+        self.interps = TRADE_INTERPRETATIONS
+
+    def _assert_key(self, key):
+        self.assertIn(key, self.interps, f"Missing key: {key}")
+        entry = self.interps[key]
+        self.assertIsInstance(entry, dict)
+        self.assertIn('label', entry)
+        self.assertIn('body', entry)
+        self.assertIsInstance(entry['label'], str)
+        self.assertGreater(len(entry['label']), 5, f"Label too short for {key}")
+        # body may be None for unknown fallback entries
+        if entry['body'] is not None:
+            self.assertIsInstance(entry['body'], str)
+            self.assertGreater(len(entry['body']), 20, f"Body too short for {key}")
+
+    # Bull regime (4)
+    def test_bull_widening_deficit(self):
+        self._assert_key(("Bull", "widening_deficit"))
+
+    def test_bull_narrowing_deficit(self):
+        self._assert_key(("Bull", "narrowing_deficit"))
+
+    def test_bull_widening_surplus(self):
+        self._assert_key(("Bull", "widening_surplus"))
+
+    def test_bull_narrowing_surplus(self):
+        self._assert_key(("Bull", "narrowing_surplus"))
+
+    # Bear regime (4)
+    def test_bear_widening_deficit(self):
+        self._assert_key(("Bear", "widening_deficit"))
+
+    def test_bear_narrowing_deficit(self):
+        self._assert_key(("Bear", "narrowing_deficit"))
+
+    def test_bear_widening_surplus(self):
+        self._assert_key(("Bear", "widening_surplus"))
+
+    def test_bear_narrowing_surplus(self):
+        self._assert_key(("Bear", "narrowing_surplus"))
+
+    # Neutral regime (4)
+    def test_neutral_widening_deficit(self):
+        self._assert_key(("Neutral", "widening_deficit"))
+
+    def test_neutral_narrowing_deficit(self):
+        self._assert_key(("Neutral", "narrowing_deficit"))
+
+    def test_neutral_widening_surplus(self):
+        self._assert_key(("Neutral", "widening_surplus"))
+
+    def test_neutral_narrowing_surplus(self):
+        self._assert_key(("Neutral", "narrowing_surplus"))
+
+    # Recession Watch regime (4)
+    def test_recession_watch_widening_deficit(self):
+        self._assert_key(("Recession Watch", "widening_deficit"))
+
+    def test_recession_watch_narrowing_deficit(self):
+        self._assert_key(("Recession Watch", "narrowing_deficit"))
+
+    def test_recession_watch_widening_surplus(self):
+        self._assert_key(("Recession Watch", "widening_surplus"))
+
+    def test_recession_watch_narrowing_surplus(self):
+        self._assert_key(("Recession Watch", "narrowing_surplus"))
+
+    # Unknown fallback (4)
+    def test_unknown_widening_deficit_exists(self):
+        self.assertIn(("unknown", "widening_deficit"), self.interps)
+
+    def test_unknown_narrowing_deficit_exists(self):
+        self.assertIn(("unknown", "narrowing_deficit"), self.interps)
+
+    def test_unknown_widening_surplus_exists(self):
+        self.assertIn(("unknown", "widening_surplus"), self.interps)
+
+    def test_unknown_narrowing_surplus_exists(self):
+        self.assertIn(("unknown", "narrowing_surplus"), self.interps)
+
+    def test_total_entry_count(self):
+        # 4 regimes × 4 conditions + 4 unknown fallbacks = 20
+        self.assertGreaterEqual(len(self.interps), 20)
+
+
+class TestGetTradeInterpretation(unittest.TestCase):
+    def setUp(self):
+        from trade_interpretation_config import get_trade_interpretation
+        self.fn = get_trade_interpretation
+
+    def test_returns_tuple(self):
+        result = self.fn("Bull", "widening_deficit")
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+
+    def test_bull_widening_deficit_returns_label_and_body(self):
+        label, body = self.fn("Bull", "widening_deficit")
+        self.assertIsNotNone(label)
+        self.assertIsNotNone(body)
+        self.assertIn("EXPANSION", label)
+        self.assertIn("WIDENING DEFICIT", label)
+
+    def test_bear_narrowing_deficit_label_contains_contraction(self):
+        label, body = self.fn("Bear", "narrowing_deficit")
+        self.assertIsNotNone(label)
+        self.assertIn("CONTRACTION", label)
+
+    def test_neutral_narrowing_surplus_label_contains_stable(self):
+        label, body = self.fn("Neutral", "narrowing_surplus")
+        self.assertIsNotNone(label)
+        self.assertIn("STABLE", label)
+
+    def test_recession_watch_narrowing_surplus_label_contains_weakening(self):
+        label, body = self.fn("Recession Watch", "narrowing_surplus")
+        self.assertIsNotNone(label)
+        self.assertIn("WEAKENING", label)
+
+    def test_none_condition_returns_none_none(self):
+        label, body = self.fn("Bull", None)
+        self.assertIsNone(label)
+        self.assertIsNone(body)
+
+    def test_none_regime_uses_unknown_fallback(self):
+        label, body = self.fn(None, "widening_deficit", trade_percentile=33)
+        self.assertIsNotNone(label)
+        self.assertIsNotNone(body)
+        self.assertIn("33", body)  # percentile in fallback body
+
+    def test_unknown_regime_uses_fallback(self):
+        label, body = self.fn("Unknown", "narrowing_deficit", trade_percentile=50)
+        self.assertIsNotNone(label)
+        self.assertIsNotNone(body)
+
+    def test_all_16_regime_condition_combos_return_non_none(self):
+        regimes = ["Bull", "Bear", "Neutral", "Recession Watch"]
+        conditions = ["widening_deficit", "narrowing_deficit", "widening_surplus", "narrowing_surplus"]
+        for regime in regimes:
+            for condition in conditions:
+                label, body = self.fn(regime, condition)
+                self.assertIsNotNone(label, f"label is None for ({regime}, {condition})")
+                self.assertIsNotNone(body, f"body is None for ({regime}, {condition})")
+
+    def test_fallback_with_none_percentile_returns_none_body(self):
+        # unknown regime + None percentile → can't construct fallback body
+        label, body = self.fn(None, "widening_deficit", trade_percentile=None)
+        self.assertIsNone(body)
+
+
+# ---------------------------------------------------------------------------
+# Trade condition logic
+# ---------------------------------------------------------------------------
+
+class TestTradeConditionLogic(unittest.TestCase):
+    """Tests for the trade condition determination logic using inline implementation."""
+
+    def _determine_condition(self, current_value, yoy_change):
+        """Replicates the condition logic from dashboard.py _get_trade_balance_context."""
+        if yoy_change is None:
+            return None
+        if current_value < 0:
+            return 'widening_deficit' if yoy_change < 0 else 'narrowing_deficit'
+        else:
+            return 'widening_surplus' if yoy_change > 0 else 'narrowing_surplus'
+
+    def test_deficit_worsening_is_widening_deficit(self):
+        # -100 current, -10 YoY change (deficit grew by $10b)
+        self.assertEqual(self._determine_condition(-100.0, -10.0), 'widening_deficit')
+
+    def test_deficit_improving_is_narrowing_deficit(self):
+        # -100 current, +10 YoY change (deficit shrank by $10b)
+        self.assertEqual(self._determine_condition(-100.0, 10.0), 'narrowing_deficit')
+
+    def test_surplus_growing_is_widening_surplus(self):
+        # +5 current, +2 YoY change
+        self.assertEqual(self._determine_condition(5.0, 2.0), 'widening_surplus')
+
+    def test_surplus_shrinking_is_narrowing_surplus(self):
+        # +5 current, -2 YoY change
+        self.assertEqual(self._determine_condition(5.0, -2.0), 'narrowing_surplus')
+
+    def test_none_yoy_returns_none(self):
+        self.assertIsNone(self._determine_condition(-100.0, None))
+
+    def test_zero_current_with_positive_yoy_is_widening_surplus(self):
+        # 0 is not < 0, so treated as surplus
+        self.assertEqual(self._determine_condition(0.0, 1.0), 'widening_surplus')
+
+    def test_zero_yoy_on_deficit_is_narrowing_deficit(self):
+        # No change → not worsening
+        self.assertEqual(self._determine_condition(-50.0, 0.0), 'narrowing_deficit')
+
+
+# ---------------------------------------------------------------------------
+# YoY calculation logic
+# ---------------------------------------------------------------------------
+
+class TestYoYCalculation(unittest.TestCase):
+    def _build_df(self, rows):
+        """Build a minimal trade_balance DataFrame from (year, month, value) tuples."""
+        import pandas as pd
+        data = [
+            {'date': pd.Timestamp(year=y, month=m, day=1), 'trade_balance': v}
+            for y, m, v in rows
+        ]
+        df = pd.DataFrame(data).sort_values('date').reset_index(drop=True)
+        df['date'] = pd.to_datetime(df['date'])
+        return df
+
+    def _compute_yoy(self, df):
+        """Replicates the YoY logic from _get_trade_balance_context."""
+        current_row = df.iloc[-1]
+        current_value = float(current_row['trade_balance'])
+        current_date = current_row['date']
+        prior_year = current_date.year - 1
+        prior_month = current_date.month
+        prior_rows = df[
+            (df['date'].dt.year == prior_year) & (df['date'].dt.month == prior_month)
+        ]
+        if not prior_rows.empty:
+            prior_value = float(prior_rows.iloc[-1]['trade_balance'])
+            return round(current_value - prior_value, 1)
+        return None
+
+    def test_yoy_deficit_widening(self):
+        # Jan 2025: -90, Jan 2026: -100 → YoY = -10
+        df = self._build_df([(2025, 1, -90.0), (2025, 6, -95.0), (2026, 1, -100.0)])
+        self.assertAlmostEqual(self._compute_yoy(df), -10.0)
+
+    def test_yoy_deficit_narrowing(self):
+        # Jan 2025: -100, Jan 2026: -80 → YoY = +20
+        df = self._build_df([(2025, 1, -100.0), (2025, 6, -95.0), (2026, 1, -80.0)])
+        self.assertAlmostEqual(self._compute_yoy(df), 20.0)
+
+    def test_yoy_no_prior_year_row_returns_none(self):
+        # Only one month of data
+        df = self._build_df([(2026, 1, -100.0)])
+        self.assertIsNone(self._compute_yoy(df))
+
+    def test_yoy_same_value(self):
+        df = self._build_df([(2025, 3, -75.0), (2026, 3, -75.0)])
+        self.assertAlmostEqual(self._compute_yoy(df), 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Percentile computation
+# ---------------------------------------------------------------------------
+
+class TestTradePercentile(unittest.TestCase):
+    """Tests for the 10-year rolling percentile logic used in _get_trade_balance_context."""
+
+    def _compute_percentile(self, values_by_date, current_value):
+        """Replicates the 10-year window percentile logic."""
+        import pandas as pd
+        series = pd.Series(values_by_date)
+        series.index = pd.to_datetime(series.index)
+        cutoff = pd.Timestamp.today() - pd.DateOffset(years=10)
+        windowed = series[series.index >= cutoff]
+        if len(windowed) < 2:
+            windowed = series
+        count_below = int((windowed < current_value).sum())
+        return round(float(count_below / len(windowed) * 100), 1)
+
+    def test_value_at_minimum_returns_0(self):
+        import pandas as pd
+        # Generate 12 monthly values within last 10 years
+        dates = pd.date_range(start='2020-01-01', periods=12, freq='MS')
+        values = {str(d.date()): float(i + 1) for i, d in enumerate(dates)}
+        pct = self._compute_percentile(values, 1.0)
+        self.assertAlmostEqual(pct, 0.0)
+
+    def test_value_above_all_returns_100(self):
+        import pandas as pd
+        dates = pd.date_range(start='2020-01-01', periods=12, freq='MS')
+        values = {str(d.date()): float(i + 1) for i, d in enumerate(dates)}
+        pct = self._compute_percentile(values, 100.0)
+        self.assertAlmostEqual(pct, 100.0)
+
+    def test_value_at_median_returns_approx_50(self):
+        import pandas as pd
+        dates = pd.date_range(start='2020-01-01', periods=100, freq='MS')
+        values = {str(d.date()): float(i) for i, d in enumerate(dates)}
+        # Value 50 is at position 50 out of 100, so 50/100 = 50%
+        pct = self._compute_percentile(values, 50.0)
+        self.assertAlmostEqual(pct, 50.0, delta=2.0)
+
+    def test_old_data_outside_10y_excluded(self):
+        """Data older than 10 years should be excluded from the percentile window."""
+        import pandas as pd
+        # Mix: old high values + recent low values
+        old_dates = pd.date_range(start='2010-01-01', periods=60, freq='MS')
+        recent_dates = pd.date_range(start='2020-01-01', periods=12, freq='MS')
+        values = {}
+        for d in old_dates:
+            values[str(d.date())] = 1000.0  # very high old values
+        for d in recent_dates:
+            values[str(d.date())] = 1.0  # low recent values
+        # current_value=1.0, all recent values also 1.0, so 0 below current
+        pct = self._compute_percentile(values, 1.0)
+        # Should be 0% since all windowed values equal current (none strictly below)
+        self.assertAlmostEqual(pct, 0.0, delta=1.0)
+
+
+# ---------------------------------------------------------------------------
+# dashboard.py integration
+# ---------------------------------------------------------------------------
+
+class TestDashboardImports(unittest.TestCase):
+    def test_imports_get_trade_interpretation(self):
+        src = get_dashboard_src()
+        self.assertIn('get_trade_interpretation', src)
+
+    def test_imports_from_trade_interpretation_config(self):
+        src = get_dashboard_src()
+        self.assertIn('trade_interpretation_config', src)
+
+    def test_get_trade_balance_context_defined(self):
+        src = get_dashboard_src()
+        self.assertIn('_get_trade_balance_context', src)
+
+    def test_index_route_calls_get_trade_balance_context(self):
+        src = get_dashboard_src()
+        self.assertIn('_get_trade_balance_context()', src)
+
+    def test_index_route_passes_ctx_to_template(self):
+        src = get_dashboard_src()
+        # Should have **ctx unpacking to render_template
+        self.assertIn('render_template(\'index.html\', **ctx)', src)
+
+    def test_trade_balance_value_key_in_context_fn(self):
+        src = get_dashboard_src()
+        self.assertIn('trade_balance_value', src)
+
+    def test_trade_percentile_key_in_context_fn(self):
+        src = get_dashboard_src()
+        self.assertIn('trade_percentile', src)
+
+    def test_trade_interpretation_label_key(self):
+        src = get_dashboard_src()
+        self.assertIn('trade_interpretation_label', src)
+
+    def test_trade_interpretation_body_key(self):
+        src = get_dashboard_src()
+        self.assertIn('trade_interpretation_body', src)
+
+    def test_trade_last_updated_key(self):
+        src = get_dashboard_src()
+        self.assertIn('trade_last_updated', src)
+
+    def test_trade_yoy_change_key(self):
+        src = get_dashboard_src()
+        self.assertIn('trade_yoy_change', src)
+
+    def test_trade_condition_key(self):
+        src = get_dashboard_src()
+        self.assertIn('trade_condition', src)
+
+    def test_trade_balance_csv_loaded(self):
+        src = get_dashboard_src()
+        self.assertIn('trade_balance.csv', src)
+
+
+# ---------------------------------------------------------------------------
+# market_signals.py — BOPGSTB registration
+# ---------------------------------------------------------------------------
+
+class TestMarketSignalsBOPGSTB(unittest.TestCase):
+    def test_bopgstb_in_fred_series(self):
+        src = get_market_signals_src()
+        self.assertIn('BOPGSTB', src)
+
+    def test_trade_balance_key_present(self):
+        src = get_market_signals_src()
+        self.assertIn("'trade_balance'", src)
+
+    def test_bopgstb_mapped_to_trade_balance(self):
+        src = get_market_signals_src()
+        # Both key and value should appear near each other
+        idx_key = src.find("'trade_balance'")
+        idx_val = src.find("'BOPGSTB'")
+        self.assertGreater(idx_key, -1)
+        self.assertGreater(idx_val, -1)
+        # They should be within 100 chars of each other
+        self.assertLess(abs(idx_key - idx_val), 100)
+
+    def test_market_signals_tracker_importable(self):
+        from market_signals import MarketSignalsTracker  # noqa: F401
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #212

## Summary
- Fetches US goods trade balance (BOPGSTB) from FRED and stores to `data/trade_balance.csv`
- Computes 10-year rolling percentile, YoY change (same-month prior year), and trade condition
- Provides regime-conditioned interpretation copy via `trade_interpretation_config.py` (16 entries)
- Passes all 9 `trade_*` context vars to the homepage template

## Changes
- **Engineer:** `trade_interpretation_config.py` — 16 regime×condition entries + fallbacks; `_get_trade_balance_context()` in `dashboard.py`; BOPGSTB added to `fred_series` in `market_signals.py`; 66 new unit tests
- **QA:** 66 tests verified; no regressions; all acceptance criteria met

## Testing
- ✅ All unit tests passing (2380 passed)
- ✅ QA verification complete
- ✅ No regressions

## Design Spec
Implements `docs/specs/feature-8.2-global-trade-pulse.md` (backend portion)