### PR TITLE
Fix Bug #224: EDGAR submissions API + EX-99.1 extraction

### DIFF
--- a/signaltrackers/sector_tone_pipeline.py
+++ b/signaltrackers/sector_tone_pipeline.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import time
 from datetime import datetime
 from pathlib import Path
@@ -204,83 +205,127 @@ def _fetch_edgar_ticker_map() -> dict[str, str]:
     return result
 
 
+def _extract_ex991_url(index_html: str, int_cik: int, accession_clean: str) -> Optional[str]:
+    """Extract the EX-99.1 exhibit URL from a filing index HTML page.
+
+    Searches table rows for an EX-99.1 entry and returns the full HTTPS URL
+    to the exhibit document. Returns None if no EX-99.1 row is found.
+    """
+    rows = re.findall(r'<tr[^>]*>(.*?)</tr>', index_html, re.DOTALL | re.IGNORECASE)
+    for row in rows:
+        if re.search(r'\bEX-99\.1\b', row, re.IGNORECASE):
+            hrefs = re.findall(
+                r'href="(/Archives/edgar/data/[^"]+\.htm[^"]*)"',
+                row,
+                re.IGNORECASE,
+            )
+            if hrefs:
+                return f"https://www.sec.gov{hrefs[0]}"
+    return None
+
+
 def _fetch_recent_8k_filing_texts(
     cik: str,
     quarter: str,
     year: int,
 ) -> list[str]:
-    """Fetch text from recent 8-K filings for a company in the given quarter.
+    """Fetch text from recent 8-K earnings filings for a company in the given quarter.
 
-    Uses EDGAR full-text search endpoint (no API key required). Returns a list
-    of text strings (up to _MAX_FILINGS_PER_COMPANY), each at most
-    _MAX_FINBERT_INPUT_CHARS characters. Returns [] on any error.
+    Uses the EDGAR submissions API (company-specific by design) to get the
+    8-K filing list for the company, fetches each filing's index HTML to
+    locate the EX-99.1 earnings press release, and returns the press release
+    text. Falls back to the primary document if no EX-99.1 is present.
+
+    Returns a list of text strings (up to _MAX_FILINGS_PER_COMPANY), each at
+    most _MAX_FINBERT_INPUT_CHARS characters. Returns [] on any error.
     """
     headers = {"User-Agent": "SignalTrackers financial-research@signaltrackers.app"}
     startdt, enddt = _quarter_date_range(quarter, year)
 
-    params = {
-        "q": "earnings",
-        "forms": "8-K",
-        "dateRange": "custom",
-        "startdt": startdt,
-        "enddt": enddt,
-        "entity": str(int(cik)),  # EDGAR search takes unpadded CIK
-    }
-
+    # Step 1: Fetch company-specific submissions JSON (zero-padded 10-digit CIK)
+    submissions_url = _EDGAR_SUBMISSIONS_URL.format(cik=cik)
     try:
-        resp = requests.get(
-            _EDGAR_SEARCH_URL,
-            params=params,
-            timeout=_EDGAR_TIMEOUT,
-            headers=headers,
-        )
+        resp = requests.get(submissions_url, timeout=_EDGAR_TIMEOUT, headers=headers)
         if resp.status_code == 429:
             logger.warning("EDGAR rate limited (429) for CIK %s — skipping", cik)
             return []
         resp.raise_for_status()
-        data = resp.json()
+        submissions = resp.json()
     except Exception as exc:
-        logger.warning("EDGAR search failed for CIK %s: %s", cik, exc)
+        logger.warning("EDGAR submissions fetch failed for CIK %s: %s", cik, exc)
         return []
 
-    hits = data.get("hits", {}).get("hits", [])
+    time.sleep(_EDGAR_RATE_LIMIT_PAUSE)
+
+    # Step 2: Filter 8-K filings within the quarter date range
+    recent = submissions.get("filings", {}).get("recent", {})
+    accession_numbers = recent.get("accessionNumber", [])
+    forms = recent.get("form", [])
+    filing_dates = recent.get("filingDate", [])
+    primary_docs = recent.get("primaryDocument", [])
+
+    matching: list[tuple[str, str]] = []  # (accession_no, primary_doc)
+    for accession, form, filing_date, primary_doc in zip(
+        accession_numbers, forms, filing_dates, primary_docs
+    ):
+        if form != "8-K":
+            continue
+        if not (startdt <= filing_date <= enddt):
+            continue
+        matching.append((accession, primary_doc))
+        if len(matching) >= _MAX_FILINGS_PER_COMPANY:
+            break
+
+    if not matching:
+        return []
+
     texts: list[str] = []
+    int_cik = int(cik)
 
-    for hit in hits[:_MAX_FILINGS_PER_COMPANY]:
-        source = hit.get("_source", {})
-        # Use entity/filing description as text proxy; in production you would
-        # fetch the actual exhibit document (Ex-99.1 earnings press release).
-        display_names = source.get("display_names", "")
-        if isinstance(display_names, list):
-            display_names = " ".join(display_names)
-        file_desc = source.get("file_desc", "")
-        period = source.get("period_of_report", "")
-        # Build a text excerpt from available metadata + description
-        text_parts = [p for p in [display_names, file_desc, period] if p]
-        text = " | ".join(text_parts)
+    for accession, primary_doc in matching:
+        accession_clean = accession.replace("-", "")
+        index_url = (
+            f"{_EDGAR_ARCHIVES_BASE}/{int_cik}/{accession_clean}/{accession}-index.htm"
+        )
 
-        # Attempt to fetch the actual filing document text
-        filing_url = source.get("file_date", "")
-        accession = source.get("accession_no", "")
-        if accession:
-            # Fetch Ex-99.1 from the EDGAR filing index
-            accession_clean = accession.replace("-", "")
-            index_url = (
-                f"{_EDGAR_ARCHIVES_BASE}/{int(cik)}/{accession_clean}/"
-                f"{accession}-index.htm"
+        # Step 3: Fetch filing index HTML
+        try:
+            idx_resp = requests.get(index_url, timeout=_EDGAR_TIMEOUT, headers=headers)
+            idx_resp.raise_for_status()
+            index_html = idx_resp.text
+        except Exception as exc:
+            logger.warning("EDGAR index fetch failed for %s: %s", index_url, exc)
+            time.sleep(_EDGAR_RATE_LIMIT_PAUSE)
+            continue
+
+        time.sleep(_EDGAR_RATE_LIMIT_PAUSE)
+
+        # Step 4: Locate EX-99.1 and fetch earnings press release text
+        ex99_url = _extract_ex991_url(index_html, int_cik, accession_clean)
+        text = ""
+        if ex99_url:
+            try:
+                doc_resp = requests.get(ex99_url, timeout=_EDGAR_TIMEOUT, headers=headers)
+                doc_resp.raise_for_status()
+                text = doc_resp.text[:_MAX_FINBERT_INPUT_CHARS]
+            except Exception as exc:
+                logger.warning("EDGAR EX-99.1 fetch failed for %s: %s", ex99_url, exc)
+
+        # Step 5: Fall back to primary document if no EX-99.1 text
+        if not text.strip() and primary_doc:
+            primary_url = (
+                f"{_EDGAR_ARCHIVES_BASE}/{int_cik}/{accession_clean}/{primary_doc}"
             )
             try:
-                idx_resp = requests.get(
-                    index_url, timeout=_EDGAR_TIMEOUT, headers=headers
-                )
-                if idx_resp.ok:
-                    # Use the index page text as filing content
-                    text = idx_resp.text[:_MAX_FINBERT_INPUT_CHARS]
-            except Exception:
-                pass  # Fall back to metadata text
+                doc_resp = requests.get(primary_url, timeout=_EDGAR_TIMEOUT, headers=headers)
+                doc_resp.raise_for_status()
+                text = doc_resp.text[:_MAX_FINBERT_INPUT_CHARS]
+            except Exception as exc:
+                logger.warning("EDGAR primary doc fetch failed for %s: %s", primary_url, exc)
 
         if text and text.strip():
-            texts.append(text[:_MAX_FINBERT_INPUT_CHARS])
+            texts.append(text)
+
         time.sleep(_EDGAR_RATE_LIMIT_PAUSE)
 
     return texts

--- a/tests/test_bug224_edgar_submissions_fix.py
+++ b/tests/test_bug224_edgar_submissions_fix.py
@@ -1,0 +1,704 @@
+"""
+Static and mocked-HTTP tests for Bug #224:
+EDGAR fetch is broken — EFTS search entity filter ignored, primary doc is XBRL.
+
+Fix: replace _fetch_recent_8k_filing_texts() with the EDGAR submissions API
+(data.sec.gov/submissions/CIK{cik}.json) + EX-99.1 index-HTML extraction.
+
+All tests run without live network calls or FinBERT installed.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SIGNALTRACKERS_DIR = os.path.join(REPO_ROOT, 'signaltrackers')
+sys.path.insert(0, SIGNALTRACKERS_DIR)
+
+
+def read_source(filename):
+    path = os.path.join(SIGNALTRACKERS_DIR, filename)
+    with open(path, 'r') as f:
+        return f.read()
+
+
+def _make_submissions_json(accession_numbers, forms, filing_dates, primary_docs):
+    """Helper: build a minimal EDGAR submissions API response."""
+    return {
+        "filings": {
+            "recent": {
+                "accessionNumber": accession_numbers,
+                "form": forms,
+                "filingDate": filing_dates,
+                "primaryDocument": primary_docs,
+            }
+        }
+    }
+
+
+def _make_mock_response(status_code=200, json_data=None, text=""):
+    """Helper: build a mock requests.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.ok = (status_code == 200)
+    if json_data is not None:
+        resp.json.return_value = json_data
+    resp.text = text
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = Exception(f"HTTP {status_code}")
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Source Code Inspection Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSourceNoLongerUsesEftsEntityFilter(unittest.TestCase):
+    """_fetch_recent_8k_filing_texts must not use EFTS entity filter."""
+
+    def setUp(self):
+        self.src = read_source('sector_tone_pipeline.py')
+
+    def test_fetch_function_does_not_use_entity_param(self):
+        """The entity= param that didn't work must be removed from the fetch function."""
+        import ast
+        # Parse and find the function body
+        tree = ast.parse(self.src)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == '_fetch_recent_8k_filing_texts':
+                func_src = ast.get_source_segment(self.src, node) or ''
+                self.assertNotIn('"entity"', func_src,
+                                 '_fetch_recent_8k_filing_texts must not use entity param')
+                self.assertNotIn("'entity'", func_src,
+                                 '_fetch_recent_8k_filing_texts must not use entity param')
+                return
+        # If we reach here, function not found in AST (should not happen)
+        self.assertIn('_fetch_recent_8k_filing_texts', self.src)
+
+    def test_fetch_function_does_not_call_efts_search_url(self):
+        """Function must not call _EDGAR_SEARCH_URL with entity filter."""
+        import ast
+        tree = ast.parse(self.src)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == '_fetch_recent_8k_filing_texts':
+                func_src = ast.get_source_segment(self.src, node) or ''
+                self.assertNotIn('_EDGAR_SEARCH_URL', func_src,
+                                 '_fetch_recent_8k_filing_texts must not use _EDGAR_SEARCH_URL')
+                return
+
+    def test_submissions_url_pattern_in_source(self):
+        """Source must contain the submissions API URL with zero-padded CIK."""
+        self.assertIn('data.sec.gov/submissions/CIK', self.src)
+
+    def test_submissions_url_constant_defined(self):
+        """_EDGAR_SUBMISSIONS_URL constant must be defined."""
+        import sector_tone_pipeline as stp
+        self.assertTrue(hasattr(stp, '_EDGAR_SUBMISSIONS_URL'))
+        self.assertIn('data.sec.gov/submissions', stp._EDGAR_SUBMISSIONS_URL)
+
+    def test_ex991_extraction_logic_in_source(self):
+        """Source must contain EX-99.1 extraction logic."""
+        self.assertIn('EX-99', self.src)
+
+    def test_ex991_helper_function_exists(self):
+        """_extract_ex991_url helper must be defined."""
+        from sector_tone_pipeline import _extract_ex991_url
+        self.assertTrue(callable(_extract_ex991_url))
+
+    def test_max_filings_constant_still_used(self):
+        """_MAX_FILINGS_PER_COMPANY must still bound the filings processed."""
+        import ast
+        tree = ast.parse(self.src)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == '_fetch_recent_8k_filing_texts':
+                func_src = ast.get_source_segment(self.src, node) or ''
+                self.assertIn('_MAX_FILINGS_PER_COMPANY', func_src,
+                              '_MAX_FILINGS_PER_COMPANY must bound filings in fetch function')
+                return
+
+    def test_edgar_search_url_constant_preserved(self):
+        """_EDGAR_SEARCH_URL constant kept for backwards compat with existing tests."""
+        import sector_tone_pipeline as stp
+        self.assertTrue(hasattr(stp, '_EDGAR_SEARCH_URL'))
+
+
+# ---------------------------------------------------------------------------
+# _extract_ex991_url helper
+# ---------------------------------------------------------------------------
+
+
+class TestExtractEx991Url(unittest.TestCase):
+    """_extract_ex991_url must find EX-99.1 href in filing index HTML."""
+
+    def setUp(self):
+        from sector_tone_pipeline import _extract_ex991_url
+        self.fn = _extract_ex991_url
+
+    def _make_index_html(self, exhibit_path):
+        """Build a minimal filing index HTML with an EX-99.1 row."""
+        return f"""
+<html><body><table>
+<tr><td>Exhibit 99.1</td><td>EX-99.1</td>
+<td><a href="{exhibit_path}">exhibit</a></td></tr>
+</table></body></html>
+"""
+
+    def test_returns_none_for_empty_html(self):
+        result = self.fn("", 320193, "000032019324000001")
+        self.assertIsNone(result)
+
+    def test_returns_none_when_no_ex991_row(self):
+        html = "<html><table><tr><td>EX-10.1</td><td><a href='/some/path.htm'>doc</a></td></tr></table></html>"
+        result = self.fn(html, 320193, "000032019324000001")
+        self.assertIsNone(result)
+
+    def test_returns_url_when_ex991_present(self):
+        html = self._make_index_html("/Archives/edgar/data/320193/000032019324000001/ex991.htm")
+        result = self.fn(html, 320193, "000032019324000001")
+        self.assertIsNotNone(result)
+        self.assertIn("https://www.sec.gov", result)
+        self.assertIn("ex991.htm", result)
+
+    def test_returned_url_is_https(self):
+        html = self._make_index_html("/Archives/edgar/data/320193/000032019324000001/ex991.htm")
+        result = self.fn(html, 320193, "000032019324000001")
+        self.assertTrue(result.startswith("https://"))
+
+    def test_case_insensitive_ex991_match(self):
+        html = '<table><tr><td>ex-99.1</td><td><a href="/Archives/edgar/data/320193/000032019324000001/ex99.htm">doc</a></td></tr></table>'
+        result = self.fn(html, 320193, "000032019324000001")
+        self.assertIsNotNone(result)
+
+    def test_returns_none_when_ex991_row_has_no_href(self):
+        html = "<table><tr><td>EX-99.1</td><td>no link here</td></tr></table>"
+        result = self.fn(html, 320193, "000032019324000001")
+        self.assertIsNone(result)
+
+    def test_first_ex991_href_is_returned(self):
+        html = """<table>
+        <tr><td>EX-99.1</td>
+        <td><a href="/Archives/edgar/data/1/1/first.htm">first</a></td>
+        <td><a href="/Archives/edgar/data/1/1/second.htm">second</a></td>
+        </tr></table>"""
+        result = self.fn(html, 1, "1")
+        self.assertIn("first.htm", result)
+
+
+# ---------------------------------------------------------------------------
+# Functional Tests — _fetch_recent_8k_filing_texts (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+
+SAMPLE_INDEX_HTML = """
+<html><body>
+<table>
+<tr><td>8-K</td><td>EX-99.1</td>
+<td><a href="/Archives/edgar/data/320193/000032019324000001/ex99-1.htm">Earnings PR</a></td>
+</tr>
+</table>
+</body></html>
+"""
+
+SAMPLE_EARNINGS_TEXT = (
+    "Apple Inc. today announced financial results for its fiscal 2024 first quarter. "
+    "Revenue of $119.6 billion and earnings per diluted share of $2.18. "
+    "CEO Tim Cook commented that strong iPhone sales drove record performance."
+)
+
+XBRL_BOILERPLATE = (
+    "true true true NASDAQ 0000320193 aapl:Zero500NotesDue2031Member "
+    "aapl:A250NotesDue2030Member dei:EntityCommonStockSharesOutstanding"
+)
+
+SAMPLE_CIK = "0000320193"
+SAMPLE_QUARTER = "Q1"
+SAMPLE_YEAR = 2024
+SAMPLE_ACCESSION = "0000320193-24-000001"
+SAMPLE_PRIMARY_DOC = "aapl-20240101.htm"
+
+
+def _make_submissions_response(
+    accession=SAMPLE_ACCESSION,
+    form="8-K",
+    filing_date="2024-01-31",
+    primary_doc=SAMPLE_PRIMARY_DOC,
+):
+    return _make_submissions_json(
+        accession_numbers=[accession],
+        forms=[form],
+        filing_dates=[filing_date],
+        primary_docs=[primary_doc],
+    )
+
+
+class TestFetchRecentFilingsHappyPath(unittest.TestCase):
+    """Happy path: submissions API → index HTML → EX-99.1 → earnings text."""
+
+    def setUp(self):
+        from sector_tone_pipeline import _fetch_recent_8k_filing_texts
+        self.fetch_fn = _fetch_recent_8k_filing_texts
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_first_request_goes_to_submissions_url(self, mock_get, mock_sleep):
+        submissions_resp = _make_mock_response(json_data=_make_submissions_response())
+        index_resp = _make_mock_response(text=SAMPLE_INDEX_HTML)
+        doc_resp = _make_mock_response(text=SAMPLE_EARNINGS_TEXT)
+        mock_get.side_effect = [submissions_resp, index_resp, doc_resp]
+
+        self.fetch_fn(SAMPLE_CIK, SAMPLE_QUARTER, SAMPLE_YEAR)
+
+        first_url = mock_get.call_args_list[0][0][0]
+        self.assertIn('data.sec.gov/submissions/CIK', first_url)
+        self.assertIn(SAMPLE_CIK, first_url)
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_zero_padded_cik_in_submissions_url(self, mock_get, mock_sleep):
+        submissions_resp = _make_mock_response(json_data=_make_submissions_response())
+        index_resp = _make_mock_response(text=SAMPLE_INDEX_HTML)
+        doc_resp = _make_mock_response(text=SAMPLE_EARNINGS_TEXT)
+        mock_get.side_effect = [submissions_resp, index_resp, doc_resp]
+
+        self.fetch_fn(SAMPLE_CIK, SAMPLE_QUARTER, SAMPLE_YEAR)
+
+        first_url = mock_get.call_args_list[0][0][0]
+        # CIK must be zero-padded to 10 digits
+        self.assertIn('CIK0000320193', first_url)
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_index_html_fetched_for_each_matching_8k(self, mock_get, mock_sleep):
+        submissions_resp = _make_mock_response(json_data=_make_submissions_response())
+        index_resp = _make_mock_response(text=SAMPLE_INDEX_HTML)
+        doc_resp = _make_mock_response(text=SAMPLE_EARNINGS_TEXT)
+        mock_get.side_effect = [submissions_resp, index_resp, doc_resp]
+
+        self.fetch_fn(SAMPLE_CIK, SAMPLE_QUARTER, SAMPLE_YEAR)
+
+        # Second call should be to the index HTML
+        second_url = mock_get.call_args_list[1][0][0]
+        self.assertIn('Archives/edgar/data', second_url)
+        self.assertIn('index.htm', second_url)
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_ex991_document_fetched_when_found_in_index(self, mock_get, mock_sleep):
+        submissions_resp = _make_mock_response(json_data=_make_submissions_response())
+        index_resp = _make_mock_response(text=SAMPLE_INDEX_HTML)
+        doc_resp = _make_mock_response(text=SAMPLE_EARNINGS_TEXT)
+        mock_get.side_effect = [submissions_resp, index_resp, doc_resp]
+
+        self.fetch_fn(SAMPLE_CIK, SAMPLE_QUARTER, SAMPLE_YEAR)
+
+        # Third call should be to the EX-99.1 document
+        third_url = mock_get.call_args_list[2][0][0]
+        self.assertIn('ex99-1.htm', third_url)
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_returns_earnings_prose_not_xbrl(self, mock_get, mock_sleep):
+        submissions_resp = _make_mock_response(json_data=_make_submissions_response())
+        index_resp = _make_mock_response(text=SAMPLE_INDEX_HTML)
+        doc_resp = _make_mock_response(text=SAMPLE_EARNINGS_TEXT)
+        mock_get.side_effect = [submissions_resp, index_resp, doc_resp]
+
+        result = self.fetch_fn(SAMPLE_CIK, SAMPLE_QUARTER, SAMPLE_YEAR)
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("Apple", result[0])
+        self.assertNotIn("aapl:Zero500NotesDue", result[0])
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_result_length_bounded_by_max_filings(self, mock_get, mock_sleep):
+        import sector_tone_pipeline as stp
+        max_f = stp._MAX_FILINGS_PER_COMPANY
+        # Provide more filings than max
+        accessions = [f"0000320193-24-{i:06d}" for i in range(max_f + 3)]
+        submissions_data = _make_submissions_json(
+            accession_numbers=accessions,
+            forms=["8-K"] * len(accessions),
+            filing_dates=["2024-01-15"] * len(accessions),
+            primary_docs=[f"doc{i}.htm" for i in range(len(accessions))],
+        )
+        responses = [_make_mock_response(json_data=submissions_data)]
+        for _ in range(max_f):
+            responses.append(_make_mock_response(text=SAMPLE_INDEX_HTML))
+            responses.append(_make_mock_response(text=SAMPLE_EARNINGS_TEXT))
+        mock_get.side_effect = responses
+
+        result = self.fetch_fn(SAMPLE_CIK, SAMPLE_QUARTER, SAMPLE_YEAR)
+        self.assertLessEqual(len(result), max_f)
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_rate_limit_pause_applied(self, mock_get, mock_sleep):
+        """time.sleep must be called between EDGAR requests."""
+        submissions_resp = _make_mock_response(json_data=_make_submissions_response())
+        index_resp = _make_mock_response(text=SAMPLE_INDEX_HTML)
+        doc_resp = _make_mock_response(text=SAMPLE_EARNINGS_TEXT)
+        mock_get.side_effect = [submissions_resp, index_resp, doc_resp]
+
+        self.fetch_fn(SAMPLE_CIK, SAMPLE_QUARTER, SAMPLE_YEAR)
+
+        import sector_tone_pipeline as stp
+        mock_sleep.assert_called_with(stp._EDGAR_RATE_LIMIT_PAUSE)
+        self.assertGreater(mock_sleep.call_count, 0)
+
+
+# ---------------------------------------------------------------------------
+# Edge Cases
+# ---------------------------------------------------------------------------
+
+
+class TestFetchFilingsEdgeCases(unittest.TestCase):
+
+    def setUp(self):
+        from sector_tone_pipeline import _fetch_recent_8k_filing_texts
+        self.fetch_fn = _fetch_recent_8k_filing_texts
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_empty_submissions_recent_returns_empty_list(self, mock_get, mock_sleep):
+        """Submissions JSON with no filings → returns []."""
+        submissions_data = {"filings": {"recent": {}}}
+        mock_get.return_value = _make_mock_response(json_data=submissions_data)
+
+        result = self.fetch_fn(SAMPLE_CIK, SAMPLE_QUARTER, SAMPLE_YEAR)
+        self.assertEqual(result, [])
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_no_8k_filings_in_recent_returns_empty_list(self, mock_get, mock_sleep):
+        """Submissions with only non-8-K forms → returns []."""
+        submissions_data = _make_submissions_json(
+            accession_numbers=["0000320193-24-000001"],
+            forms=["10-Q"],
+            filing_dates=["2024-02-01"],
+            primary_docs=["10q.htm"],
+        )
+        mock_get.return_value = _make_mock_response(json_data=submissions_data)
+
+        result = self.fetch_fn(SAMPLE_CIK, SAMPLE_QUARTER, SAMPLE_YEAR)
+        self.assertEqual(result, [])
+        # Only one request (submissions); no index fetch needed
+        self.assertEqual(mock_get.call_count, 1)
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_filings_outside_quarter_are_excluded(self, mock_get, mock_sleep):
+        """8-K filings outside the quarter date range are skipped."""
+        submissions_data = _make_submissions_json(
+            accession_numbers=["0000320193-24-000001", "0000320193-24-000002"],
+            forms=["8-K", "8-K"],
+            filing_dates=["2024-07-15", "2024-08-01"],  # Q3 2024, not Q1
+            primary_docs=["doc1.htm", "doc2.htm"],
+        )
+        mock_get.return_value = _make_mock_response(json_data=submissions_data)
+
+        result = self.fetch_fn(SAMPLE_CIK, "Q1", 2024)
+        self.assertEqual(result, [])
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_no_ex991_falls_back_to_primary_doc(self, mock_get, mock_sleep):
+        """When index has no EX-99.1 row, falls back to primary document text."""
+        index_html_no_ex991 = "<html><table><tr><td>EX-10.1</td><td><a href='/Archives/edgar/data/320193/abc/doc.htm'>doc</a></td></tr></table></html>"
+        primary_text = "Pursuant to the requirements of the Securities Exchange Act..."
+
+        submissions_resp = _make_mock_response(json_data=_make_submissions_response())
+        index_resp = _make_mock_response(text=index_html_no_ex991)
+        primary_resp = _make_mock_response(text=primary_text)
+        mock_get.side_effect = [submissions_resp, index_resp, primary_resp]
+
+        result = self.fetch_fn(SAMPLE_CIK, SAMPLE_QUARTER, SAMPLE_YEAR)
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("Securities Exchange Act", result[0])
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_ex991_http_error_falls_back_to_primary_doc(self, mock_get, mock_sleep):
+        """When EX-99.1 fetch returns HTTP error, falls back to primary doc."""
+        submissions_resp = _make_mock_response(json_data=_make_submissions_response())
+        index_resp = _make_mock_response(text=SAMPLE_INDEX_HTML)
+        ex991_error = _make_mock_response(status_code=404)
+        primary_resp = _make_mock_response(text="Primary document content")
+        mock_get.side_effect = [submissions_resp, index_resp, ex991_error, primary_resp]
+
+        result = self.fetch_fn(SAMPLE_CIK, SAMPLE_QUARTER, SAMPLE_YEAR)
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("Primary document content", result[0])
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_submissions_429_returns_empty_list(self, mock_get, mock_sleep):
+        """Submissions API returns 429 → returns []."""
+        mock_get.return_value = _make_mock_response(status_code=429)
+        mock_get.return_value.raise_for_status.return_value = None  # 429 doesn't raise
+
+        result = self.fetch_fn(SAMPLE_CIK, SAMPLE_QUARTER, SAMPLE_YEAR)
+        self.assertEqual(result, [])
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_submissions_network_exception_returns_empty_list(self, mock_get, mock_sleep):
+        """Submissions API network error → returns []."""
+        mock_get.side_effect = ConnectionError("network error")
+
+        result = self.fetch_fn(SAMPLE_CIK, SAMPLE_QUARTER, SAMPLE_YEAR)
+        self.assertEqual(result, [])
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_index_fetch_failure_skips_filing(self, mock_get, mock_sleep):
+        """Index HTML fetch failure → filing skipped, no unhandled exception."""
+        submissions_resp = _make_mock_response(json_data=_make_submissions_response())
+        index_error = _make_mock_response(status_code=500)
+        mock_get.side_effect = [submissions_resp, index_error]
+
+        result = self.fetch_fn(SAMPLE_CIK, SAMPLE_QUARTER, SAMPLE_YEAR)
+        self.assertEqual(result, [])
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_cik_zero_padded_in_submissions_url(self, mock_get, mock_sleep):
+        """CIK with leading zeros is correctly zero-padded to 10 digits."""
+        short_cik = "0000001234"  # 10-digit padded CIK
+        submissions_data = _make_submissions_json([], [], [], [])
+        mock_get.return_value = _make_mock_response(json_data=submissions_data)
+
+        self.fetch_fn(short_cik, SAMPLE_QUARTER, SAMPLE_YEAR)
+
+        url = mock_get.call_args_list[0][0][0]
+        self.assertIn('CIK0000001234', url)
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_empty_primary_doc_does_not_crash(self, mock_get, mock_sleep):
+        """When primary_doc is empty string and EX-99.1 absent, returns []."""
+        index_html_no_ex991 = "<html><table></table></html>"
+        submissions_data = _make_submissions_json(
+            accession_numbers=[SAMPLE_ACCESSION],
+            forms=["8-K"],
+            filing_dates=["2024-01-15"],
+            primary_docs=[""],  # empty primary doc
+        )
+        submissions_resp = _make_mock_response(json_data=submissions_data)
+        index_resp = _make_mock_response(text=index_html_no_ex991)
+        mock_get.side_effect = [submissions_resp, index_resp]
+
+        result = self.fetch_fn(SAMPLE_CIK, SAMPLE_QUARTER, SAMPLE_YEAR)
+        self.assertEqual(result, [])
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_multiple_8k_filings_all_processed_up_to_max(self, mock_get, mock_sleep):
+        """Multiple matching 8-Ks all get index + doc fetches, up to MAX."""
+        import sector_tone_pipeline as stp
+        max_f = stp._MAX_FILINGS_PER_COMPANY
+
+        accessions = [f"0000320193-24-{i:06d}" for i in range(max_f)]
+        submissions_data = _make_submissions_json(
+            accession_numbers=accessions,
+            forms=["8-K"] * max_f,
+            filing_dates=["2024-01-15"] * max_f,
+            primary_docs=[f"doc{i}.htm" for i in range(max_f)],
+        )
+        responses = [_make_mock_response(json_data=submissions_data)]
+        for _ in range(max_f):
+            responses.append(_make_mock_response(text=SAMPLE_INDEX_HTML))
+            responses.append(_make_mock_response(text=SAMPLE_EARNINGS_TEXT))
+        mock_get.side_effect = responses
+
+        result = self.fetch_fn(SAMPLE_CIK, SAMPLE_QUARTER, SAMPLE_YEAR)
+        self.assertEqual(len(result), max_f)
+
+
+# ---------------------------------------------------------------------------
+# Security Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityNoSafeFilter(unittest.TestCase):
+    """EDGAR-sourced text must not be rendered with Jinja2 | safe filter."""
+
+    def test_sector_tone_template_no_safe_filter_on_sector_data(self):
+        """sector_tone.html must not render sector data with | safe."""
+        templates_dir = os.path.join(SIGNALTRACKERS_DIR, 'templates')
+        template_path = os.path.join(templates_dir, 'index.html')
+        if not os.path.exists(template_path):
+            self.skipTest("index.html not found")
+        with open(template_path) as f:
+            content = f.read()
+        # sector_management_tone data sourced from EDGAR must never use | safe
+        # We check that sector tone fields aren't piped through safe
+        import re
+        safe_uses = re.findall(r'\{\{[^}]*sector_management_tone[^}]*\|\s*safe[^}]*\}\}', content)
+        self.assertEqual(safe_uses, [],
+                         f"sector_management_tone data rendered with | safe: {safe_uses}")
+
+    def test_cik_is_not_from_user_input(self):
+        """CIK used in submissions URL must come from EDGAR ticker map, not user input."""
+        src = read_source('sector_tone_pipeline.py')
+        # The pipeline uses SP500_BY_SECTOR tickers → ticker_map CIK lookup
+        # Verify the fetch is called with CIK from ticker_map, not request args
+        self.assertIn('ticker_map', src)
+        self.assertNotIn('request.args', src)
+        self.assertNotIn('request.form', src)
+
+
+class TestSubmissionsUrlSecurity(unittest.TestCase):
+    """Submissions URL must be constructed from validated CIK only."""
+
+    def test_submissions_url_template_uses_cik_only(self):
+        """_EDGAR_SUBMISSIONS_URL format string uses only {cik} placeholder."""
+        import sector_tone_pipeline as stp
+        # Should only have one format placeholder: {cik}
+        url_template = stp._EDGAR_SUBMISSIONS_URL
+        self.assertIn('{cik}', url_template)
+        # Should not have any other placeholders
+        placeholders = [p for p in url_template.split('{') if '}' in p and p.split('}')[0] != 'cik']
+        self.assertEqual(placeholders, [])
+
+    def test_submissions_url_is_https(self):
+        """Submissions URL must use HTTPS."""
+        import sector_tone_pipeline as stp
+        self.assertTrue(stp._EDGAR_SUBMISSIONS_URL.startswith('https://'))
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_no_user_input_injected_into_submissions_url(self, mock_get, mock_sleep):
+        """CIK value is sanitized (zero-padded string from ticker map, not raw user input)."""
+        from sector_tone_pipeline import _fetch_recent_8k_filing_texts
+        # CIK is always a zero-padded 10-digit string from _fetch_edgar_ticker_map
+        submissions_data = _make_submissions_json([], [], [], [])
+        mock_get.return_value = _make_mock_response(json_data=submissions_data)
+
+        # Even with a numeric CIK string, the URL must be well-formed
+        _fetch_recent_8k_filing_texts("0000320193", "Q1", 2024)
+
+        url = mock_get.call_args_list[0][0][0]
+        # URL must be a proper EDGAR URL
+        self.assertTrue(url.startswith('https://data.sec.gov/submissions/CIK'))
+
+
+# ---------------------------------------------------------------------------
+# Performance / Correctness Contracts
+# ---------------------------------------------------------------------------
+
+
+class TestPerformanceContracts(unittest.TestCase):
+
+    def setUp(self):
+        from sector_tone_pipeline import _fetch_recent_8k_filing_texts
+        self.fetch_fn = _fetch_recent_8k_filing_texts
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_empty_text_not_appended_to_results(self, mock_get, mock_sleep):
+        """Filings with empty/whitespace text are not included in results."""
+        submissions_resp = _make_mock_response(json_data=_make_submissions_response())
+        index_resp = _make_mock_response(text=SAMPLE_INDEX_HTML)
+        doc_resp = _make_mock_response(text="   \n  ")  # whitespace only
+        mock_get.side_effect = [submissions_resp, index_resp, doc_resp,
+                                _make_mock_response(text="")]  # primary fallback also empty
+        result = self.fetch_fn(SAMPLE_CIK, SAMPLE_QUARTER, SAMPLE_YEAR)
+        self.assertEqual(result, [])
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_text_truncated_to_max_finbert_chars(self, mock_get, mock_sleep):
+        """Returned texts must not exceed _MAX_FINBERT_INPUT_CHARS."""
+        import sector_tone_pipeline as stp
+        long_text = "earnings " * 10000  # Very long earnings text
+        submissions_resp = _make_mock_response(json_data=_make_submissions_response())
+        index_resp = _make_mock_response(text=SAMPLE_INDEX_HTML)
+        doc_resp = _make_mock_response(text=long_text)
+        mock_get.side_effect = [submissions_resp, index_resp, doc_resp]
+
+        result = self.fetch_fn(SAMPLE_CIK, SAMPLE_QUARTER, SAMPLE_YEAR)
+
+        self.assertEqual(len(result), 1)
+        self.assertLessEqual(len(result[0]), stp._MAX_FINBERT_INPUT_CHARS)
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_returns_list_type(self, mock_get, mock_sleep):
+        """Return type must always be a list."""
+        mock_get.side_effect = ConnectionError("fail")
+        result = self.fetch_fn(SAMPLE_CIK, SAMPLE_QUARTER, SAMPLE_YEAR)
+        self.assertIsInstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# Acceptance Criteria Verification
+# ---------------------------------------------------------------------------
+
+
+class TestAcceptanceCriteria(unittest.TestCase):
+
+    def test_ac1_submissions_api_used(self):
+        """AC: submissions API URL present in fetch function body."""
+        import ast
+        src = read_source('sector_tone_pipeline.py')
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == '_fetch_recent_8k_filing_texts':
+                func_src = ast.get_source_segment(src, node) or ''
+                self.assertIn('_EDGAR_SUBMISSIONS_URL', func_src)
+                return
+        self.fail('_fetch_recent_8k_filing_texts not found in source')
+
+    def test_ac2_index_html_parsed_for_ex991(self):
+        """AC: filing index HTML is parsed to locate EX-99.1 exhibit."""
+        src = read_source('sector_tone_pipeline.py')
+        self.assertIn('_extract_ex991_url', src)
+
+    def test_ac3_fallback_to_primary_doc_if_no_ex991(self):
+        """AC: fallback to primary doc text if no EX-99.1 is found."""
+        src = read_source('sector_tone_pipeline.py')
+        # The fallback uses primary_doc variable
+        import ast
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == '_fetch_recent_8k_filing_texts':
+                func_src = ast.get_source_segment(src, node) or ''
+                self.assertIn('primary_doc', func_src)
+                return
+        self.fail('_fetch_recent_8k_filing_texts not found')
+
+    def test_ac4_rate_limit_pause_constant_exists(self):
+        """AC: _EDGAR_RATE_LIMIT_PAUSE constant exists and is used."""
+        import sector_tone_pipeline as stp
+        self.assertTrue(hasattr(stp, '_EDGAR_RATE_LIMIT_PAUSE'))
+        self.assertGreater(stp._EDGAR_RATE_LIMIT_PAUSE, 0)
+        src = read_source('sector_tone_pipeline.py')
+        self.assertIn('_EDGAR_RATE_LIMIT_PAUSE', src)
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_ac5_ex991_text_passed_to_finbert_not_xbrl(self, mock_get, mock_sleep):
+        """AC: EX-99.1 earnings prose text is returned (not XBRL boilerplate)."""
+        from sector_tone_pipeline import _fetch_recent_8k_filing_texts
+        submissions_resp = _make_mock_response(json_data=_make_submissions_response())
+        index_resp = _make_mock_response(text=SAMPLE_INDEX_HTML)
+        doc_resp = _make_mock_response(text=SAMPLE_EARNINGS_TEXT)
+        mock_get.side_effect = [submissions_resp, index_resp, doc_resp]
+
+        result = _fetch_recent_8k_filing_texts(SAMPLE_CIK, SAMPLE_QUARTER, SAMPLE_YEAR)
+
+        self.assertEqual(len(result), 1)
+        # Verify it contains earnings prose, not XBRL boilerplate
+        self.assertNotIn('aapl:Zero500NotesDue', result[0])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #224

## Summary
- Replaced broken EFTS entity-filtered search with `data.sec.gov/submissions/CIK{cik}.json` — the only EDGAR endpoint that returns company-specific filings
- Added `_extract_ex991_url()` helper: parses filing index HTML for the EX-99.1 earnings press release row
- Falls back gracefully to the primary document when no EX-99.1 is found
- `_EDGAR_SEARCH_URL` constant preserved for backwards compatibility with existing tests

## Root Cause Fixed
The EFTS `entity=` param was silently ignored — every company returned the same 6,797 results. Even when accession numbers were available, the primary 8-K document is XBRL boilerplate (`aapl:Zero500NotesDue2031Member`), not earnings prose. FinBERT scored all as neutral.

## Changes
- `signaltrackers/sector_tone_pipeline.py`: new `_extract_ex991_url()` helper + rewritten `_fetch_recent_8k_filing_texts()`
- `tests/test_bug224_edgar_submissions_fix.py`: 46 new tests (source inspection, mocked HTTP, edge cases, security, acceptance criteria)

## Testing
- ✅ 46 new tests passing
- ✅ All 134 existing `test_us1231_sector_tone_backend.py` tests passing
- ✅ No regression on existing sector tone test suite
- ✅ QA verification complete

## Design Spec
N/A — bug fix only