### PR TITLE
Bug #257: Wire credit briefing into daily synthesis and portfolio context

### DIFF
--- a/signaltrackers/ai_summary.py
+++ b/signaltrackers/ai_summary.py
@@ -540,6 +540,10 @@ def generate_daily_summary(market_data_summary, top_movers):
         if dollar_summary and dollar_summary.get("date") == today:
             briefings_found.append(f"### Dollar & Currency Briefing:\n{dollar_summary['summary']}")
 
+        credit_summary = get_latest_credit_summary()
+        if credit_summary and credit_summary.get("date") == today:
+            briefings_found.append(f"### Credit Markets Briefing:\n{credit_summary['summary']}")
+
         if briefings_found:
             specific_briefings_context = "\n\n## TODAY'S SPECIFIC MARKET BRIEFINGS (synthesize these into your narrative):\n" + "\n\n".join(briefings_found)
 

--- a/signaltrackers/dashboard.py
+++ b/signaltrackers/dashboard.py
@@ -3269,7 +3269,7 @@ def generate_portfolio_market_context():
     from ai_summary import (
         get_latest_summary, get_latest_crypto_summary,
         get_latest_equity_summary, get_latest_rates_summary,
-        get_latest_dollar_summary
+        get_latest_dollar_summary, get_latest_credit_summary
     )
 
     context_parts = []
@@ -3296,6 +3296,10 @@ def generate_portfolio_market_context():
     dollar = get_latest_dollar_summary()
     if dollar:
         briefings.append(f"**Dollar Briefing:**\n{dollar.get('summary', 'N/A')}")
+
+    credit = get_latest_credit_summary()
+    if credit:
+        briefings.append(f"**Credit Briefing:**\n{credit.get('summary', 'N/A')}")
 
     if briefings:
         context_parts.append("## Today's AI Briefings\n" + "\n\n".join(briefings))

--- a/tests/test_bug257_credit_briefing_wiring.py
+++ b/tests/test_bug257_credit_briefing_wiring.py
@@ -1,0 +1,245 @@
+"""
+Static verification tests for Bug #257: Credit briefing excluded from daily synthesis
+and portfolio context.
+
+These tests verify that get_latest_credit_summary() is wired into both
+generate_daily_summary() (ai_summary.py) and generate_portfolio_market_context()
+(dashboard.py), following the identical pattern used for crypto/equity/rates/dollar.
+"""
+
+import os
+import sys
+import unittest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SIGNALTRACKERS_DIR = os.path.join(REPO_ROOT, 'signaltrackers')
+sys.path.insert(0, SIGNALTRACKERS_DIR)
+
+
+def read_source(filename):
+    path = os.path.join(SIGNALTRACKERS_DIR, filename)
+    with open(path, 'r') as f:
+        return f.read()
+
+
+# ---------------------------------------------------------------------------
+# TestCreditStepInDailySummary — ai_summary.py generate_daily_summary()
+# ---------------------------------------------------------------------------
+
+
+class TestCreditStepInDailySummary(unittest.TestCase):
+    """get_latest_credit_summary() must be called inside generate_daily_summary()."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = read_source('ai_summary.py')
+
+    def _get_daily_summary_section(self):
+        """Extract the generate_daily_summary function body for scoped assertions."""
+        start = self.src.find('def generate_daily_summary(')
+        self.assertGreater(start, 0, 'generate_daily_summary() not found in ai_summary.py')
+        # Take a generous window — function is ~200 lines
+        return self.src[start:start + 6000]
+
+    def test_get_latest_credit_summary_called(self):
+        section = self._get_daily_summary_section()
+        self.assertIn('get_latest_credit_summary()', section,
+                      'get_latest_credit_summary() must be called inside generate_daily_summary()')
+
+    def test_credit_summary_date_guard(self):
+        section = self._get_daily_summary_section()
+        self.assertIn('credit_summary', section,
+                      'credit_summary variable must exist in generate_daily_summary()')
+        # Date guard: credit_summary.get("date") == today
+        self.assertIn('credit_summary.get("date")', section,
+                      'credit_summary date guard missing — must check date == today')
+
+    def test_credit_briefing_label_appended(self):
+        section = self._get_daily_summary_section()
+        self.assertIn('Credit Markets Briefing', section,
+                      '"Credit Markets Briefing" label must be appended to briefings_found')
+
+    def test_credit_block_after_dollar_block(self):
+        section = self._get_daily_summary_section()
+        dollar_pos = section.find('dollar_summary')
+        credit_pos = section.find('credit_summary')
+        self.assertGreater(dollar_pos, 0, 'dollar_summary block not found in generate_daily_summary()')
+        self.assertGreater(credit_pos, 0, 'credit_summary block not found in generate_daily_summary()')
+        self.assertGreater(credit_pos, dollar_pos,
+                           'Credit block must appear AFTER dollar block in generate_daily_summary()')
+
+    def test_existing_crypto_branch_intact(self):
+        section = self._get_daily_summary_section()
+        self.assertIn('get_latest_crypto_summary()', section)
+        self.assertIn('Crypto/Bitcoin Briefing', section)
+
+    def test_existing_equity_branch_intact(self):
+        section = self._get_daily_summary_section()
+        self.assertIn('get_latest_equity_summary()', section)
+        self.assertIn('Equity Markets Briefing', section)
+
+    def test_existing_rates_branch_intact(self):
+        section = self._get_daily_summary_section()
+        self.assertIn('get_latest_rates_summary()', section)
+        self.assertIn('Rates & Yield Curve Briefing', section)
+
+    def test_existing_dollar_branch_intact(self):
+        section = self._get_daily_summary_section()
+        self.assertIn('get_latest_dollar_summary()', section)
+        self.assertIn('Dollar & Currency Briefing', section)
+
+
+# ---------------------------------------------------------------------------
+# TestCreditStepInPortfolioContext — dashboard.py generate_portfolio_market_context()
+# ---------------------------------------------------------------------------
+
+
+class TestCreditStepInPortfolioContext(unittest.TestCase):
+    """get_latest_credit_summary() must be imported and called in generate_portfolio_market_context()."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = read_source('dashboard.py')
+
+    def _get_portfolio_context_section(self):
+        """Extract generate_portfolio_market_context function body for scoped assertions."""
+        start = self.src.find('def generate_portfolio_market_context(')
+        self.assertGreater(start, 0, 'generate_portfolio_market_context() not found in dashboard.py')
+        return self.src[start:start + 4000]
+
+    def test_get_latest_credit_summary_imported(self):
+        section = self._get_portfolio_context_section()
+        self.assertIn('get_latest_credit_summary', section,
+                      'get_latest_credit_summary must appear in the from ai_summary import block')
+
+    def test_get_latest_credit_summary_called(self):
+        section = self._get_portfolio_context_section()
+        self.assertIn('get_latest_credit_summary()', section,
+                      'get_latest_credit_summary() must be called inside generate_portfolio_market_context()')
+
+    def test_credit_if_guard_present(self):
+        section = self._get_portfolio_context_section()
+        # Find credit call and check surrounding code for if credit: guard
+        credit_pos = section.find('get_latest_credit_summary()')
+        self.assertGreater(credit_pos, 0)
+        ctx = section[credit_pos:credit_pos + 300]
+        self.assertIn('if credit', ctx,
+                      'if credit: guard must follow get_latest_credit_summary() call')
+
+    def test_credit_briefing_appended_to_briefings(self):
+        section = self._get_portfolio_context_section()
+        self.assertIn('Credit Briefing', section,
+                      '"Credit Briefing" entry must be appended to briefings list')
+
+    def test_credit_block_after_dollar_block(self):
+        section = self._get_portfolio_context_section()
+        dollar_pos = section.find('get_latest_dollar_summary()')
+        credit_pos = section.find('get_latest_credit_summary()')
+        self.assertGreater(dollar_pos, 0, 'get_latest_dollar_summary() call not found')
+        self.assertGreater(credit_pos, 0, 'get_latest_credit_summary() call not found')
+        self.assertGreater(credit_pos, dollar_pos,
+                           'Credit block must appear AFTER dollar block in generate_portfolio_market_context()')
+
+    def test_existing_crypto_branch_intact(self):
+        section = self._get_portfolio_context_section()
+        self.assertIn('get_latest_crypto_summary()', section)
+        self.assertIn('Crypto Briefing', section)
+
+    def test_existing_equity_branch_intact(self):
+        section = self._get_portfolio_context_section()
+        self.assertIn('get_latest_equity_summary()', section)
+        self.assertIn('Equity Briefing', section)
+
+    def test_existing_rates_branch_intact(self):
+        section = self._get_portfolio_context_section()
+        self.assertIn('get_latest_rates_summary()', section)
+        self.assertIn('Rates Briefing', section)
+
+    def test_existing_dollar_branch_intact(self):
+        section = self._get_portfolio_context_section()
+        self.assertIn('get_latest_dollar_summary()', section)
+        self.assertIn('Dollar Briefing', section)
+
+    def test_existing_general_branch_intact(self):
+        section = self._get_portfolio_context_section()
+        self.assertIn('get_latest_summary()', section)
+        self.assertIn('General Market Briefing', section)
+
+
+# ---------------------------------------------------------------------------
+# TestExistingStepsUnmodified — regression: no logic changes elsewhere
+# ---------------------------------------------------------------------------
+
+
+class TestExistingStepsUnmodified(unittest.TestCase):
+    """Verify no logic was accidentally changed in either file."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ai_src = read_source('ai_summary.py')
+        cls.dash_src = read_source('dashboard.py')
+
+    def test_get_latest_credit_summary_definition_exists(self):
+        self.assertIn('def get_latest_credit_summary(', self.ai_src,
+                      'get_latest_credit_summary() definition must not have been removed')
+
+    def test_generate_credit_summary_definition_exists(self):
+        self.assertIn('def generate_credit_summary(', self.ai_src,
+                      'generate_credit_summary() definition must not have been removed')
+
+    def test_generate_credit_market_summary_definition_exists(self):
+        self.assertIn('def generate_credit_market_summary(', self.dash_src,
+                      'generate_credit_market_summary() definition must not have been removed')
+
+    def test_ai_summary_dollar_branch_unmodified(self):
+        # Dollar block is immediately before credit; ensure it was not accidentally deleted
+        self.assertIn('get_latest_dollar_summary()', self.ai_src)
+        self.assertIn('Dollar & Currency Briefing', self.ai_src)
+
+    def test_dashboard_dollar_branch_unmodified(self):
+        self.assertIn('get_latest_dollar_summary()', self.dash_src)
+        self.assertIn('Dollar Briefing', self.dash_src)
+
+    def test_no_logic_change_to_generate_daily_summary_structure(self):
+        # briefings_found list and specific_briefings_context must still exist
+        self.assertIn('briefings_found', self.ai_src)
+        self.assertIn('specific_briefings_context', self.ai_src)
+
+    def test_no_logic_change_to_portfolio_context_structure(self):
+        # briefings list and context_parts must still exist
+        self.assertIn('context_parts', self.dash_src)
+        # generate_portfolio_market_context must still have briefings list
+        start = self.dash_src.find('def generate_portfolio_market_context(')
+        section = self.dash_src[start:start + 4000]
+        self.assertIn('briefings = []', section)
+        self.assertIn('context_parts.append', section)
+
+
+# ---------------------------------------------------------------------------
+# TestEdgeCases — None guard coverage
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases(unittest.TestCase):
+    """Verify None-safe guards exist so missing credit summary does not crash."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ai_src = read_source('ai_summary.py')
+        cls.dash_src = read_source('dashboard.py')
+
+    def test_ai_summary_credit_guard_is_none_safe(self):
+        # Pattern: `if credit_summary and credit_summary.get("date") == today:`
+        self.assertIn('if credit_summary and credit_summary.get', self.ai_src,
+                      'credit_summary must be None-checked before accessing .get("date")')
+
+    def test_portfolio_context_credit_guard_is_none_safe(self):
+        start = self.dash_src.find('def generate_portfolio_market_context(')
+        section = self.dash_src[start:start + 4000]
+        # Pattern: `if credit:` — truthy check handles None return
+        self.assertIn('if credit:', section,
+                      'if credit: guard must be present to handle None return safely')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #257

## Summary
- Wires `get_latest_credit_summary()` into `generate_daily_summary()` — credit briefing now injected into daily synthesis context alongside crypto/equity/rates/dollar
- Wires `get_latest_credit_summary()` into `generate_portfolio_market_context()` — credit briefing available to portfolio AI analysis
- Mechanical wiring only (~10 lines); no logic changes

## Changes
- `ai_summary.py`: added `get_latest_credit_summary()` call after dollar block in `generate_daily_summary()` with date guard; appends `"### Credit Markets Briefing:"` to briefings context
- `dashboard.py`: added `get_latest_credit_summary` to import inside `generate_portfolio_market_context()`; appends credit briefing after dollar block under `if credit:` guard
- 27 new static source-analysis tests added

## Testing
- ✅ All unit tests passing (2970 passed, 19 pre-existing failures, 0 regressions)
- ✅ QA verification complete
- ✅ No design review required (backend wiring only)