### PR TITLE
Fix #287: Chatbot FAB visibility and close button on desktop/tablet

### DIFF
--- a/signaltrackers/static/css/components/chatbot.css
+++ b/signaltrackers/static/css/components/chatbot.css
@@ -561,24 +561,7 @@
         border-radius: 0;
     }
 
-    /* FAB: add right-shift transition for smooth repositioning */
-    .chatbot-fab {
-        transition: right 250ms cubic-bezier(0.4, 0.0, 0.2, 1),
-                    box-shadow 150ms ease,
-                    transform 150ms ease;
-    }
-
-    /* FAB shifts left when panel open — stays visible (not hidden like mobile) */
-    .chatbot-fab[aria-expanded="true"] {
-        opacity: 1;
-        pointer-events: auto;
-        transform: none;
-        right: 376px; /* 360px panel + 16px margin */
-    }
-
-    .chatbot-fab[aria-expanded="true"]:hover {
-        transform: scale(1.05);
-    }
+    /* FAB: hidden when chatbot open (consistent across all viewports) */
 }
 
 /* ============================================
@@ -590,11 +573,6 @@
     /* Panel: wider than tablet */
     .chatbot-panel {
         width: 440px;
-    }
-
-    /* FAB shifts further left for wider panel */
-    .chatbot-fab[aria-expanded="true"] {
-        right: 456px; /* 440px panel + 16px margin */
     }
 
     /* Enhanced hover scale on desktop (mouse precision) */

--- a/signaltrackers/static/js/components/chatbot.js
+++ b/signaltrackers/static/js/components/chatbot.js
@@ -8,7 +8,7 @@
  *
  * Binary state model:
  *   closed   — FAB visible, panel hidden
- *   expanded — Panel visible, FAB hidden (mobile) or shifted (tablet/desktop)
+ *   expanded — Panel visible, FAB hidden (all viewports)
  */
 
 class ChatbotWidget {
@@ -135,7 +135,7 @@ class ChatbotWidget {
 
         this.state = 'expanded';
 
-        // Set aria-expanded (mobile: FAB hides via CSS, tablet/desktop: shifts)
+        // Set aria-expanded (FAB hides via CSS on all viewports)
         this.fab.setAttribute('aria-expanded', 'true');
 
         // Show panel

--- a/tests/test_bug287_chatbot_close_fab.py
+++ b/tests/test_bug287_chatbot_close_fab.py
@@ -1,0 +1,298 @@
+"""
+Tests for Bug #287: Chatbot close button and FAB visibility.
+
+Verifies that:
+- Close (X) button is visible on all viewports (desktop, tablet, mobile)
+- FAB is hidden when chatbot is open on all viewports
+- Behavior is consistent across breakpoints
+"""
+
+import os
+import re
+import pytest
+from bs4 import BeautifulSoup
+
+
+CHATBOT_CSS_PATH = os.path.join(
+    os.path.dirname(__file__), '..', 'signaltrackers', 'static', 'css', 'components', 'chatbot.css'
+)
+
+CHATBOT_JS_PATH = os.path.join(
+    os.path.dirname(__file__), '..', 'signaltrackers', 'static', 'js', 'components', 'chatbot.js'
+)
+
+BASE_HTML_PATH = os.path.join(
+    os.path.dirname(__file__), '..', 'signaltrackers', 'templates', 'base.html'
+)
+
+
+@pytest.fixture(scope='module')
+def chatbot_css():
+    with open(CHATBOT_CSS_PATH) as f:
+        return f.read()
+
+
+@pytest.fixture(scope='module')
+def chatbot_js():
+    with open(CHATBOT_JS_PATH) as f:
+        return f.read()
+
+
+@pytest.fixture(scope='module')
+def base_html():
+    with open(BASE_HTML_PATH) as f:
+        return f.read()
+
+
+@pytest.fixture(scope='module')
+def base_soup(base_html):
+    return BeautifulSoup(base_html, 'html.parser')
+
+
+# ============================================
+# Close Button Visibility Tests
+# ============================================
+
+class TestCloseButtonVisibility:
+    """Close (X) button must be visible and functional on all viewports."""
+
+    def test_close_button_exists_in_html(self, base_soup):
+        """chatbot-minimize button exists in the DOM."""
+        btn = base_soup.find('button', class_='chatbot-minimize')
+        assert btn is not None, 'Close button (.chatbot-minimize) must exist in base.html'
+
+    def test_close_button_has_aria_label(self, base_soup):
+        """Close button has aria-label='Close chatbot'."""
+        btn = base_soup.find('button', class_='chatbot-minimize')
+        assert btn.get('aria-label') == 'Close chatbot', \
+            'Close button must have aria-label="Close chatbot"'
+
+    def test_close_button_has_aria_controls(self, base_soup):
+        """Close button has aria-controls pointing to chatbot-panel."""
+        btn = base_soup.find('button', class_='chatbot-minimize')
+        assert btn.get('aria-controls') == 'chatbot-panel', \
+            'Close button must have aria-controls="chatbot-panel"'
+
+    def test_close_button_contains_x_symbol(self, base_soup):
+        """Close button contains × symbol."""
+        btn = base_soup.find('button', class_='chatbot-minimize')
+        assert '×' in btn.get_text(), 'Close button must contain × symbol'
+
+    def test_close_button_not_hidden_by_css(self, chatbot_css):
+        """No CSS rule hides .chatbot-minimize at any breakpoint."""
+        # Check that chatbot-minimize is never set to display:none or visibility:hidden
+        minimize_blocks = re.findall(
+            r'\.chatbot-minimize[^{]*\{([^}]+)\}', chatbot_css
+        )
+        for block in minimize_blocks:
+            assert 'display: none' not in block and 'display:none' not in block, \
+                '.chatbot-minimize must never have display:none'
+            assert 'visibility: hidden' not in block and 'visibility:hidden' not in block, \
+                '.chatbot-minimize must never have visibility:hidden'
+
+    def test_close_button_is_keyboard_focusable(self, chatbot_css):
+        """Close button has focus styles (keyboard accessible)."""
+        assert '.chatbot-minimize:focus' in chatbot_css, \
+            '.chatbot-minimize must have :focus styles for keyboard accessibility'
+
+
+# ============================================
+# FAB Hidden When Chatbot Open Tests
+# ============================================
+
+class TestFabHiddenWhenOpen:
+    """FAB must be hidden when chatbot is open on ALL viewports."""
+
+    def test_fab_hidden_base_rule(self, chatbot_css):
+        """Base rule hides FAB when aria-expanded='true' (opacity:0, pointer-events:none)."""
+        # Find the base (non-media-query) rule for .chatbot-fab[aria-expanded="true"]
+        match = re.search(
+            r'\.chatbot-fab\[aria-expanded="true"\]\s*\{([^}]+)\}',
+            chatbot_css
+        )
+        assert match, 'Base rule for .chatbot-fab[aria-expanded="true"] must exist'
+        rule_body = match.group(1)
+        assert 'opacity' in rule_body and '0' in rule_body, \
+            'FAB must have opacity:0 when expanded'
+        assert 'pointer-events' in rule_body and 'none' in rule_body, \
+            'FAB must have pointer-events:none when expanded'
+
+    def test_no_desktop_fab_visible_override(self, chatbot_css):
+        """No media query overrides FAB to be visible when expanded."""
+        # Extract all media query blocks
+        media_blocks = re.findall(
+            r'@media[^{]+\{((?:[^{}]|\{[^}]*\})*)\}',
+            chatbot_css
+        )
+        for block in media_blocks:
+            # Check if any rule re-enables FAB when expanded
+            fab_expanded = re.findall(
+                r'\.chatbot-fab\[aria-expanded="true"\]\s*\{([^}]+)\}',
+                block
+            )
+            for rule_body in fab_expanded:
+                assert 'opacity: 1' not in rule_body and 'opacity:1' not in rule_body, \
+                    'No media query should override FAB opacity to 1 when expanded'
+                assert 'pointer-events: auto' not in rule_body and 'pointer-events:auto' not in rule_body, \
+                    'No media query should override FAB pointer-events to auto when expanded'
+
+    def test_no_fab_shift_right_when_expanded(self, chatbot_css):
+        """FAB should not shift position when expanded (old behavior removed)."""
+        media_blocks = re.findall(
+            r'@media[^{]+\{((?:[^{}]|\{[^}]*\})*)\}',
+            chatbot_css
+        )
+        for block in media_blocks:
+            fab_expanded = re.findall(
+                r'\.chatbot-fab\[aria-expanded="true"\]\s*\{([^}]+)\}',
+                block
+            )
+            for rule_body in fab_expanded:
+                assert 'right: 376px' not in rule_body, \
+                    'FAB should not shift to right:376px when expanded (old tablet behavior)'
+                assert 'right: 456px' not in rule_body, \
+                    'FAB should not shift to right:456px when expanded (old desktop behavior)'
+
+
+# ============================================
+# FAB Reappears After Close Tests
+# ============================================
+
+class TestFabReappearsAfterClose:
+    """FAB must reappear when chatbot is closed."""
+
+    def test_close_sets_aria_expanded_false(self, chatbot_js):
+        """closeChatbot() sets aria-expanded='false' on FAB."""
+        close_match = re.search(
+            r'closeChatbot\s*\(\)\s*\{([\s\S]*?)\n    \}',
+            chatbot_js
+        )
+        assert close_match, 'closeChatbot method must exist'
+        body = close_match.group(1)
+        assert "aria-expanded" in body and "'false'" in body, \
+            'closeChatbot must set aria-expanded to false'
+
+    def test_close_hides_panel(self, chatbot_js):
+        """closeChatbot() sets aria-hidden='true' on panel."""
+        close_match = re.search(
+            r'closeChatbot\s*\(\)\s*\{([\s\S]*?)\n    \}',
+            chatbot_js
+        )
+        body = close_match.group(1)
+        assert "aria-hidden" in body and "'true'" in body, \
+            'closeChatbot must set panel aria-hidden to true'
+
+    def test_close_returns_focus_to_fab(self, chatbot_js):
+        """closeChatbot() returns focus to FAB."""
+        close_match = re.search(
+            r'closeChatbot\s*\(\)\s*\{([\s\S]*?)\n    \}',
+            chatbot_js
+        )
+        body = close_match.group(1)
+        assert 'this.fab.focus()' in body, \
+            'closeChatbot must return focus to FAB'
+
+
+# ============================================
+# Re-opening After Close Tests
+# ============================================
+
+class TestReopenAfterClose:
+    """Clicking FAB after closing chatbot must re-open the panel."""
+
+    def test_expand_sets_aria_expanded_true(self, chatbot_js):
+        """expand() sets aria-expanded='true' on FAB."""
+        expand_match = re.search(
+            r'expand\s*\(\)\s*\{([\s\S]*?)\n    \}',
+            chatbot_js
+        )
+        assert expand_match, 'expand method must exist'
+        body = expand_match.group(1)
+        assert "aria-expanded" in body and "'true'" in body, \
+            'expand must set aria-expanded to true'
+
+    def test_expand_shows_panel(self, chatbot_js):
+        """expand() sets aria-hidden='false' on panel."""
+        expand_match = re.search(
+            r'expand\s*\(\)\s*\{([\s\S]*?)\n    \}',
+            chatbot_js
+        )
+        body = expand_match.group(1)
+        assert "aria-hidden" in body and "'false'" in body, \
+            'expand must set panel aria-hidden to false'
+
+
+# ============================================
+# Keyboard Dismiss Tests
+# ============================================
+
+class TestKeyboardDismiss:
+    """Escape key must close the chatbot."""
+
+    def test_escape_key_handler_exists(self, chatbot_js):
+        """Document keydown listener checks for Escape when expanded."""
+        assert "'Escape'" in chatbot_js or '"Escape"' in chatbot_js, \
+            'Escape key handler must exist'
+        assert 'closeChatbot' in chatbot_js, \
+            'Escape handler must call closeChatbot'
+
+
+# ============================================
+# Consistency Tests
+# ============================================
+
+class TestConsistentBehavior:
+    """Behavior must be consistent across mobile, tablet, and desktop."""
+
+    def test_no_viewport_specific_fab_expanded_overrides(self, chatbot_css):
+        """No breakpoint-specific overrides for FAB expanded state exist."""
+        # The only .chatbot-fab[aria-expanded="true"] rule should be the base one
+        all_fab_expanded = re.findall(
+            r'\.chatbot-fab\[aria-expanded="true"\]',
+            chatbot_css
+        )
+        # Count occurrences — should be exactly 1 (the base rule)
+        assert len(all_fab_expanded) == 1, \
+            f'Expected exactly 1 .chatbot-fab[aria-expanded="true"] rule (base), found {len(all_fab_expanded)}'
+
+    def test_minimize_button_wired_to_close(self, chatbot_js):
+        """Minimize button click handler calls closeChatbot()."""
+        assert 'this.minimizeBtn.addEventListener' in chatbot_js, \
+            'minimizeBtn must have event listener'
+        assert 'closeChatbot' in chatbot_js, \
+            'minimizeBtn click must call closeChatbot'
+
+
+# ============================================
+# Security Tests
+# ============================================
+
+class TestSecurity:
+    """No unsafe template filters added."""
+
+    def test_no_safe_filter_in_chatbot_html(self, base_html):
+        """No | safe filter on dynamic content near chatbot markup."""
+        # Find chatbot section in base.html
+        chatbot_start = base_html.find('id="chatbot-fab"')
+        chatbot_end = base_html.find('</aside>', chatbot_start) if chatbot_start != -1 else -1
+        if chatbot_start != -1 and chatbot_end != -1:
+            chatbot_section = base_html[chatbot_start:chatbot_end]
+            assert '| safe' not in chatbot_section, \
+                'No | safe filter should be used in chatbot HTML section'
+
+
+# ============================================
+# CSS No Inline Styles Tests
+# ============================================
+
+class TestNoInlineStyles:
+    """All hiding/showing must use CSS classes or aria attributes, not inline styles."""
+
+    def test_js_does_not_inline_style_fab_display(self, chatbot_js):
+        """JS does not set fab.style.display or fab.style.visibility."""
+        assert 'this.fab.style.display' not in chatbot_js, \
+            'FAB visibility must be controlled via aria attributes and CSS, not inline styles'
+        assert 'this.fab.style.visibility' not in chatbot_js, \
+            'FAB visibility must not use inline visibility style'
+        assert 'this.fab.style.opacity' not in chatbot_js, \
+            'FAB visibility must not use inline opacity style'

--- a/tests/test_us324_responsive_layouts.py
+++ b/tests/test_us324_responsive_layouts.py
@@ -91,48 +91,13 @@ class TestTabletMediaQuery(unittest.TestCase):
         header_block = block[header_idx:header_idx + 100]
         self.assertIn('border-radius: 0', header_block)
 
-    def test_tablet_fab_transition_includes_right(self):
-        """FAB must transition 'right' property for smooth position shift on tablet."""
+    def test_tablet_fab_hidden_when_panel_open(self):
+        """FAB must be hidden (no visibility override) when panel is open on tablet (Bug #287)."""
         idx = self.css.find('@media (min-width: 768px)')
         block = self.css[idx:idx + 2000]
-        # FAB transition override must include 'right'
-        fab_transition_idx = block.find('.chatbot-fab {')
-        self.assertGreater(fab_transition_idx, 0)
-        fab_block = block[fab_transition_idx:fab_transition_idx + 200]
-        self.assertIn('right', fab_block)
-        self.assertIn('transition:', fab_block)
-
-    def test_tablet_fab_visible_when_panel_open(self):
-        """FAB must remain visible (opacity: 1) when panel is open on tablet."""
-        idx = self.css.find('@media (min-width: 768px)')
-        block = self.css[idx:idx + 2000]
-        # aria-expanded true rule must set opacity: 1 (not 0)
-        expanded_idx = block.find('[aria-expanded="true"]')
-        self.assertGreater(expanded_idx, 0)
-        expanded_block = block[expanded_idx:expanded_idx + 200]
-        self.assertIn('opacity: 1', expanded_block)
-
-    def test_tablet_fab_pointer_events_auto_when_open(self):
-        """FAB must have pointer-events: auto when panel is open on tablet."""
-        idx = self.css.find('@media (min-width: 768px)')
-        block = self.css[idx:idx + 2000]
-        expanded_idx = block.find('[aria-expanded="true"]')
-        expanded_block = block[expanded_idx:expanded_idx + 200]
-        self.assertIn('pointer-events: auto', expanded_block)
-
-    def test_tablet_fab_shifts_right_376px_when_panel_open(self):
-        """FAB must be at right: 376px when panel is open on tablet (360px + 16px)."""
-        idx = self.css.find('@media (min-width: 768px)')
-        block = self.css[idx:idx + 2000]
-        self.assertIn('right: 376px', block)
-
-    def test_tablet_fab_transform_none_when_panel_open(self):
-        """FAB must reset transform to none when panel is open on tablet."""
-        idx = self.css.find('@media (min-width: 768px)')
-        block = self.css[idx:idx + 2000]
-        expanded_idx = block.find('[aria-expanded="true"]')
-        expanded_block = block[expanded_idx:expanded_idx + 200]
-        self.assertIn('transform: none', expanded_block)
+        # No aria-expanded="true" override should exist in the tablet media query
+        self.assertNotIn('.chatbot-fab[aria-expanded="true"]', block,
+            'Tablet media query must not override FAB expanded state — FAB should hide on all viewports')
 
 
 class TestDesktopMediaQuery(unittest.TestCase):
@@ -151,11 +116,12 @@ class TestDesktopMediaQuery(unittest.TestCase):
         block = self.css[idx:idx + 2000]
         self.assertIn('width: 440px', block)
 
-    def test_desktop_fab_shifts_right_456px_when_panel_open(self):
-        """FAB must be at right: 456px when panel is open on desktop (440px + 16px)."""
+    def test_desktop_fab_hidden_when_panel_open(self):
+        """FAB must be hidden (no visibility override) when panel is open on desktop (Bug #287)."""
         idx = self.css.find('@media (min-width: 1024px)')
         block = self.css[idx:idx + 2000]
-        self.assertIn('right: 456px', block)
+        self.assertNotIn('.chatbot-fab[aria-expanded="true"]', block,
+            'Desktop media query must not override FAB expanded state — FAB should hide on all viewports')
 
     def test_desktop_fab_hover_scale_108(self):
         """FAB hover must scale to 1.08 on desktop."""

--- a/tests/test_us421_three_state_chatbot.py
+++ b/tests/test_us421_three_state_chatbot.py
@@ -154,16 +154,13 @@ class TestBinaryModelCSS(unittest.TestCase):
         self.assertIn('opacity: 0', rule)
         self.assertIn('pointer-events: none', rule)
 
-    def test_fab_shifts_right_on_tablet(self):
-        """FAB [aria-expanded='true'] on tablet must shift left to accommodate panel."""
+    def test_fab_hidden_on_tablet_when_expanded(self):
+        """FAB must be hidden on tablet when expanded — no override keeping it visible (Bug #287)."""
         idx = self.css.find('@media (min-width: 768px)')
         self.assertGreater(idx, 0)
         block = self.css[idx:idx + 2000]
-        self.assertIn('.chatbot-fab[aria-expanded="true"]', block)
-        fab_expanded_idx = block.find('.chatbot-fab[aria-expanded="true"]')
-        rule = block[fab_expanded_idx:fab_expanded_idx + 200]
-        self.assertIn('opacity: 1', rule)
-        self.assertIn('pointer-events: auto', rule)
+        self.assertNotIn('.chatbot-fab[aria-expanded="true"]', block,
+            'Tablet media query must not override FAB expanded state')
 
     def test_panel_slides_down_when_hidden(self):
         """Panel must start with translateY(100%) to be hidden below viewport."""


### PR DESCRIPTION
Fixes #287

## Summary
- Removed 768px+ and 1024px+ CSS overrides that kept the FAB visible (shifted right) when chatbot panel was open
- FAB now consistently hides via `opacity:0; pointer-events:none` on all viewports when `aria-expanded="true"`
- Close (×) button was already in HTML — now the only dismiss mechanism on all viewports (consistent behavior)
- 3 existing tests updated + 19 new tests covering close button visibility, FAB hiding, accessibility, keyboard dismiss, and cross-viewport consistency

## Testing
- ✅ All unit tests passing
- ✅ QA verification complete