### PR TITLE
Bug #232: add openpyxl to requirements so Richmond Fed SOS parses xlsx

### DIFF
--- a/signaltrackers/requirements.txt
+++ b/signaltrackers/requirements.txt
@@ -1,6 +1,7 @@
 # Core
 pandas>=2.0.0
 xlrd>=2.0.0
+openpyxl>=3.0.0
 numpy>=1.24.0
 requests>=2.31.0
 yfinance>=0.2.0

--- a/tests/test_bug232_openpyxl_missing.py
+++ b/tests/test_bug232_openpyxl_missing.py
@@ -1,0 +1,254 @@
+"""
+Tests for Bug #232: Richmond Fed SOS Indicator missing — openpyxl not installed.
+
+openpyxl must be listed in signaltrackers/requirements.txt so that
+pandas.read_excel() can parse the Richmond Fed .xlsx file. Without it,
+_fetch_richmond_sos() silently returns (None, None) via a bare except clause,
+causing the SOS model block to be omitted from the Recession Probability panel.
+"""
+
+import io
+import os
+import sys
+import unittest
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SIGNALTRACKERS_DIR = os.path.join(REPO_ROOT, 'signaltrackers')
+sys.path.insert(0, SIGNALTRACKERS_DIR)
+
+
+def _read_requirements() -> str:
+    path = os.path.join(SIGNALTRACKERS_DIR, 'requirements.txt')
+    with open(path) as f:
+        return f.read()
+
+
+def _read_source(filename: str) -> str:
+    path = os.path.join(SIGNALTRACKERS_DIR, filename)
+    with open(path) as f:
+        return f.read()
+
+
+# ---------------------------------------------------------------------------
+# Requirements file tests
+# ---------------------------------------------------------------------------
+
+
+class TestOpenpyxlInRequirements(unittest.TestCase):
+    """openpyxl must be listed in requirements.txt with a lower-bound pin."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.reqs = _read_requirements()
+
+    def test_openpyxl_present(self):
+        """requirements.txt must contain an openpyxl entry."""
+        self.assertIn('openpyxl', self.reqs, "openpyxl not found in requirements.txt")
+
+    def test_openpyxl_has_version_pin(self):
+        """openpyxl entry must have a >= version constraint, not a wildcard."""
+        import re
+        match = re.search(r'openpyxl\s*>=\s*[\d.]+', self.reqs)
+        self.assertIsNotNone(
+            match,
+            "openpyxl must be pinned with >= in requirements.txt (e.g. openpyxl>=3.0.0)"
+        )
+
+    def test_openpyxl_minimum_version(self):
+        """openpyxl minimum version must be >= 3.0.0."""
+        import re
+        match = re.search(r'openpyxl\s*>=\s*([\d.]+)', self.reqs)
+        self.assertIsNotNone(match, "openpyxl version constraint not found")
+        from packaging.version import Version
+        min_ver = Version(match.group(1))
+        self.assertGreaterEqual(min_ver, Version('3.0.0'),
+                                "openpyxl must require >= 3.0.0 for xlsx support")
+
+    def test_xlrd_still_present(self):
+        """xlrd must remain in requirements.txt (used for legacy .xls support)."""
+        self.assertIn('xlrd', self.reqs)
+
+
+# ---------------------------------------------------------------------------
+# Static source tests
+# ---------------------------------------------------------------------------
+
+
+class TestRichmondSOSSourceStructure(unittest.TestCase):
+    """_fetch_richmond_sos() must use read_excel and handle failures gracefully."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = _read_source('recession_probability.py')
+
+    def test_read_excel_called(self):
+        """Source must call pd.read_excel to parse the .xlsx file."""
+        self.assertIn('read_excel', self.src)
+
+    def test_graceful_none_return_on_failure(self):
+        """Function must return (None, None) on failure, not raise."""
+        self.assertIn('return None, None', self.src)
+
+    def test_richmond_sos_key_in_cache(self):
+        """'richmond_sos' key must appear in the cache-building section."""
+        self.assertIn("'richmond_sos'", self.src)
+
+    def test_sos_risk_label_assigned(self):
+        """richmond_sos_risk must be assigned in the probability update."""
+        self.assertIn('richmond_sos_risk', self.src)
+
+
+# ---------------------------------------------------------------------------
+# Behavioural tests (mocked network)
+# ---------------------------------------------------------------------------
+
+
+def _make_xlsx_bytes(rows: list[tuple]) -> bytes:
+    """Build a minimal .xlsx file in memory using openpyxl."""
+    try:
+        import openpyxl
+    except ImportError:
+        return b''
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    # Header row
+    ws.append(['Date', 'SOS Indicator', 'Recession Threshold'])
+    for row in rows:
+        ws.append(list(row))
+    buf = io.BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+def _excel_serial(date: datetime) -> int:
+    """Convert a datetime to Excel serial integer (1900 epoch, 1-indexed)."""
+    return (date - datetime(1899, 12, 31)).days + 1
+
+
+class TestFetchRichmondSOSSuccess(unittest.TestCase):
+    """_fetch_richmond_sos() must parse a well-formed xlsx and return (value, date)."""
+
+    def setUp(self):
+        try:
+            import openpyxl  # noqa: F401
+        except ImportError:
+            self.skipTest("openpyxl not installed — install it via requirements.txt")
+
+    def test_returns_float_and_date_string(self):
+        """Happy path: valid xlsx → (float, 'YYYY-MM-DD')."""
+        from recession_probability import _fetch_richmond_sos
+
+        target_date = datetime(2026, 2, 7)
+        serial = _excel_serial(target_date)
+        xlsx_bytes = _make_xlsx_bytes([(serial, 0.35, 0.2)])
+
+        mock_resp = MagicMock()
+        mock_resp.content = xlsx_bytes
+        mock_resp.raise_for_status.return_value = None
+
+        with patch('recession_probability.requests.get', return_value=mock_resp):
+            prob, date_str = _fetch_richmond_sos()
+
+        self.assertIsNotNone(prob, "Expected float probability, got None")
+        self.assertAlmostEqual(prob, 0.35, places=5)
+        self.assertEqual(date_str, '2026-02-07')
+
+    def test_returns_latest_row(self):
+        """With multiple rows, the last row's value is returned."""
+        from recession_probability import _fetch_richmond_sos
+
+        d1 = _excel_serial(datetime(2026, 1, 31))
+        d2 = _excel_serial(datetime(2026, 2, 7))
+        xlsx_bytes = _make_xlsx_bytes([(d1, 0.10, 0.2), (d2, 0.45, 0.2)])
+
+        mock_resp = MagicMock()
+        mock_resp.content = xlsx_bytes
+        mock_resp.raise_for_status.return_value = None
+
+        with patch('recession_probability.requests.get', return_value=mock_resp):
+            prob, date_str = _fetch_richmond_sos()
+
+        self.assertAlmostEqual(prob, 0.45, places=5)
+        self.assertEqual(date_str, '2026-02-07')
+
+
+class TestFetchRichmondSOSNetworkFailure(unittest.TestCase):
+    """_fetch_richmond_sos() must return (None, None) on network errors."""
+
+    def test_network_error_returns_none_tuple(self):
+        """RequestException → (None, None), no crash."""
+        from recession_probability import _fetch_richmond_sos
+        import requests as req
+
+        with patch('recession_probability.requests.get',
+                   side_effect=req.exceptions.ConnectionError("timeout")):
+            result = _fetch_richmond_sos()
+
+        self.assertEqual(result, (None, None))
+
+    def test_http_error_returns_none_tuple(self):
+        """HTTP 404 → (None, None), no crash."""
+        from recession_probability import _fetch_richmond_sos
+        import requests as req
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = req.exceptions.HTTPError("404")
+
+        with patch('recession_probability.requests.get', return_value=mock_resp):
+            result = _fetch_richmond_sos()
+
+        self.assertEqual(result, (None, None))
+
+    def test_empty_dataframe_returns_none_tuple(self):
+        """Empty xlsx (header only) → (None, None), no crash."""
+        try:
+            import openpyxl  # noqa: F401
+        except ImportError:
+            self.skipTest("openpyxl not installed")
+
+        from recession_probability import _fetch_richmond_sos
+
+        xlsx_bytes = _make_xlsx_bytes([])  # header row only, no data
+        mock_resp = MagicMock()
+        mock_resp.content = xlsx_bytes
+        mock_resp.raise_for_status.return_value = None
+
+        with patch('recession_probability.requests.get', return_value=mock_resp):
+            result = _fetch_richmond_sos()
+
+        self.assertEqual(result, (None, None))
+
+
+class TestTemplateSOSConditional(unittest.TestCase):
+    """index.html must guard the SOS model block on recession_probability.richmond_sos."""
+
+    @classmethod
+    def setUpClass(cls):
+        template_path = os.path.join(SIGNALTRACKERS_DIR, 'templates', 'index.html')
+        with open(template_path) as f:
+            cls.src = f.read()
+
+    def test_richmond_sos_referenced_in_template(self):
+        """Template must reference recession_probability.richmond_sos (the SOS value)."""
+        self.assertIn('richmond_sos', self.src,
+                      "richmond_sos not found in index.html — SOS block may be missing")
+
+    def test_richmond_sos_conditional_present(self):
+        """Template must conditionally render the SOS block using an 'is defined' guard."""
+        self.assertIn('richmond_sos is defined', self.src,
+                      "SOS conditional guard 'richmond_sos is defined' not found in index.html")
+
+    def test_richmond_sos_date_rendered(self):
+        """Template must render richmond_sos_date when present."""
+        self.assertIn('richmond_sos_date', self.src)
+
+    def test_richmond_sos_risk_rendered(self):
+        """Template must render richmond_sos_risk label."""
+        self.assertIn('richmond_sos_risk', self.src)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #232

## Summary
Richmond Fed SOS Indicator (third recession model) was silently failing because `openpyxl` was missing from `requirements.txt`. The Richmond Fed publishes SOS data as `.xlsx`, which `pandas.read_excel()` requires `openpyxl` to parse. The bare `except Exception: pass` in `_fetch_richmond_sos()` was swallowing the `ImportError`, returning `(None, None)` and causing the model to be skipped in the template.

## Changes
- **Engineer:** Added `openpyxl>=3.0.0` to `signaltrackers/requirements.txt` (note: `xlrd` already listed only supports legacy `.xls`)
- **QA:** 14 new tests in `tests/test_bug232_openpyxl_missing.py` covering the dependency requirement, xlsx parsing path, and fallback behavior

## Testing
- ✅ All unit tests passing
- ✅ QA verification complete
- ✅ No design review required (backend-only fix)