### PR TITLE
US-259.3: News data pipeline — fetch, store, and summarize daily macro news

### DIFF
--- a/signaltrackers/dashboard.py
+++ b/signaltrackers/dashboard.py
@@ -2367,6 +2367,15 @@ def run_data_collection():
         reload_status['last_reload'] = datetime.now(eastern).strftime('%Y-%m-%d %H:%M:%S')
         print("Data reload completed successfully!")
 
+        # Fetch and store daily news BEFORE briefing generation so briefings can use it
+        reload_status['status'] = 'Fetching daily news...'
+        print("Fetching daily news...")
+        try:
+            from news_pipeline import run_news_pipeline
+            run_news_pipeline()
+        except Exception as news_pipeline_error:
+            print(f"News pipeline error (non-fatal): {news_pipeline_error}")
+
         # Generate market-specific briefings FIRST so they can be included in general summary
         # Generate Crypto AI summary
         reload_status['status'] = 'Generating Crypto AI summary...'

--- a/signaltrackers/news_pipeline.py
+++ b/signaltrackers/news_pipeline.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""
+Daily macro news pipeline.
+
+Fetches news across six market topic areas via Tavily, stores full article
+content keyed by date, and generates a single cross-market AI summary.
+
+Usage:
+    from news_pipeline import run_news_pipeline, get_stored_news
+
+    run_news_pipeline()          # fetch + store + summarize
+    data = get_stored_news()     # read stored data for today (or recent)
+"""
+
+import json
+import logging
+import os
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytz
+import requests
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+DATA_DIR = Path(__file__).parent / 'data'
+NEWS_CACHE_FILE = DATA_DIR / 'news_data.json'
+
+RETENTION_DAYS = 90
+
+# ---------------------------------------------------------------------------
+# Topic queries
+# ---------------------------------------------------------------------------
+TOPIC_QUERIES = [
+    ('macro',   'macroeconomic news today federal reserve GDP inflation employment'),
+    ('crypto',  'cryptocurrency Bitcoin Ethereum crypto market news today'),
+    ('equity',  'stock market equity S&P 500 earnings news today'),
+    ('rates',   'interest rates treasury yields bond market news today'),
+    ('dollar',  'US dollar DXY currency forex news today'),
+    ('credit',  'credit markets corporate bonds spreads high yield news today'),
+]
+
+TAVILY_API_URL = 'https://api.tavily.com/search'
+
+# ---------------------------------------------------------------------------
+# Fetch helpers
+# ---------------------------------------------------------------------------
+
+def _fetch_topic(api_key: str, topic: str, query: str) -> list[dict]:
+    """Fetch articles for one topic. Returns list of article dicts."""
+    try:
+        payload = {
+            'api_key': api_key,
+            'query': query,
+            'search_depth': 'advanced',
+            'max_results': 7,
+            'include_raw_content': True,
+            'include_answer': False,
+        }
+        resp = requests.post(TAVILY_API_URL, json=payload, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:
+        logger.warning('[news_pipeline] Tavily fetch failed for topic=%s: %s', topic, exc)
+        return []
+
+    articles = []
+    for item in data.get('results', []):
+        url = item.get('url', '')
+        try:
+            domain = urlparse(url).netloc.lstrip('www.')
+        except Exception:
+            domain = ''
+        raw = item.get('raw_content') or item.get('content', '')
+        articles.append({
+            'headline': item.get('title', ''),
+            'url': url,
+            'source': domain,
+            'timestamp': datetime.now(tz=pytz.utc).isoformat(),
+            'raw_content': raw,
+            'topic': topic,
+        })
+    return articles
+
+
+# ---------------------------------------------------------------------------
+# AI summarization
+# ---------------------------------------------------------------------------
+
+def _generate_cross_market_summary(articles: list[dict]) -> str | None:
+    """
+    Generate a single cross-market prose summary from all articles.
+    Returns the summary string, or None if AI is unavailable.
+    """
+    # Build article digest for the prompt (cap per-article length to save tokens)
+    digest_parts = []
+    for art in articles[:40]:  # max 40 articles
+        content_snippet = (art['raw_content'] or '')[:600]
+        digest_parts.append(
+            f"[{art['topic'].upper()}] {art['headline']}\n"
+            f"Source: {art['source']}\n"
+            f"{content_snippet}"
+        )
+    digest = '\n\n---\n\n'.join(digest_parts)
+
+    system_prompt = (
+        "You are a senior macro analyst writing a daily market briefing for sophisticated investors. "
+        "Write a comprehensive cross-market summary of today's news in 3-5 prose paragraphs. "
+        "Do NOT use bullet points or headers. Write in flowing, analytical prose. "
+        "Cover the major themes across macro, equities, rates, credit, crypto, and currencies. "
+        "Focus on what matters most and how the pieces connect. Be direct and authoritative."
+    )
+    user_prompt = (
+        f"Today's date: {date.today().isoformat()}\n\n"
+        f"Here are today's key articles across all market areas:\n\n{digest}\n\n"
+        "Write your cross-market summary now."
+    )
+
+    # Try Anthropic first, fall back to OpenAI
+    provider = os.environ.get('AI_PROVIDER', 'openai').lower()
+
+    if provider == 'anthropic':
+        return _summarize_with_anthropic(system_prompt, user_prompt)
+    else:
+        return _summarize_with_openai(system_prompt, user_prompt)
+
+
+def _summarize_with_openai(system_prompt: str, user_prompt: str) -> str | None:
+    try:
+        from openai import OpenAI
+        api_key = os.environ.get('OPENAI_API_KEY')
+        if not api_key:
+            return None
+        client = OpenAI(api_key=api_key)
+        resp = client.chat.completions.create(
+            model='gpt-5.2',
+            messages=[
+                {'role': 'system', 'content': system_prompt},
+                {'role': 'user', 'content': user_prompt},
+            ],
+            max_completion_tokens=1200,
+            temperature=0.6,
+        )
+        content = resp.choices[0].message.content
+        return content.strip() if content else None
+    except Exception as exc:
+        logger.warning('[news_pipeline] OpenAI summarization failed: %s', exc)
+        return None
+
+
+def _summarize_with_anthropic(system_prompt: str, user_prompt: str) -> str | None:
+    try:
+        import anthropic as anthropic_lib
+        api_key = os.environ.get('ANTHROPIC_API_KEY')
+        if not api_key:
+            return None
+        client = anthropic_lib.Anthropic(api_key=api_key)
+        msg = client.messages.create(
+            model='claude-opus-4-6',
+            max_tokens=1200,
+            system=system_prompt,
+            messages=[{'role': 'user', 'content': user_prompt}],
+        )
+        content = msg.content[0].text if msg.content else None
+        return content.strip() if content else None
+    except Exception as exc:
+        logger.warning('[news_pipeline] Anthropic summarization failed: %s', exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Storage helpers
+# ---------------------------------------------------------------------------
+
+def _load_cache() -> dict:
+    if not NEWS_CACHE_FILE.exists():
+        return {}
+    try:
+        with open(NEWS_CACHE_FILE) as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def _save_cache(data: dict) -> None:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    with open(NEWS_CACHE_FILE, 'w') as f:
+        json.dump(data, f, indent=2)
+
+
+def _prune(data: dict) -> dict:
+    """Remove entries older than RETENTION_DAYS."""
+    cutoff = (date.today() - timedelta(days=RETENTION_DAYS)).isoformat()
+    return {k: v for k, v in data.items() if k >= cutoff}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def run_news_pipeline() -> bool:
+    """
+    Fetch daily macro news, store articles, and generate a cross-market summary.
+
+    Returns True on success, False if Tavily is unavailable.
+    Failures in individual topic fetches or summarization are non-fatal.
+    """
+    api_key = os.environ.get('TAVILY_API_KEY')
+    if not api_key:
+        logger.info('[news_pipeline] TAVILY_API_KEY not set — skipping news pipeline')
+        return False
+
+    today = date.today().isoformat()
+    logger.info('[news_pipeline] Starting news pipeline for %s', today)
+
+    # Fetch all topic areas
+    all_articles = []
+    for topic, query in TOPIC_QUERIES:
+        logger.info('[news_pipeline] Fetching topic: %s', topic)
+        articles = _fetch_topic(api_key, topic, query)
+        all_articles.extend(articles)
+        logger.info('[news_pipeline] Got %d articles for topic %s', len(articles), topic)
+
+    logger.info('[news_pipeline] Total articles fetched: %d', len(all_articles))
+
+    # Generate cross-market AI summary
+    logger.info('[news_pipeline] Generating cross-market summary...')
+    summary = _generate_cross_market_summary(all_articles) if all_articles else None
+    if summary:
+        logger.info('[news_pipeline] Summary generated (%d chars)', len(summary))
+    else:
+        logger.warning('[news_pipeline] Summary generation failed or returned empty')
+
+    # Build record
+    eastern = pytz.timezone('US/Eastern')
+    record = {
+        'date': today,
+        'fetched_at': datetime.now(eastern).isoformat(),
+        'articles': all_articles,
+        'summary': summary,
+    }
+
+    # Load, update, prune, save
+    cache = _load_cache()
+    cache[today] = record
+    cache = _prune(cache)
+    _save_cache(cache)
+
+    logger.info('[news_pipeline] News pipeline complete for %s', today)
+    return True
+
+
+def get_stored_news(max_stale_days: int = 7) -> dict | None:
+    """
+    Return stored news data.
+
+    Checks today's record first. If absent, returns the most recent record
+    within max_stale_days. Returns None if no suitable record exists or if
+    the storage file is missing/malformed.
+
+    Args:
+        max_stale_days: How many days old the most recent record may be.
+
+    Returns:
+        dict with keys 'date', 'fetched_at', 'articles', 'summary', or None.
+    """
+    try:
+        cache = _load_cache()
+    except Exception:
+        return None
+
+    if not cache:
+        return None
+
+    today = date.today().isoformat()
+
+    # Prefer today's record
+    if today in cache:
+        return cache[today]
+
+    # Fall back to most recent within stale window
+    cutoff = (date.today() - timedelta(days=max_stale_days)).isoformat()
+    candidates = {k: v for k, v in cache.items() if k >= cutoff}
+    if not candidates:
+        return None
+
+    most_recent_key = max(candidates.keys())
+    return candidates[most_recent_key]

--- a/tests/test_us2593_news_pipeline.py
+++ b/tests/test_us2593_news_pipeline.py
@@ -1,0 +1,598 @@
+"""
+Tests for US-259.3: News data pipeline — fetch, store, and summarize daily macro news.
+
+These are static source-analysis tests. No live Tavily calls, no Docker required.
+"""
+
+import ast
+import importlib.util
+import inspect
+import json
+import os
+import sys
+import textwrap
+from datetime import date, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers to load the module under test
+# ---------------------------------------------------------------------------
+REPO_ROOT = Path(__file__).parent.parent
+SIGNALTRACKERS_DIR = REPO_ROOT / 'signaltrackers'
+
+sys.path.insert(0, str(SIGNALTRACKERS_DIR))
+
+# Load news_pipeline without executing side effects
+NEWS_PIPELINE_FILE = SIGNALTRACKERS_DIR / 'news_pipeline.py'
+NEWS_PIPELINE_SOURCE = NEWS_PIPELINE_FILE.read_text()
+
+# Parse AST for static checks
+NEWS_PIPELINE_AST = ast.parse(NEWS_PIPELINE_SOURCE)
+
+
+def load_news_pipeline_module():
+    """Import news_pipeline with minimal env so no live calls are made."""
+    spec = importlib.util.spec_from_file_location('news_pipeline', NEWS_PIPELINE_FILE)
+    mod = importlib.util.module_from_spec(spec)
+    # Provide stubs for optional deps
+    sys.modules.setdefault('pytz', __import__('pytz'))
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Module structure tests
+# ---------------------------------------------------------------------------
+
+class TestModuleStructure:
+    def test_module_is_importable(self):
+        """Module must import without error."""
+        mod = load_news_pipeline_module()
+        assert mod is not None
+
+    def test_run_news_pipeline_exported(self):
+        """run_news_pipeline() must be a callable exported from the module."""
+        mod = load_news_pipeline_module()
+        assert callable(getattr(mod, 'run_news_pipeline', None))
+
+    def test_get_stored_news_exported(self):
+        """get_stored_news() must be a callable exported from the module."""
+        mod = load_news_pipeline_module()
+        assert callable(getattr(mod, 'get_stored_news', None))
+
+    def test_get_stored_news_has_max_stale_days_param(self):
+        """get_stored_news() must accept max_stale_days argument."""
+        mod = load_news_pipeline_module()
+        sig = inspect.signature(mod.get_stored_news)
+        assert 'max_stale_days' in sig.parameters
+
+    def test_run_news_pipeline_callable_no_required_args(self):
+        """run_news_pipeline() must be callable with no arguments."""
+        mod = load_news_pipeline_module()
+        sig = inspect.signature(mod.run_news_pipeline)
+        required = [
+            p for p in sig.parameters.values()
+            if p.default is inspect.Parameter.empty
+        ]
+        assert len(required) == 0
+
+
+# ---------------------------------------------------------------------------
+# Six topic areas
+# ---------------------------------------------------------------------------
+
+class TestTopicAreas:
+    def test_six_topic_areas_defined(self):
+        """Pipeline must define exactly 6 topic queries."""
+        mod = load_news_pipeline_module()
+        assert len(mod.TOPIC_QUERIES) == 6
+
+    def test_topic_macro_present(self):
+        topics = {t for t, _ in load_news_pipeline_module().TOPIC_QUERIES}
+        assert 'macro' in topics
+
+    def test_topic_crypto_present(self):
+        topics = {t for t, _ in load_news_pipeline_module().TOPIC_QUERIES}
+        assert 'crypto' in topics
+
+    def test_topic_equity_present(self):
+        topics = {t for t, _ in load_news_pipeline_module().TOPIC_QUERIES}
+        assert 'equity' in topics
+
+    def test_topic_rates_present(self):
+        topics = {t for t, _ in load_news_pipeline_module().TOPIC_QUERIES}
+        assert 'rates' in topics
+
+    def test_topic_dollar_present(self):
+        topics = {t for t, _ in load_news_pipeline_module().TOPIC_QUERIES}
+        assert 'dollar' in topics
+
+    def test_topic_credit_present(self):
+        topics = {t for t, _ in load_news_pipeline_module().TOPIC_QUERIES}
+        assert 'credit' in topics
+
+    def test_all_topics_have_queries(self):
+        """Every topic must have a non-empty query string."""
+        mod = load_news_pipeline_module()
+        for topic, query in mod.TOPIC_QUERIES:
+            assert query.strip(), f"Empty query for topic: {topic}"
+
+
+# ---------------------------------------------------------------------------
+# Search depth and raw content flags
+# ---------------------------------------------------------------------------
+
+class TestFetchConfig:
+    def test_advanced_search_depth_in_source(self):
+        """_fetch_topic must use search_depth='advanced'."""
+        assert "search_depth': 'advanced'" in NEWS_PIPELINE_SOURCE or \
+               '"search_depth": "advanced"' in NEWS_PIPELINE_SOURCE or \
+               "'advanced'" in NEWS_PIPELINE_SOURCE
+
+    def test_include_raw_content_true_in_source(self):
+        """_fetch_topic must set include_raw_content=True."""
+        assert 'include_raw_content' in NEWS_PIPELINE_SOURCE
+        assert 'True' in NEWS_PIPELINE_SOURCE
+
+
+# ---------------------------------------------------------------------------
+# Article schema
+# ---------------------------------------------------------------------------
+
+class TestArticleSchema:
+    REQUIRED_KEYS = {'headline', 'url', 'source', 'timestamp', 'raw_content', 'topic'}
+
+    def test_article_schema_contains_headline(self):
+        assert 'headline' in NEWS_PIPELINE_SOURCE
+
+    def test_article_schema_contains_url(self):
+        assert "'url'" in NEWS_PIPELINE_SOURCE or '"url"' in NEWS_PIPELINE_SOURCE
+
+    def test_article_schema_contains_source(self):
+        assert "'source'" in NEWS_PIPELINE_SOURCE or '"source"' in NEWS_PIPELINE_SOURCE
+
+    def test_article_schema_contains_timestamp(self):
+        assert 'timestamp' in NEWS_PIPELINE_SOURCE
+
+    def test_article_schema_contains_raw_content(self):
+        assert 'raw_content' in NEWS_PIPELINE_SOURCE
+
+    def test_article_schema_contains_topic(self):
+        assert "'topic'" in NEWS_PIPELINE_SOURCE or '"topic"' in NEWS_PIPELINE_SOURCE
+
+    def test_fetch_topic_builds_article_dicts(self):
+        """_fetch_topic must build article dicts with required keys."""
+        mod = load_news_pipeline_module()
+        fake_response = {
+            'results': [{
+                'title': 'Test Headline',
+                'url': 'https://reuters.com/test',
+                'content': 'Test content',
+                'raw_content': 'Full raw content here',
+            }]
+        }
+        with patch('requests.post') as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = fake_response
+            mock_resp.raise_for_status = MagicMock()
+            mock_post.return_value = mock_resp
+
+            articles = mod._fetch_topic('testapikey', 'macro', 'test query')
+
+        assert len(articles) == 1
+        art = articles[0]
+        for key in self.REQUIRED_KEYS:
+            assert key in art, f"Missing key: {key}"
+
+    def test_article_source_is_domain(self):
+        """source field should be domain name, not full URL."""
+        mod = load_news_pipeline_module()
+        fake_response = {
+            'results': [{
+                'title': 'Test',
+                'url': 'https://www.reuters.com/article/test',
+                'content': 'content',
+                'raw_content': None,
+            }]
+        }
+        with patch('requests.post') as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = fake_response
+            mock_resp.raise_for_status = MagicMock()
+            mock_post.return_value = mock_resp
+
+            articles = mod._fetch_topic('key', 'macro', 'query')
+
+        assert '/' not in articles[0]['source'], "source should be domain, not full URL"
+        assert 'reuters.com' in articles[0]['source']
+
+    def test_article_topic_set_correctly(self):
+        """topic field must match the topic argument passed to _fetch_topic."""
+        mod = load_news_pipeline_module()
+        fake_response = {
+            'results': [{'title': 'T', 'url': 'https://x.com', 'content': 'c', 'raw_content': 'r'}]
+        }
+        with patch('requests.post') as mock_post:
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = fake_response
+            mock_resp.raise_for_status = MagicMock()
+            mock_post.return_value = mock_resp
+
+            articles = mod._fetch_topic('key', 'credit', 'credit query')
+
+        assert articles[0]['topic'] == 'credit'
+
+
+# ---------------------------------------------------------------------------
+# Cross-market AI summary
+# ---------------------------------------------------------------------------
+
+class TestAISummary:
+    def test_single_summary_function_exists(self):
+        """A function to generate the cross-market summary must exist."""
+        mod = load_news_pipeline_module()
+        assert callable(getattr(mod, '_generate_cross_market_summary', None))
+
+    def test_summary_prompt_instructs_prose_paragraphs(self):
+        """AI prompt must instruct prose paragraphs, not bullets."""
+        assert 'prose' in NEWS_PIPELINE_SOURCE.lower() or 'paragraph' in NEWS_PIPELINE_SOURCE.lower()
+        # Must NOT instruct bullet points
+        # (We check the negative: the prompt itself shouldn't say "use bullets")
+        # The positive check above is sufficient
+
+    def test_no_bullet_instruction_in_prompt(self):
+        """The summarization prompt must NOT tell the model to use bullet points."""
+        # Find the system_prompt string in source
+        assert 'Do NOT use bullet' in NEWS_PIPELINE_SOURCE or \
+               'no bullet' in NEWS_PIPELINE_SOURCE.lower() or \
+               'not use bullet' in NEWS_PIPELINE_SOURCE.lower()
+
+    def test_summary_stored_in_record(self):
+        """run_news_pipeline must store 'summary' key in the date record."""
+        mod = load_news_pipeline_module()
+        with patch.dict(os.environ, {'TAVILY_API_KEY': 'testkey'}), \
+             patch.object(mod, '_fetch_topic', return_value=[]), \
+             patch.object(mod, '_generate_cross_market_summary', return_value='Test summary'), \
+             patch.object(mod, '_save_cache') as mock_save:
+
+            mod.run_news_pipeline()
+
+        assert mock_save.called
+        saved_data = mock_save.call_args[0][0]
+        today = date.today().isoformat()
+        assert today in saved_data
+        assert 'summary' in saved_data[today]
+
+    def test_single_ai_call_not_per_topic(self):
+        """Only one summarization call should be made per pipeline run (not one per topic)."""
+        # Verify there is one call to _generate_cross_market_summary, not 6
+        mod = load_news_pipeline_module()
+        call_count = []
+
+        def mock_summarize(articles):
+            call_count.append(1)
+            return 'summary text'
+
+        with patch.dict(os.environ, {'TAVILY_API_KEY': 'testkey'}), \
+             patch.object(mod, '_fetch_topic', return_value=[
+                 {'headline': 'h', 'url': 'u', 'source': 's',
+                  'timestamp': 't', 'raw_content': 'r', 'topic': 'macro'}
+             ]), \
+             patch.object(mod, '_generate_cross_market_summary', side_effect=mock_summarize), \
+             patch.object(mod, '_save_cache'):
+
+            mod.run_news_pipeline()
+
+        assert len(call_count) == 1, f"Expected 1 summarization call, got {len(call_count)}"
+
+
+# ---------------------------------------------------------------------------
+# Storage layer
+# ---------------------------------------------------------------------------
+
+class TestStorageLayer:
+    def test_storage_path_inside_data_dir(self):
+        """NEWS_CACHE_FILE must be inside the data/ directory."""
+        mod = load_news_pipeline_module()
+        assert 'data' in str(mod.NEWS_CACHE_FILE)
+
+    def test_storage_keyed_by_date_string(self):
+        """Records must be stored with date string keys (YYYY-MM-DD)."""
+        mod = load_news_pipeline_module()
+        with patch.dict(os.environ, {'TAVILY_API_KEY': 'key'}), \
+             patch.object(mod, '_fetch_topic', return_value=[]), \
+             patch.object(mod, '_generate_cross_market_summary', return_value=None), \
+             patch.object(mod, '_save_cache') as mock_save:
+
+            mod.run_news_pipeline()
+
+        saved = mock_save.call_args[0][0]
+        today = date.today().isoformat()
+        assert today in saved
+        # Key format: YYYY-MM-DD
+        assert len(today) == 10
+        assert today[4] == '-' and today[7] == '-'
+
+    def test_one_record_per_date_overwrites(self):
+        """A second run on the same day must overwrite, not append."""
+        mod = load_news_pipeline_module()
+        today = date.today().isoformat()
+        existing = {
+            today: {
+                'date': today,
+                'articles': [{'headline': 'old'}],
+                'summary': 'old summary',
+                'fetched_at': '2026-01-01T00:00:00',
+            }
+        }
+        saved_calls = []
+        fake_article = {
+            'headline': 'h', 'url': 'u', 'source': 's',
+            'timestamp': 't', 'raw_content': 'r', 'topic': 'macro',
+        }
+
+        def mock_save(data):
+            saved_calls.append(data)
+
+        with patch.dict(os.environ, {'TAVILY_API_KEY': 'key'}), \
+             patch.object(mod, '_load_cache', return_value=existing.copy()), \
+             patch.object(mod, '_fetch_topic', return_value=[fake_article]), \
+             patch.object(mod, '_generate_cross_market_summary', return_value='new summary'), \
+             patch.object(mod, '_save_cache', side_effect=mock_save):
+
+            mod.run_news_pipeline()
+
+        final = saved_calls[-1]
+        # Should still have exactly one entry for today (overwritten, not duplicated)
+        today_records = [k for k in final.keys() if k == today]
+        assert len(today_records) == 1
+        assert final[today]['summary'] == 'new summary'
+
+    def test_90_day_pruning_logic_present(self):
+        """Source must contain 90-day pruning logic."""
+        assert '90' in NEWS_PIPELINE_SOURCE
+        assert 'prune' in NEWS_PIPELINE_SOURCE.lower() or 'cutoff' in NEWS_PIPELINE_SOURCE.lower() or \
+               'retention' in NEWS_PIPELINE_SOURCE.lower()
+
+    def test_pruning_removes_old_entries(self):
+        """_prune must remove entries older than RETENTION_DAYS."""
+        mod = load_news_pipeline_module()
+        old_date = (date.today() - timedelta(days=91)).isoformat()
+        recent_date = date.today().isoformat()
+        data = {
+            old_date: {'date': old_date},
+            recent_date: {'date': recent_date},
+        }
+        pruned = mod._prune(data)
+        assert old_date not in pruned
+        assert recent_date in pruned
+
+    def test_load_cache_returns_empty_dict_when_file_missing(self, tmp_path):
+        """_load_cache must return {} when the file does not exist."""
+        mod = load_news_pipeline_module()
+        nonexistent = tmp_path / 'news_data.json'  # does not exist
+        with patch.object(mod, 'NEWS_CACHE_FILE', nonexistent):
+            result = mod._load_cache()
+        assert result == {}
+
+    def test_load_cache_returns_empty_dict_on_malformed_json(self, tmp_path):
+        """_load_cache must return {} on malformed JSON without raising."""
+        mod = load_news_pipeline_module()
+        bad_file = tmp_path / 'bad.json'
+        bad_file.write_text('{ invalid json }')
+        with patch.object(mod, 'NEWS_CACHE_FILE', bad_file):
+            result = mod._load_cache()
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# get_stored_news behavior
+# ---------------------------------------------------------------------------
+
+class TestGetStoredNews:
+    def test_returns_today_record_when_present(self):
+        mod = load_news_pipeline_module()
+        today = date.today().isoformat()
+        cache = {today: {'date': today, 'summary': 'today summary', 'articles': []}}
+        with patch.object(mod, '_load_cache', return_value=cache):
+            result = mod.get_stored_news()
+        assert result is not None
+        assert result['date'] == today
+
+    def test_returns_recent_stale_record_within_window(self):
+        mod = load_news_pipeline_module()
+        yesterday = (date.today() - timedelta(days=1)).isoformat()
+        cache = {yesterday: {'date': yesterday, 'summary': 'yesterday', 'articles': []}}
+        with patch.object(mod, '_load_cache', return_value=cache):
+            result = mod.get_stored_news(max_stale_days=7)
+        assert result is not None
+        assert result['date'] == yesterday
+
+    def test_returns_none_when_record_too_stale(self):
+        mod = load_news_pipeline_module()
+        old = (date.today() - timedelta(days=8)).isoformat()
+        cache = {old: {'date': old, 'summary': 'old', 'articles': []}}
+        with patch.object(mod, '_load_cache', return_value=cache):
+            result = mod.get_stored_news(max_stale_days=7)
+        assert result is None
+
+    def test_returns_none_when_file_absent(self):
+        mod = load_news_pipeline_module()
+        with patch.object(mod, '_load_cache', return_value={}):
+            result = mod.get_stored_news()
+        assert result is None
+
+    def test_returns_none_on_malformed_cache(self):
+        mod = load_news_pipeline_module()
+        with patch.object(mod, '_load_cache', side_effect=Exception('boom')):
+            result = mod.get_stored_news()
+        assert result is None
+
+    def test_returns_most_recent_when_multiple_stale_records(self):
+        mod = load_news_pipeline_module()
+        d1 = (date.today() - timedelta(days=3)).isoformat()
+        d2 = (date.today() - timedelta(days=5)).isoformat()
+        cache = {
+            d1: {'date': d1, 'summary': 'newer', 'articles': []},
+            d2: {'date': d2, 'summary': 'older', 'articles': []},
+        }
+        with patch.object(mod, '_load_cache', return_value=cache):
+            result = mod.get_stored_news(max_stale_days=7)
+        assert result['date'] == d1
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation (no TAVILY_API_KEY)
+# ---------------------------------------------------------------------------
+
+class TestGracefulDegradation:
+    def test_run_news_pipeline_returns_false_without_api_key(self):
+        mod = load_news_pipeline_module()
+        env = {k: v for k, v in os.environ.items() if k != 'TAVILY_API_KEY'}
+        with patch.dict(os.environ, env, clear=True):
+            result = mod.run_news_pipeline()
+        assert result is False
+
+    def test_run_news_pipeline_does_not_raise_without_api_key(self):
+        mod = load_news_pipeline_module()
+        env = {k: v for k, v in os.environ.items() if k != 'TAVILY_API_KEY'}
+        with patch.dict(os.environ, env, clear=True):
+            try:
+                mod.run_news_pipeline()
+            except Exception as exc:
+                pytest.fail(f"run_news_pipeline raised unexpectedly: {exc}")
+
+    def test_fetch_topic_returns_empty_list_on_http_error(self):
+        mod = load_news_pipeline_module()
+        with patch('requests.post', side_effect=Exception('network error')):
+            result = mod._fetch_topic('key', 'macro', 'query')
+        assert result == []
+
+    def test_run_pipeline_continues_if_summary_generation_fails(self):
+        """If AI summarization fails, pipeline should still save articles."""
+        mod = load_news_pipeline_module()
+        saved = []
+        with patch.dict(os.environ, {'TAVILY_API_KEY': 'key'}), \
+             patch.object(mod, '_fetch_topic', return_value=[
+                 {'headline': 'h', 'url': 'u', 'source': 's',
+                  'timestamp': 't', 'raw_content': 'r', 'topic': 'macro'}
+             ]), \
+             patch.object(mod, '_generate_cross_market_summary', return_value=None), \
+             patch.object(mod, '_save_cache', side_effect=lambda d: saved.append(d)):
+
+            mod.run_news_pipeline()
+
+        assert saved, "Cache was not saved when summary generation returned None"
+        today = date.today().isoformat()
+        assert today in saved[0]
+        assert len(saved[0][today]['articles']) > 0
+
+
+# ---------------------------------------------------------------------------
+# Security tests
+# ---------------------------------------------------------------------------
+
+class TestSecurity:
+    def test_api_key_read_from_env_not_hardcoded(self):
+        """TAVILY_API_KEY must come from os.environ, not be hardcoded."""
+        assert "os.environ.get('TAVILY_API_KEY')" in NEWS_PIPELINE_SOURCE or \
+               'os.environ.get("TAVILY_API_KEY")' in NEWS_PIPELINE_SOURCE
+
+    def test_no_hardcoded_api_key_value(self):
+        """No API key value pattern should appear in source."""
+        import re
+        # Check for common API key patterns (long alphanumeric strings)
+        suspicious = re.findall(r'tvly-[A-Za-z0-9]{20,}', NEWS_PIPELINE_SOURCE)
+        assert len(suspicious) == 0, f"Possible hardcoded Tavily key found: {suspicious}"
+
+    def test_no_eval_exec_on_article_content(self):
+        """Article content must never be passed to eval() or exec()."""
+        assert 'eval(' not in NEWS_PIPELINE_SOURCE
+        assert 'exec(' not in NEWS_PIPELINE_SOURCE
+
+
+# ---------------------------------------------------------------------------
+# Performance / API credit usage
+# ---------------------------------------------------------------------------
+
+class TestPerformance:
+    def test_at_most_six_tavily_calls_per_run(self):
+        """Pipeline must not exceed 6 Tavily search calls per run."""
+        mod = load_news_pipeline_module()
+        fetch_calls = []
+
+        def mock_fetch(api_key, topic, query):
+            fetch_calls.append(topic)
+            return []
+
+        with patch.dict(os.environ, {'TAVILY_API_KEY': 'key'}), \
+             patch.object(mod, '_fetch_topic', side_effect=mock_fetch), \
+             patch.object(mod, '_generate_cross_market_summary', return_value=None), \
+             patch.object(mod, '_save_cache'):
+
+            mod.run_news_pipeline()
+
+        assert len(fetch_calls) <= 6, f"Expected ≤6 fetch calls, got {len(fetch_calls)}"
+
+
+# ---------------------------------------------------------------------------
+# dashboard.py integration
+# ---------------------------------------------------------------------------
+
+DASHBOARD_FILE = SIGNALTRACKERS_DIR / 'dashboard.py'
+DASHBOARD_SOURCE = DASHBOARD_FILE.read_text()
+
+
+class TestDashboardIntegration:
+    def test_news_pipeline_imported_in_run_data_collection(self):
+        """run_data_collection must import or reference news_pipeline."""
+        assert 'news_pipeline' in DASHBOARD_SOURCE
+
+    def test_run_news_pipeline_called_in_data_collection(self):
+        """run_data_collection must call run_news_pipeline()."""
+        assert 'run_news_pipeline' in DASHBOARD_SOURCE
+
+    def test_news_pipeline_call_wrapped_in_try_except(self):
+        """News pipeline call must be wrapped in try/except."""
+        # Find the block containing run_news_pipeline
+        assert 'run_news_pipeline' in DASHBOARD_SOURCE
+        # Verify try/except pattern exists near it
+        idx = DASHBOARD_SOURCE.find('run_news_pipeline')
+        surrounding = DASHBOARD_SOURCE[max(0, idx - 200):idx + 200]
+        assert 'try' in surrounding or 'except' in surrounding
+
+    def test_news_pipeline_called_before_briefing_generation(self):
+        """News pipeline must be called before generate_crypto_summary call inside run_data_collection."""
+        # Find run_data_collection body (search from its def onwards)
+        func_start = DASHBOARD_SOURCE.find('def run_data_collection()')
+        assert func_start >= 0, "run_data_collection not found in dashboard.py"
+        body = DASHBOARD_SOURCE[func_start:]
+        news_idx = body.find('run_news_pipeline')
+        # Find the call site (not the import) by looking for the function call pattern
+        # The call will be after the import statement
+        import_idx = body.find('from news_pipeline import')
+        crypto_call_idx = body.find('generate_crypto_summary(')
+        assert news_idx >= 0, "run_news_pipeline not found in run_data_collection body"
+        assert crypto_call_idx >= 0, "generate_crypto_summary call not found in run_data_collection body"
+        assert news_idx < crypto_call_idx, (
+            "run_news_pipeline() must appear before generate_crypto_summary() "
+            "in run_data_collection()"
+        )
+
+    def test_news_pipeline_called_before_general_summary(self):
+        """News pipeline must be called before generate_daily_summary inside run_data_collection."""
+        func_start = DASHBOARD_SOURCE.find('def run_data_collection()')
+        body = DASHBOARD_SOURCE[func_start:]
+        news_idx = body.find('run_news_pipeline')
+        daily_idx = body.find('generate_daily_summary(')
+        assert news_idx >= 0
+        assert daily_idx >= 0
+        assert news_idx < daily_idx
+
+    def test_fetching_news_status_message(self):
+        """run_data_collection must emit a status message for the news step."""
+        assert 'Fetching daily news' in DASHBOARD_SOURCE or \
+               'news pipeline' in DASHBOARD_SOURCE.lower()


### PR DESCRIPTION
Fixes #275

## Summary
- `news_pipeline.py`: daily macro news pipeline — fetches 6 topic areas (macro, crypto, equity, rates, dollar, credit) via Tavily with `search_depth='advanced'` and `include_raw_content=True`
- Each article stored with headline, URL, source domain, timestamp, raw_content, and topic tag
- Single cross-market AI summary generated as prose paragraphs (not bullets) from all articles combined
- Data stored in `data/news_data.json` keyed by date; 90-day retention; `get_stored_news(max_stale_days=7)` for stale fallback
- `dashboard.py`: `run_data_collection()` calls `run_news_pipeline()` before all briefing generation (non-fatal try/except)

## Changes
- Engineer: `signaltrackers/news_pipeline.py` (new), `signaltrackers/dashboard.py` (wired into data collection)
- QA: `tests/test_us2593_news_pipeline.py` (56 tests)

## Testing
- ✅ 56 story tests passing
- ✅ Full suite: 3255 passed, 0 new failures
- ✅ Design review approved (backend-only story, no UI changes)
- ✅ QA verification complete — all 8 acceptance criteria met

## Design Spec
Implements parent feature #259 (News Feed)