### PR TITLE
US-218.2: Recession Probability Panel — Consolidate Explanation Elements

### DIFF
--- a/signaltrackers/static/css/components/recession-panel.css
+++ b/signaltrackers/static/css/components/recession-panel.css
@@ -215,27 +215,66 @@
 .recession-panel.regime-bear .recession-bar-marker     { background: var(--regime-bear-border); }
 .recession-panel.regime-recession .recession-bar-marker { background: var(--regime-recession-border); }
 
-/* --- Divergence Alert --- */
-.recession-divergence-alert {
-  background: #FEF3C7;           /* warning-100 */
-  border: 1px solid #FDE68A;     /* warning-200 */
-  border-radius: 6px;
-  padding: 12px 16px;
-  margin: 12px 0;
-  font-size: 0.875rem;           /* text-sm */
-  color: #B45309;                /* warning-700 */
-}
-
-.recession-divergence-alert .bi {
-  margin-right: 6px;
-}
-
 /* --- Plain-Language Footer --- */
 .recession-footer {
   font-size: 0.875rem;  /* text-sm */
   color: #4b5563;       /* neutral-600 */
   line-height: 1.6;
   margin: 12px 0 8px;
+}
+
+/* Diverging state: warning palette (replaces removed alert box) */
+.recession-footer--diverging {
+  border-left: 4px solid #D97706;  /* warning-600 */
+  background: #FEF3C7;             /* warning-100 */
+  padding: 10px 12px;
+  border-radius: 0 4px 4px 0;
+}
+
+/* --- WHY THREE MODELS Progressive Disclosure Toggle --- */
+.recession-why-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 44px;
+  padding: 8px 0;
+  margin-top: 8px;
+  background: none;
+  border: none;
+  border-top: 1px solid #e5e7eb;
+  cursor: pointer;
+  color: #4b5563;       /* neutral-600 */
+  font-size: 0.875rem;  /* text-sm */
+}
+
+.recession-why-toggle:focus {
+  outline: 2px solid #1E40AF;
+  outline-offset: 2px;
+}
+
+.recession-why-toggle-line {
+  flex: 1;
+  height: 1px;
+  background: #d1d5db;  /* neutral-300 */
+}
+
+.recession-why-toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+}
+
+.recession-why-chevron {
+  color: #6b7280;  /* neutral-500 */
+  transition: transform 0.2s ease;
+  flex-shrink: 0;
+}
+
+.recession-why-toggle[aria-expanded="true"] .recession-why-chevron {
+  transform: rotate(180deg);
 }
 
 /* --- Data Source Credit --- */

--- a/signaltrackers/templates/index.html
+++ b/signaltrackers/templates/index.html
@@ -358,34 +358,39 @@
 
             </div>{# /.recession-card-grid #}
 
-            {# ── Divergence alert (shown when spread ≥ 15pp) ─────────── #}
-            {% if recession_probability.divergence_pp >= 15 %}
-            <div class="recession-divergence-alert">
-                <i class="bi bi-exclamation-triangle-fill" aria-hidden="true"></i>
-                Models diverge by {{ recession_probability.divergence_pp }}pp — leading and coincident signals disagree. Spread itself signals elevated uncertainty.
-            </div>
-            {% endif %}
-
-            {# ── Plain-language footer ────────────────────────────────── #}
+            {# ── Plain-language footer (diverging state: warning styling) ── #}
             <hr class="regime-divider">
-            <div class="recession-footer">
+            <div class="recession-footer{% if recession_probability.divergence_pp >= 15 %} recession-footer--diverging{% endif %}">
                 {{ recession_probability.interpretation }}
             </div>
             <div class="recession-source">
                 Data: FRED API · Richmond Fed · Updated {{ recession_probability.updated }}
             </div>
 
-            <hr class="regime-divider">
-            <div class="bg-light border-start border-2 border-secondary rounded-2 p-3 mt-2">
-              <p class="text-xs text-uppercase fw-semibold text-secondary mb-1">
-                <i class="bi bi-info-circle me-1" aria-hidden="true"></i>Why three models?
-              </p>
-              <p class="small text-muted mb-0">
-                Single indicators fail in practice. The yield curve inverted in 2022 and held through
-                2024 — a textbook recession signal — while the expansion continued. Three
-                methodologically distinct models are more reliable than any one, and when they diverge,
-                the disagreement is itself the signal.
-              </p>
+            {# ── WHY THREE MODELS — progressive disclosure (collapsed by default) ── #}
+            <button class="recession-why-toggle"
+                    id="recession-why-toggle"
+                    aria-expanded="false"
+                    aria-controls="recession-why-content">
+                <span class="recession-why-toggle-line" aria-hidden="true"></span>
+                <span class="recession-why-toggle-label">
+                    <i class="bi bi-chevron-down recession-why-chevron" aria-hidden="true"></i>
+                    Why three models?
+                </span>
+                <span class="recession-why-toggle-line" aria-hidden="true"></span>
+            </button>
+            <div id="recession-why-content" class="recession-why-content" hidden>
+              <div class="bg-light border-start border-2 border-secondary rounded-2 p-3 mt-2">
+                <p class="text-xs text-uppercase fw-semibold text-secondary mb-1">
+                  <i class="bi bi-info-circle me-1" aria-hidden="true"></i>Why three models?
+                </p>
+                <p class="small text-muted mb-0">
+                  Single indicators fail in practice. The yield curve inverted in 2022 and held through
+                  2024 — a textbook recession signal — while the expansion continued. Three
+                  methodologically distinct models are more reliable than any one, and when they diverge,
+                  the disagreement is itself the signal.
+                </p>
+              </div>
             </div>
 
         </div>{# /.recession-panel__content #}
@@ -1827,6 +1832,21 @@ document.addEventListener('DOMContentLoaded', function() {
                 content.classList.add('recession-panel__content--expanded');
             } else {
                 content.classList.remove('recession-panel__content--expanded');
+            }
+        });
+    }
+
+    // WHY THREE MODELS progressive disclosure toggle (US-218.2)
+    const recessionWhyToggle = document.getElementById('recession-why-toggle');
+    if (recessionWhyToggle) {
+        recessionWhyToggle.addEventListener('click', function() {
+            const content = document.getElementById('recession-why-content');
+            const expanded = this.getAttribute('aria-expanded') === 'true';
+            this.setAttribute('aria-expanded', String(!expanded));
+            if (!expanded) {
+                content.removeAttribute('hidden');
+            } else {
+                content.setAttribute('hidden', '');
             }
         });
     }

--- a/tests/test_us2181_multi_model_trust_signal.py
+++ b/tests/test_us2181_multi_model_trust_signal.py
@@ -41,21 +41,23 @@ class TestMultiModelTrustSignalCallout(unittest.TestCase):
         self.assertGreater(callout_idx, source_idx,
                            "callout must appear after .recession-source")
 
-    def test_callout_separated_by_hr(self):
+    def test_callout_separated_by_toggle(self):
+        # US-218.2: callout now in progressive disclosure; toggle button separates source from content
         panel = self._recession_panel_content()
         source_idx = panel.find('recession-source')
         callout_idx = panel.find('Why three models?')
         between = panel[source_idx:callout_idx]
-        self.assertIn('regime-divider', between,
-                      "<hr class='regime-divider'> must appear between source and callout")
+        self.assertIn('recession-why-toggle', between,
+                      "recession-why-toggle must appear between source and callout")
 
     def test_callout_uses_info_circle_icon(self):
+        # US-218.2: info-circle is in the collapsible content (second occurrence of "Why three models?")
         panel = self._recession_panel_content()
-        callout_idx = panel.find('Why three models?')
-        # Look in the surrounding block (~500 chars)
-        block = panel[max(0, callout_idx - 200):callout_idx + 200]
-        self.assertIn('bi-info-circle', block)
-        self.assertIn('aria-hidden="true"', block)
+        content_idx = panel.find('id="recession-why-content"')
+        self.assertNotEqual(content_idx, -1, "recession-why-content not found")
+        content_block = panel[content_idx:content_idx + 600]
+        self.assertIn('bi-info-circle', content_block)
+        self.assertIn('aria-hidden="true"', content_block)
 
     def test_callout_uses_bootstrap_utilities_only(self):
         panel = self._recession_panel_content()
@@ -75,9 +77,10 @@ class TestMultiModelTrustSignalCallout(unittest.TestCase):
         self.assertIn(expected_fragment, self.html)
 
     def test_callout_body_ends_correctly(self):
+        # US-218.2: indentation updated to match progressive disclosure wrapper
         expected_fragment = (
             "and when they diverge,\n"
-            "                the disagreement is itself the signal."
+            "                  the disagreement is itself the signal."
         )
         self.assertIn(expected_fragment, self.html)
 
@@ -125,16 +128,20 @@ class TestMultiModelTrustSignalLabelText(unittest.TestCase):
         self.assertIn('Why three models?', self.html)
 
     def test_label_style_classes(self):
-        idx = self.html.find('Why three models?')
-        block = self.html[max(0, idx - 200):idx + 50]
+        # US-218.2: callout heading is inside collapsible content; find via recession-why-content
+        content_idx = self.html.find('id="recession-why-content"')
+        self.assertNotEqual(content_idx, -1, "recession-why-content not found")
+        block = self.html[content_idx:content_idx + 400]
         self.assertIn('text-xs', block)
         self.assertIn('text-uppercase', block)
         self.assertIn('fw-semibold', block)
         self.assertIn('text-secondary', block)
 
     def test_body_style_classes(self):
-        idx = self.html.find('Why three models?')
-        block = self.html[idx:idx + 500]
+        # US-218.2: callout body is inside collapsible content
+        content_idx = self.html.find('id="recession-why-content"')
+        self.assertNotEqual(content_idx, -1, "recession-why-content not found")
+        block = self.html[content_idx:content_idx + 600]
         self.assertIn('small text-muted mb-0', block)
 
 

--- a/tests/test_us2182_recession_panel_consolidation.py
+++ b/tests/test_us2182_recession_panel_consolidation.py
@@ -1,0 +1,302 @@
+"""
+Tests for US-218.2: Recession Probability Panel — Consolidate Explanation Elements
+
+Acceptance criteria:
+- recession-divergence-alert HTML block is removed
+- recession-footer receives recession-footer--diverging class when divergence_pp >= 15
+- --diverging state has correct CSS (4px left border #D97706, #FEF3C7 bg)
+- WHY THREE MODELS callout wrapped in progressive disclosure (collapsed by default)
+- Toggle follows established pattern with aria-expanded="false" by default
+- Dead code cleanup: no orphaned recession-divergence-alert references
+"""
+import os
+import re
+import unittest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SIGNALTRACKERS_DIR = os.path.join(REPO_ROOT, 'signaltrackers')
+INDEX_HTML = os.path.join(SIGNALTRACKERS_DIR, 'templates', 'index.html')
+RECESSION_CSS = os.path.join(SIGNALTRACKERS_DIR, 'static', 'css', 'components', 'recession-panel.css')
+
+
+def get_index_html():
+    with open(INDEX_HTML, 'r') as f:
+        return f.read()
+
+
+def get_recession_css():
+    with open(RECESSION_CSS, 'r') as f:
+        return f.read()
+
+
+def get_panel_section(html):
+    """Return the portion of index.html inside #recession-panel-content."""
+    start = html.find('id="recession-panel-content"')
+    assert start != -1, "#recession-panel-content not found"
+    end = html.find('</div>{# /.recession-panel #}', start)
+    assert end != -1, "recession-panel closing comment not found"
+    return html[start:end]
+
+
+class TestDivergenceAlertRemoved(unittest.TestCase):
+    """recession-divergence-alert must not appear anywhere."""
+
+    def test_alert_class_not_in_template(self):
+        html = get_index_html()
+        self.assertNotIn('recession-divergence-alert', html,
+                         "recession-divergence-alert still present in index.html")
+
+    def test_alert_class_not_in_css(self):
+        css = get_recession_css()
+        self.assertNotIn('recession-divergence-alert', css,
+                         "recession-divergence-alert CSS rule not removed from recession-panel.css")
+
+    def test_alert_icon_not_in_template(self):
+        """The exclamation-triangle icon was part of the removed alert block."""
+        html = get_index_html()
+        self.assertNotIn('bi-exclamation-triangle-fill', html,
+                         "Alert icon still present — alert block not fully removed")
+
+
+class TestRecessionFooterDivergingClass(unittest.TestCase):
+    """recession-footer--diverging class applied conditionally via Jinja2."""
+
+    def test_diverging_class_applied_when_divergence_gte_15(self):
+        html = get_index_html()
+        panel = get_panel_section(html)
+        # Jinja2 conditional: divergence_pp >= 15 -> adds class
+        self.assertIn('recession-footer--diverging', panel,
+                      "recession-footer--diverging modifier class not found in panel")
+
+    def test_diverging_class_inside_recession_footer_div(self):
+        html = get_index_html()
+        panel = get_panel_section(html)
+        # The div opening tag should have both classes conditionally
+        pattern = r'<div class="recession-footer[^"]*recession-footer--diverging[^"]*"'
+        # Check using Jinja2 syntax (conditional insertion)
+        jinja_pattern = r'recession-footer\{%.*?divergence_pp.*?%\}.*?recession-footer--diverging'
+        # Either static class or Jinja2 conditional is acceptable
+        has_static = bool(re.search(r'class="[^"]*recession-footer--diverging', panel))
+        has_jinja = ('recession-footer--diverging' in panel and 'divergence_pp' in panel)
+        self.assertTrue(has_static or has_jinja,
+                        "recession-footer--diverging not properly applied in template")
+
+    def test_divergence_condition_uses_gte_15(self):
+        html = get_index_html()
+        panel = get_panel_section(html)
+        # Should check >= 15 for the diverging class
+        self.assertIn('divergence_pp >= 15', panel,
+                      "Boundary condition divergence_pp >= 15 not found in panel")
+
+    def test_no_safe_filter_on_interpretation(self):
+        """interpretation must NOT use | safe filter (security guard)."""
+        html = get_index_html()
+        panel = get_panel_section(html)
+        interp_idx = panel.find('recession_probability.interpretation')
+        self.assertNotEqual(interp_idx, -1, "interpretation not found in panel")
+        # Check the 50 chars after interpretation for | safe
+        snippet = panel[interp_idx:interp_idx + 60]
+        self.assertNotIn('| safe', snippet,
+                         "| safe filter used on interpretation — XSS risk")
+
+
+class TestDivergingCSSRules(unittest.TestCase):
+    """CSS for recession-footer--diverging matches spec."""
+
+    def test_diverging_left_border_color(self):
+        css = get_recession_css()
+        # Should have D97706 (warning-600)
+        self.assertIn('#D97706', css,
+                      "warning-600 (#D97706) not found in recession-panel.css")
+
+    def test_diverging_background_color(self):
+        css = get_recession_css()
+        # Should have FEF3C7 (warning-100)
+        self.assertIn('#FEF3C7', css,
+                      "warning-100 (#FEF3C7) not found in recession-panel.css")
+
+    def test_diverging_border_left_width(self):
+        css = get_recession_css()
+        # Find the --diverging block
+        idx = css.find('recession-footer--diverging')
+        self.assertNotEqual(idx, -1, ".recession-footer--diverging not found in CSS")
+        block = css[idx:idx + 200]
+        self.assertIn('border-left', block,
+                      "border-left not in .recession-footer--diverging block")
+
+    def test_diverging_rule_exists(self):
+        css = get_recession_css()
+        self.assertIn('.recession-footer--diverging', css,
+                      ".recession-footer--diverging rule missing from recession-panel.css")
+
+
+class TestWhyThreeModelsProgressiveDisclosure(unittest.TestCase):
+    """WHY THREE MODELS callout is wrapped in progressive disclosure, collapsed by default."""
+
+    def test_toggle_button_present(self):
+        html = get_index_html()
+        panel = get_panel_section(html)
+        self.assertIn('recession-why-toggle', panel,
+                      "recession-why-toggle button not found in recession panel")
+
+    def test_toggle_is_button_element(self):
+        html = get_index_html()
+        panel = get_panel_section(html)
+        # Should be a <button> with the toggle class
+        self.assertIn('<button', panel, "<button> element not found in panel")
+        btn_idx = panel.find('recession-why-toggle')
+        # Walk back to find opening tag
+        tag_start = panel.rfind('<', 0, btn_idx)
+        tag_end = panel.find('>', btn_idx)
+        tag = panel[tag_start:tag_end + 1]
+        self.assertTrue(tag.startswith('<button'), f"recession-why-toggle is not a <button>: {tag[:60]}")
+
+    def test_toggle_aria_expanded_false_by_default(self):
+        html = get_index_html()
+        panel = get_panel_section(html)
+        idx = panel.find('recession-why-toggle')
+        # Get the button tag
+        tag_start = panel.rfind('<', 0, idx)
+        tag_end = panel.find('>', idx)
+        tag = panel[tag_start:tag_end + 50]  # include a bit more
+        # aria-expanded="false" should be in the button attributes
+        self.assertIn('aria-expanded="false"', tag,
+                      'aria-expanded="false" not set on toggle button by default')
+
+    def test_toggle_has_aria_controls(self):
+        html = get_index_html()
+        panel = get_panel_section(html)
+        idx = panel.find('recession-why-toggle')
+        tag_start = panel.rfind('<', 0, idx)
+        # Find the closing > of the button opening tag
+        tag_end = panel.find('>', tag_start + 100)
+        tag = panel[tag_start:tag_end + 1]
+        self.assertIn('aria-controls', tag,
+                      "aria-controls not set on toggle button")
+
+    def test_toggle_min_height_css(self):
+        css = get_recession_css()
+        idx = css.find('.recession-why-toggle')
+        self.assertNotEqual(idx, -1, ".recession-why-toggle not in CSS")
+        block_end = css.find('}', idx)
+        block = css[idx:block_end + 1]
+        self.assertIn('min-height', block,
+                      "min-height not set on .recession-why-toggle")
+        # Extract the value
+        mh_match = re.search(r'min-height:\s*(\d+)px', block)
+        self.assertIsNotNone(mh_match, "min-height px value not found")
+        self.assertGreaterEqual(int(mh_match.group(1)), 44,
+                                f"min-height is {mh_match.group(1)}px — must be ≥ 44px")
+
+    def test_callout_content_hidden_by_default(self):
+        html = get_index_html()
+        panel = get_panel_section(html)
+        # Content div should have hidden attribute
+        self.assertIn('id="recession-why-content"', panel,
+                      "recession-why-content not found in panel")
+        content_idx = panel.find('id="recession-why-content"')
+        tag_start = panel.rfind('<', 0, content_idx)
+        tag_end = panel.find('>', content_idx)
+        tag = panel[tag_start:tag_end + 1]
+        self.assertIn('hidden', tag,
+                      "recession-why-content not hidden by default (missing hidden attribute)")
+
+    def test_callout_content_after_toggle_button(self):
+        html = get_index_html()
+        panel = get_panel_section(html)
+        toggle_idx = panel.find('recession-why-toggle')
+        content_idx = panel.find('recession-why-content')
+        self.assertGreater(content_idx, toggle_idx,
+                           "recession-why-content appears before the toggle button")
+
+    def test_why_three_models_text_in_panel(self):
+        html = get_index_html()
+        panel = get_panel_section(html)
+        self.assertIn('Why three models?', panel,
+                      "Why three models? text not found in panel")
+
+    def test_toggle_chevron_present(self):
+        html = get_index_html()
+        panel = get_panel_section(html)
+        self.assertIn('recession-why-chevron', panel,
+                      "recession-why-chevron element not found in toggle button")
+
+    def test_toggle_lines_present(self):
+        html = get_index_html()
+        panel = get_panel_section(html)
+        self.assertIn('recession-why-toggle-line', panel,
+                      "recession-why-toggle-line decorative lines not found")
+
+    def test_toggle_css_exists(self):
+        css = get_recession_css()
+        self.assertIn('.recession-why-toggle', css,
+                      ".recession-why-toggle CSS not found in recession-panel.css")
+        self.assertIn('.recession-why-toggle-line', css,
+                      ".recession-why-toggle-line CSS not found in recession-panel.css")
+        self.assertIn('.recession-why-chevron', css,
+                      ".recession-why-chevron CSS not found in recession-panel.css")
+
+    def test_chevron_rotation_on_expanded_css(self):
+        css = get_recession_css()
+        self.assertIn('aria-expanded="true"]', css,
+                      "aria-expanded true state not handled in CSS (chevron rotation)")
+
+    def test_toggle_focus_style_in_css(self):
+        css = get_recession_css()
+        self.assertIn('.recession-why-toggle:focus', css,
+                      ".recession-why-toggle:focus not defined in CSS")
+
+
+class TestJavaScriptToggleHandler(unittest.TestCase):
+    """JS toggle handler wires up recession-why-toggle correctly."""
+
+    def test_js_toggle_handler_present(self):
+        html = get_index_html()
+        self.assertIn('recession-why-toggle', html,
+                      "recession-why-toggle JS handler not found")
+
+    def test_js_toggles_aria_expanded(self):
+        html = get_index_html()
+        # Should flip aria-expanded
+        idx = html.find('recession-why-toggle')
+        # Find the JS block that references this id
+        js_block_start = html.find("getElementById('recession-why-toggle')")
+        self.assertNotEqual(js_block_start, -1,
+                            "getElementById('recession-why-toggle') not found in JS")
+        js_block = html[js_block_start:js_block_start + 400]
+        self.assertIn('aria-expanded', js_block,
+                      "aria-expanded not toggled in JS handler")
+
+    def test_js_toggles_hidden_attribute(self):
+        html = get_index_html()
+        js_block_start = html.find("getElementById('recession-why-toggle')")
+        self.assertNotEqual(js_block_start, -1,
+                            "getElementById('recession-why-toggle') not found")
+        js_block = html[js_block_start:js_block_start + 600]
+        # Either removeAttribute('hidden') or setAttribute('hidden') pattern
+        self.assertTrue(
+            'hidden' in js_block,
+            "hidden attribute not toggled in JS handler — content must be shown/hidden via 'hidden'"
+        )
+
+
+class TestDeadCodeCleanup(unittest.TestCase):
+    """No orphaned references to recession-divergence-alert remain."""
+
+    def test_no_alert_in_template(self):
+        html = get_index_html()
+        self.assertNotIn('recession-divergence-alert', html)
+
+    def test_no_alert_in_css(self):
+        css = get_recession_css()
+        self.assertNotIn('recession-divergence-alert', css)
+
+    def test_plain_footer_css_rule_still_exists(self):
+        """Base .recession-footer rule must remain for non-diverging state."""
+        css = get_recession_css()
+        self.assertIn('.recession-footer', css,
+                      ".recession-footer base rule removed — needed for plain state")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_us462_recession_panel_frontend.py
+++ b/tests/test_us462_recession_panel_frontend.py
@@ -119,7 +119,10 @@ class TestRecessionPanelCSSClasses(unittest.TestCase):
         self.assertIn('.recession-bar-marker', self.css)
 
     def test_recession_divergence_alert_declared(self):
-        self.assertIn('.recession-divergence-alert', self.css)
+        # US-218.2: alert box removed; replaced by .recession-footer--diverging
+        self.assertNotIn('.recession-divergence-alert', self.css,
+                         "recession-divergence-alert CSS should have been removed by US-218.2")
+        self.assertIn('.recession-footer--diverging', self.css)
 
     def test_recession_footer_declared(self):
         self.assertIn('.recession-footer', self.css)
@@ -177,8 +180,11 @@ class TestDivergenceAlertCSS(unittest.TestCase):
         self.assertIn('#B45309', self.css)
 
     def test_divergence_alert_has_border(self):
-        # #FDE68A = warning-200 border
-        self.assertIn('#FDE68A', self.css)
+        # US-218.2: alert box removed; diverging footer now uses #D97706 (warning-600) left border
+        self.assertNotIn('#FDE68A', self.css,
+                         "#FDE68A was from the removed alert box — should be gone")
+        self.assertIn('#D97706', self.css,
+                      "#D97706 (warning-600) should be used as left border on .recession-footer--diverging")
 
 
 class TestMobileLayout(unittest.TestCase):
@@ -644,32 +650,31 @@ class TestDivergenceAlert(unittest.TestCase):
         self.html = get_index_html()
 
     def test_divergence_alert_class_present(self):
-        self.assertIn('class="recession-divergence-alert"', self.html)
+        # US-218.2: alert box removed; diverging state now on recession-footer via modifier class
+        self.assertNotIn('class="recession-divergence-alert"', self.html,
+                         "recession-divergence-alert HTML block should have been removed by US-218.2")
+        self.assertIn('recession-footer--diverging', self.html)
 
     def test_divergence_alert_conditional_on_15pp(self):
         self.assertIn('recession_probability.divergence_pp >= 15', self.html)
 
     def test_divergence_alert_icon_aria_hidden(self):
-        # Warning icon inside alert must be aria-hidden
-        idx = self.html.find('class="recession-divergence-alert"')
-        self.assertGreater(idx, -1)
-        alert_block = self.html[idx:idx + 500]
-        self.assertIn('aria-hidden="true"', alert_block)
+        # US-218.2: no alert icon; diverging state on footer has no icon — test removed
+        # The warning icon was removed along with the alert box; this is expected
+        self.assertNotIn('bi-exclamation-triangle-fill', self.html,
+                         "Alert icon should have been removed with the alert block")
 
     def test_divergence_alert_shows_divergence_pp_value(self):
         self.assertIn('recession_probability.divergence_pp', self.html)
 
     def test_no_empty_divergence_alert_when_below_threshold(self):
-        # The divergence alert is inside {% if %}…{% endif %}, not always rendered
-        idx = self.html.find('recession-divergence-alert')
-        self.assertGreater(idx, -1)
-        # Check that there's a Jinja2 if block controlling this element
-        before_alert = self.html[:idx]
-        # Find the last {% if %} before the alert — should contain divergence_pp >= 15
-        last_if = before_alert.rfind('{% if')
-        self.assertGreater(last_if, -1)
-        if_statement = self.html[last_if:last_if + 100]
-        self.assertIn('divergence_pp', if_statement)
+        # US-218.2: alert box removed; recession-footer--diverging conditional used instead
+        # Verify the modifier class is applied conditionally (inside Jinja2 if block)
+        idx = self.html.find('recession-footer--diverging')
+        self.assertGreater(idx, -1, "recession-footer--diverging not found")
+        before = self.html[max(0, idx - 300):idx]
+        self.assertIn('divergence_pp >= 15', before,
+                      "recession-footer--diverging must be inside a divergence_pp >= 15 conditional")
 
 
 class TestFooterElements(unittest.TestCase):
@@ -679,7 +684,8 @@ class TestFooterElements(unittest.TestCase):
         self.html = get_index_html()
 
     def test_recession_footer_class_present(self):
-        self.assertIn('class="recession-footer"', self.html)
+        # US-218.2: footer now has conditional modifier; use partial match
+        self.assertIn('recession-footer', self.html)
 
     def test_interpretation_text_rendered(self):
         self.assertIn('recession_probability.interpretation', self.html)
@@ -697,8 +703,9 @@ class TestFooterElements(unittest.TestCase):
         self.assertIn('recession_probability.updated', self.html)
 
     def test_footer_separated_by_regime_divider(self):
-        idx = self.html.find('class="recession-footer"')
-        self.assertGreater(idx, -1)
+        # US-218.2: footer div has conditional modifier class; use partial class search
+        idx = self.html.find('"recession-footer')
+        self.assertGreater(idx, -1, '"recession-footer not found in template')
         before_footer = self.html[:idx]
         # A regime-divider should appear just before the footer
         last_divider = before_footer.rfind('regime-divider')


### PR DESCRIPTION
Fixes #233

## Summary

Consolidates the three stacked explanation elements in the Recession Probability panel into a cleaner, non-repetitive layout.

## Changes

- **Engineer:** Removed `recession-divergence-alert` HTML block and all associated CSS rules from `recession-panel.css`
- **Engineer:** Added `recession-footer--diverging` modifier class (4px `#D97706` left border + `#FEF3C7` background tint) applied conditionally when `divergence_pp >= 15`
- **Engineer:** Wrapped WHY THREE MODELS callout in a progressive disclosure toggle (collapsed by default), following established `─── ⌄ [label] ───` pattern
- **Engineer:** Toggle button is 44px+ touch target with correct `aria-expanded` state management
- **QA:** 30 new tests in `test_us2182_recession_panel_consolidation.py`; updated stale tests in `test_us2181` and `test_us462`

## Testing

- ✅ All unit tests passing
- ✅ Design review approved
- ✅ QA verification complete

## Design Spec

Implements [docs/specs/us-218-recession-probability-panel-redesign.md](docs/specs/us-218-recession-probability-panel-redesign.md)