### PR TITLE
US-295.2: Bitcoin/Liquidity dimension walk-forward validation

### DIFF
--- a/signaltrackers/backtesting/bitcoin_liquidity_backtest.py
+++ b/signaltrackers/backtesting/bitcoin_liquidity_backtest.py
@@ -1,0 +1,823 @@
+"""
+Bitcoin / Liquidity Dimension Validation — Walk-Forward Backtest
+
+Tests whether the Liquidity dimension (Expanding/Neutral/Contracting) predicts
+Bitcoin 90-day forward returns.  This is SEPARATE from the main composite
+backtest — Bitcoin is orthogonal to the Growth×Inflation quadrant but
+correlates 0.94 with global M2 (~90-day lag, per Lyn Alden research).
+
+The result informs how Phase 11 presents conditions context on the crypto page:
+  - Strong accuracy → "Liquidity is expanding — historically favorable for Bitcoin (X% accuracy)"
+  - Weak accuracy → honest acknowledgment of limited macro signal
+
+Usage:
+    PYTHONPATH=signaltrackers python3 signaltrackers/backtesting/bitcoin_liquidity_backtest.py
+
+Output is written to signaltrackers/backtesting/results/
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+import warnings
+from datetime import datetime
+from itertools import combinations
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+from signaltrackers.backtesting.regime_backtest import (
+    load_csv,
+    compute_forward_return,
+    NEUTRAL_THRESHOLD,
+)
+from signaltrackers.market_conditions import compute_liquidity_history
+
+warnings.filterwarnings('ignore', category=FutureWarning)
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+RESULTS_DIR = Path(__file__).resolve().parent / 'results'
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+FORWARD_WINDOW = 90  # 90-day forward returns (matches M2 lag hypothesis)
+EVAL_FREQUENCY_MONTHS = 1  # Monthly evaluation dates
+
+# Bitcoin data starts Sep 2014; liquidity history starts earlier.
+# Use 2014 as start year for the validation window.
+FOLD_START_YEAR = 2014
+FOLD_END_YEAR = 2025
+FOLD_TEST_MONTHS = 24  # 2-year test windows (same as main backtest)
+
+# ---------------------------------------------------------------------------
+# Liquidity → Bitcoin directional expectations
+# ---------------------------------------------------------------------------
+
+# Expanding liquidity → historically favorable for Bitcoin (risk-on + M2 correlation)
+# Contracting liquidity → historically unfavorable
+# Neutral → no strong directional signal
+LIQUIDITY_EXPECTATIONS = {
+    'Strongly Expanding': 'positive',
+    'Expanding': 'positive',
+    'Neutral': 'neutral',
+    'Contracting': 'negative',
+    'Strongly Contracting': 'negative',
+}
+
+# Simplified 3-bucket grouping for reporting
+LIQUIDITY_BUCKETS = {
+    'Strongly Expanding': 'Expanding',
+    'Expanding': 'Expanding',
+    'Neutral': 'Neutral',
+    'Contracting': 'Contracting',
+    'Strongly Contracting': 'Contracting',
+}
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+
+def load_bitcoin_price() -> Optional[pd.Series]:
+    """Load Bitcoin daily price series."""
+    return load_csv('bitcoin_price')
+
+
+# ---------------------------------------------------------------------------
+# Walk-forward fold generation
+# ---------------------------------------------------------------------------
+
+
+def generate_folds(
+    start_year: int = FOLD_START_YEAR,
+    end_year: int = FOLD_END_YEAR,
+    test_months: int = FOLD_TEST_MONTHS,
+) -> list[dict]:
+    """
+    Generate walk-forward expanding window folds.
+
+    Same methodology as the main conditions backtest.
+    """
+    folds = []
+    test_start_year = start_year
+    step_years = test_months // 12
+    fold_num = 1
+
+    while test_start_year < end_year:
+        test_end_year = min(test_start_year + step_years, end_year)
+        folds.append({
+            'fold': fold_num,
+            'test_start': pd.Timestamp(f'{test_start_year}-01-01'),
+            'test_end': pd.Timestamp(f'{test_end_year}-01-01') - pd.Timedelta(days=1),
+        })
+        test_start_year = test_end_year
+        fold_num += 1
+
+    return folds
+
+
+# ---------------------------------------------------------------------------
+# Core backtest
+# ---------------------------------------------------------------------------
+
+
+def run_bitcoin_liquidity_backtest(
+    liquidity_history: pd.DataFrame,
+    bitcoin_price: pd.Series,
+    start_year: int = FOLD_START_YEAR,
+    end_year: int = FOLD_END_YEAR,
+) -> pd.DataFrame:
+    """
+    Run the Bitcoin / Liquidity validation over monthly evaluation dates.
+
+    For each evaluation date:
+      1. Get the liquidity state (point-in-time, no lookahead)
+      2. Map to expected Bitcoin direction
+      3. Compute 90-day forward Bitcoin return
+      4. Score directional accuracy
+
+    Returns DataFrame with one row per evaluation date.
+    """
+    # Need 90 days of forward data
+    last_btc_date = bitcoin_price.index[-1]
+    end_date = min(
+        pd.Timestamp(f'{end_year}-12-31'),
+        last_btc_date - pd.Timedelta(days=FORWARD_WINDOW),
+    )
+
+    # Bitcoin reliable data starts mid-Sep 2014
+    btc_start = bitcoin_price.index[0]
+    start_date = max(pd.Timestamp(f'{start_year}-01-01'), btc_start)
+
+    eval_dates = pd.date_range(
+        start=start_date,
+        end=end_date,
+        freq=f'{EVAL_FREQUENCY_MONTHS}ME',
+    )
+
+    rows = []
+    for eval_date in eval_dates:
+        # Get liquidity state at eval_date (no lookahead)
+        mask = liquidity_history['date'] <= eval_date
+        subset = liquidity_history[mask]
+        if subset.empty:
+            continue
+
+        liq_row = subset.iloc[-1]
+        liq_state = liq_row['state']
+        liq_score = liq_row['score']
+
+        # Map to 3-bucket
+        liq_bucket = LIQUIDITY_BUCKETS.get(liq_state, 'Neutral')
+        expected_direction = LIQUIDITY_EXPECTATIONS.get(liq_state, 'neutral')
+
+        # Forward returns at multiple windows for context
+        fwd_90d = compute_forward_return(bitcoin_price, eval_date, 90)
+        fwd_30d = compute_forward_return(bitcoin_price, eval_date, 30)
+        fwd_60d = compute_forward_return(bitcoin_price, eval_date, 60)
+
+        if fwd_90d is None:
+            continue
+
+        # Score directional accuracy
+        if expected_direction == 'positive':
+            correct = 1.0 if fwd_90d > 0 else 0.0
+        elif expected_direction == 'negative':
+            correct = 1.0 if fwd_90d < 0 else 0.0
+        elif expected_direction == 'neutral':
+            correct = 1.0 if abs(fwd_90d) < NEUTRAL_THRESHOLD else 0.5
+        else:
+            correct = 0.5
+
+        rows.append({
+            'date': eval_date.strftime('%Y-%m-%d'),
+            'liquidity_state': liq_state,
+            'liquidity_bucket': liq_bucket,
+            'liquidity_score': round(liq_score, 4),
+            'expected_direction': expected_direction,
+            'btc_fwd_30d': fwd_30d,
+            'btc_fwd_60d': fwd_60d,
+            'btc_fwd_90d': fwd_90d,
+            'correct': correct,
+        })
+
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+def score_results(df: pd.DataFrame) -> dict:
+    """Compute aggregate accuracy metrics per liquidity state."""
+    report = {
+        'overall': {},
+        'per_state': {},
+        'per_bucket': {},
+    }
+
+    # Overall accuracy
+    valid = df['correct'].dropna()
+    if not valid.empty:
+        report['overall']['accuracy'] = round(float(valid.mean()) * 100, 1)
+        report['overall']['total_evaluations'] = int(len(valid))
+        report['overall']['correct_count'] = int(valid.sum())
+
+    # Per liquidity state (5-state)
+    for state in LIQUIDITY_EXPECTATIONS:
+        mask = df['liquidity_state'] == state
+        subset = df[mask]
+        if subset.empty:
+            report['per_state'][state] = {'count': 0}
+            continue
+
+        state_correct = subset['correct'].dropna()
+        stats = {
+            'count': int(len(subset)),
+            'expected_direction': LIQUIDITY_EXPECTATIONS[state],
+        }
+        if not state_correct.empty:
+            stats['accuracy'] = round(float(state_correct.mean()) * 100, 1)
+            stats['correct_count'] = int(state_correct.sum())
+
+        # Average forward returns
+        for w in [30, 60, 90]:
+            col = f'btc_fwd_{w}d'
+            if col in subset.columns:
+                fwd_valid = subset[col].dropna()
+                if not fwd_valid.empty:
+                    stats[f'avg_fwd_{w}d'] = round(float(fwd_valid.mean()) * 100, 2)
+                    stats[f'median_fwd_{w}d'] = round(float(fwd_valid.median()) * 100, 2)
+
+        report['per_state'][state] = stats
+
+    # Per bucket (3-bucket: Expanding/Neutral/Contracting)
+    for bucket in ['Expanding', 'Neutral', 'Contracting']:
+        mask = df['liquidity_bucket'] == bucket
+        subset = df[mask]
+        if subset.empty:
+            report['per_bucket'][bucket] = {'count': 0}
+            continue
+
+        bucket_correct = subset['correct'].dropna()
+        stats = {'count': int(len(subset))}
+        if not bucket_correct.empty:
+            stats['accuracy'] = round(float(bucket_correct.mean()) * 100, 1)
+            stats['correct_count'] = int(bucket_correct.sum())
+
+        # Average 90d forward returns
+        fwd_valid = subset['btc_fwd_90d'].dropna()
+        if not fwd_valid.empty:
+            stats['avg_fwd_90d'] = round(float(fwd_valid.mean()) * 100, 2)
+            stats['median_fwd_90d'] = round(float(fwd_valid.median()) * 100, 2)
+            stats['pct_positive'] = round(
+                float((fwd_valid > 0).mean()) * 100, 1
+            )
+
+        report['per_bucket'][bucket] = stats
+
+    # Return magnitude ordering: Expanding > Neutral > Contracting
+    bucket_returns = {}
+    for bucket in ['Expanding', 'Neutral', 'Contracting']:
+        avg = report['per_bucket'].get(bucket, {}).get('avg_fwd_90d')
+        if avg is not None:
+            bucket_returns[bucket] = avg
+    if len(bucket_returns) >= 2:
+        ordered_vals = [bucket_returns.get(b) for b in ['Expanding', 'Neutral', 'Contracting'] if b in bucket_returns]
+        report['overall']['return_ordering_correct'] = all(
+            ordered_vals[i] >= ordered_vals[i + 1]
+            for i in range(len(ordered_vals) - 1)
+        )
+        report['overall']['avg_fwd_90d_by_bucket'] = bucket_returns
+
+    return report
+
+
+def score_walk_forward(
+    df: pd.DataFrame,
+    folds: list[dict],
+) -> dict:
+    """Score each walk-forward fold. Same structure as main backtest."""
+    fold_scores = []
+    fold_details = []
+
+    for fold in folds:
+        mask = (
+            (df['date'] >= fold['test_start'].strftime('%Y-%m-%d'))
+            & (df['date'] <= fold['test_end'].strftime('%Y-%m-%d'))
+        )
+        fold_df = df[mask]
+
+        if fold_df.empty:
+            fold_details.append({
+                'fold': fold['fold'],
+                'test_start': fold['test_start'].strftime('%Y-%m-%d'),
+                'test_end': fold['test_end'].strftime('%Y-%m-%d'),
+                'evaluations': 0,
+                'score': None,
+            })
+            continue
+
+        valid_scores = fold_df['correct'].dropna()
+        if valid_scores.empty:
+            continue
+
+        fold_score = float(valid_scores.mean()) * 100
+        fold_scores.append(fold_score)
+
+        # Per-bucket counts
+        bucket_counts = fold_df['liquidity_bucket'].value_counts().to_dict()
+
+        fold_details.append({
+            'fold': fold['fold'],
+            'test_start': fold['test_start'].strftime('%Y-%m-%d'),
+            'test_end': fold['test_end'].strftime('%Y-%m-%d'),
+            'evaluations': int(len(valid_scores)),
+            'score': round(fold_score, 1),
+            'bucket_counts': bucket_counts,
+        })
+
+    if not fold_scores:
+        return {'fold_details': fold_details, 'mean': None, 'std': None, 'sharpe': None}
+
+    mean_score = float(np.mean(fold_scores))
+    std_score = float(np.std(fold_scores, ddof=1)) if len(fold_scores) > 1 else 0.0
+    sharpe = mean_score / std_score if std_score > 0 else float('inf')
+
+    return {
+        'fold_details': fold_details,
+        'fold_scores': [round(s, 1) for s in fold_scores],
+        'mean': round(mean_score, 1),
+        'std': round(std_score, 1),
+        'sharpe': round(sharpe, 2),
+        'n_folds': len(fold_scores),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CPCV — Combinatorial Purged Cross-Validation
+# ---------------------------------------------------------------------------
+
+
+def run_cpcv(
+    df: pd.DataFrame,
+    k: int = 6,
+    p: int = 2,
+    purge_months: int = 3,
+    embargo_months: int = 1,
+) -> dict:
+    """Run CPCV on the Bitcoin/Liquidity validation results."""
+    df_sorted = df.sort_values('date').reset_index(drop=True)
+    dates = pd.to_datetime(df_sorted['date'])
+    n = len(df_sorted)
+
+    if n < k:
+        return {'pbo': None, 'n_paths': 0}
+
+    group_size = n // k
+    groups = []
+    for i in range(k):
+        start_idx = i * group_size
+        end_idx = start_idx + group_size if i < k - 1 else n
+        groups.append(list(range(start_idx, end_idx)))
+
+    test_combos = list(combinations(range(k), p))
+
+    oos_scores = []
+    is_scores = []
+
+    for combo in test_combos:
+        test_indices = set()
+        for g in combo:
+            test_indices.update(groups[g])
+
+        train_indices = set(range(n)) - test_indices
+
+        purge_days = purge_months * 30
+        embargo_days = embargo_months * 30
+
+        test_dates = dates.iloc[sorted(test_indices)]
+        if test_dates.empty:
+            continue
+
+        test_start = test_dates.min()
+        test_end = test_dates.max()
+
+        purged_train = set()
+        for idx in train_indices:
+            obs_date = dates.iloc[idx]
+            if (test_start - pd.Timedelta(days=purge_days)) <= obs_date < test_start:
+                continue
+            if test_end < obs_date <= (test_end + pd.Timedelta(days=embargo_days)):
+                continue
+            purged_train.add(idx)
+
+        test_df = df_sorted.iloc[sorted(test_indices)]
+        test_scores = test_df['correct'].dropna()
+        if test_scores.empty:
+            continue
+        oos_score = float(test_scores.mean())
+
+        train_df = df_sorted.iloc[sorted(purged_train)]
+        train_scores = train_df['correct'].dropna()
+        if train_scores.empty:
+            continue
+        is_score = float(train_scores.mean())
+
+        oos_scores.append(oos_score)
+        is_scores.append(is_score)
+
+    if not oos_scores:
+        return {'pbo': None, 'n_paths': 0}
+
+    n_overfit = sum(1 for oos, ins in zip(oos_scores, is_scores) if oos < ins)
+    pbo = n_overfit / len(oos_scores)
+
+    return {
+        'pbo': round(pbo, 3),
+        'n_paths': len(oos_scores),
+        'oos_mean': round(float(np.mean(oos_scores)) * 100, 1),
+        'oos_std': round(float(np.std(oos_scores)) * 100, 1),
+        'is_mean': round(float(np.mean(is_scores)) * 100, 1),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Plausibility checks
+# ---------------------------------------------------------------------------
+
+
+def check_plausibility(df: pd.DataFrame) -> dict:
+    """
+    Economic plausibility checks specific to Bitcoin/Liquidity.
+
+    1. 2020-2021 liquidity expansion should predict bullish Bitcoin (expected: yes)
+    2. 2022 liquidity contraction should predict bearish Bitcoin (expected: yes)
+    """
+    checks = {}
+
+    # Check 1: During 2020-2021 expansion, model should predict bullish
+    expansion_period = df[
+        (df['date'] >= '2020-06-01') & (df['date'] <= '2021-12-31')
+    ]
+    if not expansion_period.empty:
+        expanding_evals = expansion_period[
+            expansion_period['liquidity_bucket'] == 'Expanding'
+        ]
+        expanding_pct = len(expanding_evals) / len(expansion_period)
+        checks['2020_2021_liquidity_expansion'] = {
+            'pass': bool(expanding_pct > 0.5),
+            'expanding_pct': round(expanding_pct * 100, 1),
+            'expanding_count': int(len(expanding_evals)),
+            'total_count': int(len(expansion_period)),
+            'note': 'Majority of evals should classify as Expanding during 2020-2021 QE',
+        }
+    else:
+        checks['2020_2021_liquidity_expansion'] = {
+            'pass': True,
+            'note': 'No evaluation dates in range',
+        }
+
+    # Check 2: During 2022, model should see contraction
+    contraction_period = df[
+        (df['date'] >= '2022-01-01') & (df['date'] <= '2022-12-31')
+    ]
+    if not contraction_period.empty:
+        contracting_evals = contraction_period[
+            contraction_period['liquidity_bucket'] == 'Contracting'
+        ]
+        contracting_pct = len(contracting_evals) / len(contraction_period)
+        checks['2022_liquidity_contraction'] = {
+            'pass': bool(contracting_pct > 0.3),  # At least 30% contracting
+            'contracting_pct': round(contracting_pct * 100, 1),
+            'contracting_count': int(len(contracting_evals)),
+            'total_count': int(len(contraction_period)),
+            'note': 'Contraction should be present during 2022 QT',
+        }
+    else:
+        checks['2022_liquidity_contraction'] = {
+            'pass': True,
+            'note': 'No evaluation dates in range',
+        }
+
+    # Check 3: Expanding avg return > Contracting avg return
+    expanding_df = df[df['liquidity_bucket'] == 'Expanding']
+    contracting_df = df[df['liquidity_bucket'] == 'Contracting']
+    if not expanding_df.empty and not contracting_df.empty:
+        exp_avg = expanding_df['btc_fwd_90d'].dropna().mean()
+        con_avg = contracting_df['btc_fwd_90d'].dropna().mean()
+        checks['expanding_beats_contracting_returns'] = {
+            'pass': bool(exp_avg > con_avg),
+            'expanding_avg_90d': round(float(exp_avg) * 100, 2),
+            'contracting_avg_90d': round(float(con_avg) * 100, 2),
+            'note': 'Expanding liquidity should yield higher Bitcoin returns than Contracting',
+        }
+
+    all_pass = all(c.get('pass', False) for c in checks.values())
+    return {
+        'all_pass': all_pass,
+        'checks': checks,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Report generation
+# ---------------------------------------------------------------------------
+
+
+def generate_report(
+    df: pd.DataFrame,
+    agg_scores: dict,
+    wf_scores: dict,
+    plausibility: dict,
+    cpcv_result: dict,
+    baseline_accuracy: float = 34.8,
+) -> str:
+    """Generate comprehensive markdown backtest report for Bitcoin/Liquidity."""
+    lines = []
+    lines.append('# Bitcoin / Liquidity Dimension Validation Report')
+    lines.append(f'\nGenerated: {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}')
+    lines.append(f'Evaluation period: {df["date"].iloc[0]} to {df["date"].iloc[-1]}')
+    lines.append(f'Total evaluations: {len(df)}')
+    lines.append(f'Baseline (old regime model crypto accuracy): {baseline_accuracy}%')
+    lines.append('')
+    lines.append('This validation is SEPARATE from the main composite backtest.')
+    lines.append('Bitcoin correlates 0.94 with global M2 (~90-day lag). This tests')
+    lines.append('whether the Liquidity dimension predicts Bitcoin 90-day forward returns.')
+
+    # === Overall Accuracy ===
+    overall = agg_scores.get('overall', {})
+    accuracy = overall.get('accuracy')
+    if accuracy is not None:
+        delta = accuracy - baseline_accuracy
+        status = 'ABOVE' if delta > 0 else 'BELOW'
+        lines.append(f'\n## Overall Accuracy: {accuracy}% ({status} baseline: {"+" if delta > 0 else ""}{delta:.1f}pp)')
+    else:
+        lines.append('\n## Overall Accuracy: N/A')
+
+    # === Per-Bucket Breakdown ===
+    lines.append('\n## Per-Liquidity-State Accuracy (3-bucket)')
+    lines.append('')
+    lines.append('| Liquidity State | Count | Accuracy | Avg 90d Return | Median 90d Return | % Positive |')
+    lines.append('|-----------------|-------|----------|----------------|-------------------|------------|')
+    for bucket in ['Expanding', 'Neutral', 'Contracting']:
+        stats = agg_scores['per_bucket'].get(bucket, {})
+        count = stats.get('count', 0)
+        if count == 0:
+            lines.append(f'| {bucket} | 0 | — | — | — | — |')
+            continue
+        acc = f'{stats.get("accuracy", "—")}%' if 'accuracy' in stats else '—'
+        avg = f'{stats.get("avg_fwd_90d", "—")}%' if 'avg_fwd_90d' in stats else '—'
+        med = f'{stats.get("median_fwd_90d", "—")}%' if 'median_fwd_90d' in stats else '—'
+        pct = f'{stats.get("pct_positive", "—")}%' if 'pct_positive' in stats else '—'
+        lines.append(f'| {bucket} | {count} | {acc} | {avg} | {med} | {pct} |')
+
+    # Return ordering
+    ordering = overall.get('return_ordering_correct')
+    if ordering is not None:
+        lines.append(f'\nReturn magnitude ordering (Expanding > Neutral > Contracting): **{"PASS" if ordering else "FAIL"}**')
+        by_bucket = overall.get('avg_fwd_90d_by_bucket', {})
+        if by_bucket:
+            for b in ['Expanding', 'Neutral', 'Contracting']:
+                if b in by_bucket:
+                    lines.append(f'  - {b}: {by_bucket[b]}%')
+
+    # === Per-State Detail (5-state) ===
+    lines.append('\n## Per-Liquidity-State Detail (5-state)')
+    lines.append('')
+    lines.append('| State | Expected | Count | Accuracy | Avg 30d | Avg 60d | Avg 90d |')
+    lines.append('|-------|----------|-------|----------|---------|---------|---------|')
+    for state in ['Strongly Expanding', 'Expanding', 'Neutral', 'Contracting', 'Strongly Contracting']:
+        stats = agg_scores['per_state'].get(state, {})
+        count = stats.get('count', 0)
+        if count == 0:
+            lines.append(f'| {state} | {LIQUIDITY_EXPECTATIONS[state]} | 0 | — | — | — | — |')
+            continue
+        exp = stats.get('expected_direction', '—')
+        acc = f'{stats.get("accuracy", "—")}%' if 'accuracy' in stats else '—'
+        a30 = f'{stats.get("avg_fwd_30d", "—")}%' if 'avg_fwd_30d' in stats else '—'
+        a60 = f'{stats.get("avg_fwd_60d", "—")}%' if 'avg_fwd_60d' in stats else '—'
+        a90 = f'{stats.get("avg_fwd_90d", "—")}%' if 'avg_fwd_90d' in stats else '—'
+        lines.append(f'| {state} | {exp} | {count} | {acc} | {a30} | {a60} | {a90} |')
+
+    # === Walk-Forward Results ===
+    lines.append('\n## Walk-Forward Validation')
+    lines.append('')
+    if wf_scores.get('mean') is not None:
+        lines.append(f'- Mean fold score: {wf_scores["mean"]}%')
+        lines.append(f'- Std deviation: {wf_scores["std"]}%')
+        lines.append(f'- Sharpe-like ratio: {wf_scores["sharpe"]}')
+        lines.append(f'- Number of folds: {wf_scores["n_folds"]}')
+
+    lines.append('')
+    lines.append('| Fold | Period | Evaluations | Score |')
+    lines.append('|------|--------|-------------|-------|')
+    for fd in wf_scores.get('fold_details', []):
+        score_str = f'{fd["score"]}%' if fd.get('score') is not None else '—'
+        lines.append(
+            f'| {fd["fold"]} | {fd["test_start"]} to {fd["test_end"]} | '
+            f'{fd["evaluations"]} | {score_str} |'
+        )
+
+    # === CPCV ===
+    lines.append('\n## Combinatorial Purged Cross-Validation (CPCV)')
+    lines.append('')
+    if cpcv_result.get('pbo') is not None:
+        pbo = cpcv_result['pbo']
+        status = 'PASS' if pbo <= 0.5 else 'FAIL (likely overfit)'
+        lines.append(f'- PBO (Probability of Backtest Overfitting): {pbo} ({status})')
+        lines.append(f'- Number of paths tested: {cpcv_result["n_paths"]}')
+        lines.append(f'- OOS mean accuracy: {cpcv_result["oos_mean"]}%')
+        lines.append(f'- OOS std: {cpcv_result["oos_std"]}%')
+        lines.append(f'- IS mean accuracy: {cpcv_result["is_mean"]}%')
+    else:
+        lines.append('- CPCV could not be computed (insufficient data)')
+
+    # === Economic Plausibility ===
+    lines.append('\n## Economic Plausibility Checks')
+    lines.append('')
+    all_pass = plausibility.get('all_pass', False)
+    lines.append(f'**Overall: {"PASS" if all_pass else "FAIL"}**')
+    lines.append('')
+    for check_name, check_data in plausibility.get('checks', {}).items():
+        status = 'PASS' if check_data.get('pass') else 'FAIL'
+        lines.append(f'- **{check_name}**: {status}')
+        for k, v in check_data.items():
+            if k != 'pass':
+                lines.append(f'  - {k}: {v}')
+
+    # === Recommendation ===
+    lines.append('\n## Recommendation for Phase 11 Crypto Page')
+    lines.append('')
+
+    if accuracy is not None:
+        meaningful_improvement = accuracy > baseline_accuracy + 5  # > 5pp improvement
+        above_50 = accuracy > 50.0
+
+        if meaningful_improvement and above_50:
+            lines.append(f'**STRONG SIGNAL: {accuracy}% accuracy (vs {baseline_accuracy}% old regime model)**')
+            lines.append('')
+            lines.append('The Liquidity dimension provides a meaningful predictive signal for Bitcoin.')
+            lines.append('Recommended crypto page guidance:')
+            lines.append(f'> "Liquidity is [state] — historically [favorable/unfavorable] for Bitcoin ({accuracy:.0f}% accuracy)"')
+            lines.append('')
+            lines.append('This is a substantial improvement over the current regime-based crypto context.')
+        elif above_50:
+            lines.append(f'**MODERATE SIGNAL: {accuracy}% accuracy (vs {baseline_accuracy}% old regime model)**')
+            lines.append('')
+            lines.append('The Liquidity dimension provides some predictive signal for Bitcoin,')
+            lines.append('better than the old regime model but not overwhelmingly strong.')
+            lines.append('Recommended crypto page guidance:')
+            lines.append('> "Liquidity conditions may [favor/not favor] Bitcoin — signal is moderate"')
+        else:
+            lines.append(f'**WEAK SIGNAL: {accuracy}% accuracy (vs {baseline_accuracy}% old regime model)**')
+            lines.append('')
+            lines.append('The Liquidity dimension does not reliably predict Bitcoin direction.')
+            lines.append('Recommended crypto page guidance:')
+            lines.append('> "Macro conditions have limited predictive value for Bitcoin direction"')
+
+        # Per-state recommendations
+        lines.append('\n### Per-State Signal Strength')
+        for bucket in ['Expanding', 'Neutral', 'Contracting']:
+            stats = agg_scores['per_bucket'].get(bucket, {})
+            bucket_acc = stats.get('accuracy')
+            bucket_count = stats.get('count', 0)
+            if bucket_acc is not None and bucket_count >= 5:
+                strength = 'strong' if bucket_acc >= 60 else ('moderate' if bucket_acc >= 50 else 'weak')
+                lines.append(f'- **{bucket}** (n={bucket_count}): {bucket_acc}% accuracy — {strength} signal')
+
+    return '\n'.join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def main():
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    print('=' * 60)
+    print('  Bitcoin / Liquidity Dimension Validation')
+    print('=' * 60)
+
+    # Step 1: Load data
+    print('\nLoading liquidity history...')
+    liq_history = compute_liquidity_history('2010-01-01')
+    if liq_history is None or liq_history.empty:
+        print('ERROR: Cannot compute liquidity history.')
+        sys.exit(1)
+    print(f'  Liquidity: {len(liq_history)} points, '
+          f'{liq_history["date"].iloc[0].strftime("%Y-%m-%d")} to '
+          f'{liq_history["date"].iloc[-1].strftime("%Y-%m-%d")}')
+
+    print('\nLoading Bitcoin price data...')
+    btc_price = load_bitcoin_price()
+    if btc_price is None or btc_price.empty:
+        print('ERROR: No Bitcoin price data available (bitcoin_price.csv).')
+        sys.exit(1)
+    print(f'  Bitcoin: {len(btc_price)} points, '
+          f'{btc_price.index[0].strftime("%Y-%m-%d")} to '
+          f'{btc_price.index[-1].strftime("%Y-%m-%d")}')
+
+    # Step 2: Run backtest
+    print('\nRunning Bitcoin/Liquidity backtest...')
+    df = run_bitcoin_liquidity_backtest(liq_history, btc_price)
+    if df.empty:
+        print('ERROR: No results generated.')
+        sys.exit(1)
+    print(f'  {len(df)} evaluation dates scored')
+
+    # Save raw results
+    csv_path = RESULTS_DIR / 'bitcoin_liquidity_results.csv'
+    df.to_csv(csv_path, index=False)
+    print(f'  Raw results: {csv_path}')
+
+    # Step 3: Aggregate scoring
+    print('\nScoring results...')
+    agg_scores = score_results(df)
+    overall = agg_scores.get('overall', {})
+    accuracy = overall.get('accuracy')
+    print(f'  Overall accuracy: {accuracy}%')
+
+    # Step 4: Walk-forward validation
+    print('\nRunning walk-forward validation...')
+    folds = generate_folds()
+    wf_scores = score_walk_forward(df, folds)
+    print(f'  Mean fold score: {wf_scores.get("mean")}%')
+    print(f'  Std: {wf_scores.get("std")}%')
+    print(f'  Sharpe: {wf_scores.get("sharpe")}')
+
+    # Step 5: CPCV
+    print('\nRunning CPCV (k=6, p=2, purge=3mo, embargo=1mo)...')
+    cpcv_result = run_cpcv(df)
+    print(f'  PBO: {cpcv_result.get("pbo")}')
+
+    # Step 6: Economic plausibility
+    print('\nChecking economic plausibility...')
+    plausibility = check_plausibility(df)
+    print(f'  All checks pass: {plausibility["all_pass"]}')
+
+    # Step 7: Generate report
+    print('\nGenerating report...')
+    report = generate_report(
+        df, agg_scores, wf_scores, plausibility, cpcv_result,
+    )
+
+    report_path = RESULTS_DIR / 'bitcoin_liquidity_report.md'
+    with open(report_path, 'w') as f:
+        f.write(report)
+    print(f'  Report: {report_path}')
+
+    # Save structured results
+    structured = {
+        'overall': overall,
+        'walk_forward': wf_scores,
+        'per_state': agg_scores.get('per_state', {}),
+        'per_bucket': agg_scores.get('per_bucket', {}),
+        'plausibility': plausibility,
+        'cpcv': cpcv_result,
+    }
+    json_path = RESULTS_DIR / 'bitcoin_liquidity_scores.json'
+    with open(json_path, 'w') as f:
+        json.dump(structured, f, indent=2, default=str)
+    print(f'  Scores: {json_path}')
+
+    # Print summary
+    print('\n' + '=' * 60)
+    baseline = 34.8
+    if accuracy is not None:
+        delta = accuracy - baseline
+        print(f'  ACCURACY: {accuracy}% ({"+" if delta > 0 else ""}{delta:.1f}pp vs {baseline}% old regime)')
+    print('')
+    for bucket in ['Expanding', 'Neutral', 'Contracting']:
+        stats = agg_scores['per_bucket'].get(bucket, {})
+        if stats.get('count', 0) > 0:
+            acc = stats.get('accuracy', '—')
+            avg = stats.get('avg_fwd_90d', '—')
+            print(f'  {bucket}: {acc}% accurate, avg 90d return={avg}%')
+    print('')
+    if plausibility['all_pass']:
+        print('  Plausibility: PASS')
+    else:
+        print('  Plausibility: FAIL')
+    if cpcv_result.get('pbo') is not None:
+        print(f'  CPCV PBO: {cpcv_result["pbo"]} ({"PASS" if cpcv_result["pbo"] <= 0.5 else "FAIL"})')
+    print('=' * 60)
+
+    return accuracy
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_us2952_bitcoin_liquidity.py
+++ b/tests/test_us2952_bitcoin_liquidity.py
@@ -1,0 +1,782 @@
+"""
+Tests for US-295.2: Bitcoin / Liquidity Dimension Validation
+
+Tests the walk-forward backtest that validates whether the Liquidity dimension
+predicts Bitcoin 90-day forward returns.
+"""
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from signaltrackers.backtesting.bitcoin_liquidity_backtest import (
+    LIQUIDITY_EXPECTATIONS,
+    LIQUIDITY_BUCKETS,
+    FOLD_START_YEAR,
+    FOLD_END_YEAR,
+    FOLD_TEST_MONTHS,
+    FORWARD_WINDOW,
+    load_bitcoin_price,
+    generate_folds,
+    run_bitcoin_liquidity_backtest,
+    score_results,
+    score_walk_forward,
+    run_cpcv,
+    check_plausibility,
+    generate_report,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — synthetic data for deterministic tests
+# ---------------------------------------------------------------------------
+
+
+def _make_liquidity_history(
+    start='2013-01-01', end='2025-06-30', freq='W-FRI',
+    pattern='expanding',
+) -> pd.DataFrame:
+    """Create a synthetic liquidity history DataFrame."""
+    dates = pd.date_range(start=start, end=end, freq=freq)
+    if pattern == 'expanding':
+        scores = np.linspace(0.5, 1.5, len(dates))
+        states = ['Expanding'] * len(dates)
+    elif pattern == 'contracting':
+        scores = np.linspace(-0.5, -1.5, len(dates))
+        states = ['Contracting'] * len(dates)
+    elif pattern == 'mixed':
+        scores = np.sin(np.linspace(0, 8 * np.pi, len(dates)))
+        states = []
+        for s in scores:
+            if s > 0.8:
+                states.append('Strongly Expanding')
+            elif s > 0.2:
+                states.append('Expanding')
+            elif s > -0.2:
+                states.append('Neutral')
+            elif s > -0.8:
+                states.append('Contracting')
+            else:
+                states.append('Strongly Contracting')
+    else:
+        scores = np.zeros(len(dates))
+        states = ['Neutral'] * len(dates)
+
+    return pd.DataFrame({
+        'date': dates,
+        'score': scores,
+        'state': states,
+    })
+
+
+def _make_bitcoin_price(
+    start='2014-09-01', end='2025-06-30',
+    trend='up',
+) -> pd.Series:
+    """Create a synthetic Bitcoin price series."""
+    dates = pd.date_range(start=start, end=end, freq='D')
+    n = len(dates)
+    if trend == 'up':
+        prices = 500 * np.exp(np.linspace(0, 3, n))  # Exponential growth
+    elif trend == 'down':
+        prices = 50000 * np.exp(np.linspace(0, -1, n))
+    elif trend == 'flat':
+        prices = np.full(n, 30000.0)
+    else:
+        # Volatile / cyclical
+        base = 500 * np.exp(np.linspace(0, 2.5, n))
+        noise = np.sin(np.linspace(0, 20 * np.pi, n)) * 0.2
+        prices = base * (1 + noise)
+
+    return pd.Series(prices, index=dates, name='bitcoin_price')
+
+
+@pytest.fixture
+def mixed_liquidity():
+    return _make_liquidity_history(pattern='mixed')
+
+
+@pytest.fixture
+def expanding_liquidity():
+    return _make_liquidity_history(pattern='expanding')
+
+
+@pytest.fixture
+def btc_up():
+    return _make_bitcoin_price(trend='up')
+
+
+@pytest.fixture
+def btc_volatile():
+    return _make_bitcoin_price(trend='volatile')
+
+
+# ---------------------------------------------------------------------------
+# Configuration tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfiguration:
+    """Test backtest configuration constants."""
+
+    def test_liquidity_expectations_covers_all_states(self):
+        """All 5 liquidity states must have an expectation."""
+        expected_states = {
+            'Strongly Expanding', 'Expanding', 'Neutral',
+            'Contracting', 'Strongly Contracting',
+        }
+        assert set(LIQUIDITY_EXPECTATIONS.keys()) == expected_states
+
+    def test_liquidity_expectations_values(self):
+        """Expanding states should map to positive, contracting to negative."""
+        assert LIQUIDITY_EXPECTATIONS['Strongly Expanding'] == 'positive'
+        assert LIQUIDITY_EXPECTATIONS['Expanding'] == 'positive'
+        assert LIQUIDITY_EXPECTATIONS['Neutral'] == 'neutral'
+        assert LIQUIDITY_EXPECTATIONS['Contracting'] == 'negative'
+        assert LIQUIDITY_EXPECTATIONS['Strongly Contracting'] == 'negative'
+
+    def test_liquidity_buckets_covers_all_states(self):
+        """All 5 states must map to one of 3 buckets."""
+        assert set(LIQUIDITY_BUCKETS.keys()) == set(LIQUIDITY_EXPECTATIONS.keys())
+        assert set(LIQUIDITY_BUCKETS.values()) == {'Expanding', 'Neutral', 'Contracting'}
+
+    def test_forward_window_is_90(self):
+        """Forward window should be 90 days (M2 lag hypothesis)."""
+        assert FORWARD_WINDOW == 90
+
+    def test_fold_start_2014(self):
+        """Validation starts 2014 due to Bitcoin data availability."""
+        assert FOLD_START_YEAR == 2014
+
+    def test_fold_test_months_matches_main_backtest(self):
+        """2-year test windows, same as main conditions backtest."""
+        assert FOLD_TEST_MONTHS == 24
+
+
+# ---------------------------------------------------------------------------
+# Fold generation tests
+# ---------------------------------------------------------------------------
+
+
+class TestFoldGeneration:
+    """Test walk-forward fold generation."""
+
+    def test_generates_expected_number_of_folds(self):
+        folds = generate_folds(2014, 2025, 24)
+        # 2014-2015, 2016-2017, 2018-2019, 2020-2021, 2022-2023, 2024-2025
+        # = 6 folds (one fewer since last fold may be partial)
+        assert len(folds) >= 5
+
+    def test_folds_cover_full_period(self):
+        folds = generate_folds(2014, 2025, 24)
+        assert folds[0]['test_start'] == pd.Timestamp('2014-01-01')
+        assert folds[-1]['test_end'] >= pd.Timestamp('2024-01-01')
+
+    def test_folds_are_contiguous(self):
+        folds = generate_folds(2014, 2025, 24)
+        for i in range(len(folds) - 1):
+            # Next fold starts day after current fold ends (approx)
+            gap = (folds[i + 1]['test_start'] - folds[i]['test_end']).days
+            assert gap <= 2, f'Gap between fold {i} and {i+1}: {gap} days'
+
+    def test_fold_numbers_sequential(self):
+        folds = generate_folds()
+        for i, fold in enumerate(folds):
+            assert fold['fold'] == i + 1
+
+    def test_expanding_window(self):
+        """Each fold has access to all prior data (expanding window)."""
+        folds = generate_folds()
+        for i in range(1, len(folds)):
+            assert folds[i]['test_start'] > folds[i - 1]['test_start']
+
+
+# ---------------------------------------------------------------------------
+# Core backtest tests
+# ---------------------------------------------------------------------------
+
+
+class TestBacktest:
+    """Test the core walk-forward backtest logic."""
+
+    def test_returns_dataframe(self, mixed_liquidity, btc_up):
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+
+    def test_required_columns(self, mixed_liquidity, btc_up):
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        required = {
+            'date', 'liquidity_state', 'liquidity_bucket',
+            'liquidity_score', 'expected_direction',
+            'btc_fwd_30d', 'btc_fwd_60d', 'btc_fwd_90d', 'correct',
+        }
+        assert required.issubset(set(df.columns))
+
+    def test_no_lookahead_in_liquidity(self, mixed_liquidity, btc_up):
+        """Liquidity state must be from data at or before eval date."""
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        liq_dates = mixed_liquidity['date']
+        for _, row in df.iterrows():
+            eval_date = pd.Timestamp(row['date'])
+            # Must be a valid state from before eval_date
+            available = mixed_liquidity[liq_dates <= eval_date]
+            assert not available.empty, f'No liquidity data before {eval_date}'
+
+    def test_no_lookahead_in_forward_returns(self, mixed_liquidity, btc_up):
+        """Forward returns must not use data beyond eval_date + window."""
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        last_btc = btc_up.index[-1]
+        for _, row in df.iterrows():
+            eval_date = pd.Timestamp(row['date'])
+            # Eval date + 90d must be within Bitcoin data range
+            assert eval_date + pd.Timedelta(days=90) <= last_btc + pd.Timedelta(days=1)
+
+    def test_correct_scoring_positive(self, expanding_liquidity, btc_up):
+        """Expanding + uptrend Bitcoin → should score correct=1.0."""
+        df = run_bitcoin_liquidity_backtest(expanding_liquidity, btc_up)
+        # With expanding liquidity and rising BTC, most should be correct
+        avg_correct = df['correct'].mean()
+        assert avg_correct > 0.5, f'Expected > 50% accuracy, got {avg_correct*100:.1f}%'
+
+    def test_correct_scoring_negative(self):
+        """Contracting + downtrend Bitcoin → should score correct=1.0."""
+        liq = _make_liquidity_history(pattern='contracting')
+        btc = _make_bitcoin_price(trend='down')
+        df = run_bitcoin_liquidity_backtest(liq, btc)
+        if not df.empty:
+            avg_correct = df['correct'].mean()
+            assert avg_correct > 0.5
+
+    def test_correct_scoring_neutral(self):
+        """Neutral + flat Bitcoin → correct=1.0 if within threshold."""
+        liq = _make_liquidity_history(pattern='neutral')
+        btc = _make_bitcoin_price(trend='flat')
+        df = run_bitcoin_liquidity_backtest(liq, btc)
+        if not df.empty:
+            # Flat BTC ≈ 0% return → neutral expectation should score 1.0
+            avg_correct = df['correct'].mean()
+            assert avg_correct > 0.8
+
+    def test_empty_with_no_overlap(self):
+        """If liquidity and BTC don't overlap, return empty."""
+        liq = _make_liquidity_history(start='2030-01-01', end='2031-12-31')
+        btc = _make_bitcoin_price(start='2014-01-01', end='2015-12-31')
+        df = run_bitcoin_liquidity_backtest(liq, btc)
+        assert df.empty or len(df) == 0
+
+    def test_monthly_evaluation_frequency(self, mixed_liquidity, btc_up):
+        """Evaluations should be roughly monthly."""
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        if len(df) >= 2:
+            dates = pd.to_datetime(df['date'])
+            gaps = dates.diff().dropna().dt.days
+            # Monthly ≈ 28-31 days
+            assert gaps.median() >= 27
+            assert gaps.median() <= 35
+
+    def test_liquidity_bucket_matches_state(self, mixed_liquidity, btc_up):
+        """Each liquidity_bucket should match LIQUIDITY_BUCKETS mapping."""
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        for _, row in df.iterrows():
+            expected_bucket = LIQUIDITY_BUCKETS[row['liquidity_state']]
+            assert row['liquidity_bucket'] == expected_bucket
+
+    def test_expected_direction_matches_state(self, mixed_liquidity, btc_up):
+        """expected_direction should match LIQUIDITY_EXPECTATIONS."""
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        for _, row in df.iterrows():
+            expected = LIQUIDITY_EXPECTATIONS[row['liquidity_state']]
+            assert row['expected_direction'] == expected
+
+    def test_date_range_respects_btc_start(self):
+        """Should not evaluate before Bitcoin data starts."""
+        liq = _make_liquidity_history(start='2010-01-01')
+        btc = _make_bitcoin_price(start='2016-01-01', end='2025-06-30')
+        df = run_bitcoin_liquidity_backtest(liq, btc, start_year=2014)
+        if not df.empty:
+            first_date = pd.Timestamp(df['date'].iloc[0])
+            assert first_date >= pd.Timestamp('2016-01-01')
+
+
+# ---------------------------------------------------------------------------
+# Scoring tests
+# ---------------------------------------------------------------------------
+
+
+class TestScoring:
+    """Test aggregate scoring logic."""
+
+    def test_overall_accuracy(self, mixed_liquidity, btc_up):
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        scores = score_results(df)
+        assert 'overall' in scores
+        assert 'accuracy' in scores['overall']
+        assert 0 <= scores['overall']['accuracy'] <= 100
+
+    def test_per_state_breakdown(self, mixed_liquidity, btc_up):
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        scores = score_results(df)
+        assert 'per_state' in scores
+        # Should have entries for all states present in data
+        states_in_data = set(df['liquidity_state'].unique())
+        for state in states_in_data:
+            assert state in scores['per_state']
+            assert scores['per_state'][state]['count'] > 0
+
+    def test_per_bucket_breakdown(self, mixed_liquidity, btc_up):
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        scores = score_results(df)
+        assert 'per_bucket' in scores
+        buckets_in_data = set(df['liquidity_bucket'].unique())
+        for bucket in buckets_in_data:
+            assert bucket in scores['per_bucket']
+            assert scores['per_bucket'][bucket]['count'] > 0
+
+    def test_return_ordering_check(self, mixed_liquidity, btc_up):
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        scores = score_results(df)
+        overall = scores.get('overall', {})
+        # Should have return ordering check if multiple buckets exist
+        if len(set(df['liquidity_bucket'].unique())) >= 2:
+            assert 'return_ordering_correct' in overall
+
+    def test_per_state_has_avg_returns(self, mixed_liquidity, btc_up):
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        scores = score_results(df)
+        for state, stats in scores['per_state'].items():
+            if stats['count'] > 0:
+                assert 'avg_fwd_90d' in stats
+                assert 'expected_direction' in stats
+
+    def test_per_bucket_has_pct_positive(self, mixed_liquidity, btc_up):
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        scores = score_results(df)
+        for bucket, stats in scores['per_bucket'].items():
+            if stats['count'] > 0:
+                assert 'pct_positive' in stats
+                assert 0 <= stats['pct_positive'] <= 100
+
+    def test_total_evaluations_matches_dataframe(self, mixed_liquidity, btc_up):
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        scores = score_results(df)
+        assert scores['overall']['total_evaluations'] == len(df)
+
+    def test_correct_count_consistency(self, mixed_liquidity, btc_up):
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        scores = score_results(df)
+        # Sum of per-bucket counts = total evaluations
+        total_from_buckets = sum(
+            stats['count']
+            for stats in scores['per_bucket'].values()
+        )
+        assert total_from_buckets == scores['overall']['total_evaluations']
+
+
+# ---------------------------------------------------------------------------
+# Walk-forward scoring tests
+# ---------------------------------------------------------------------------
+
+
+class TestWalkForward:
+    """Test walk-forward fold scoring."""
+
+    def test_returns_fold_details(self, mixed_liquidity, btc_up):
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        folds = generate_folds()
+        wf = score_walk_forward(df, folds)
+        assert 'fold_details' in wf
+        assert len(wf['fold_details']) > 0
+
+    def test_mean_and_std(self, mixed_liquidity, btc_up):
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        folds = generate_folds()
+        wf = score_walk_forward(df, folds)
+        if wf.get('mean') is not None:
+            assert 0 <= wf['mean'] <= 100
+            assert wf['std'] >= 0
+
+    def test_sharpe_ratio(self, mixed_liquidity, btc_up):
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        folds = generate_folds()
+        wf = score_walk_forward(df, folds)
+        if wf.get('sharpe') is not None:
+            assert wf['sharpe'] >= 0
+
+    def test_fold_scores_list(self, mixed_liquidity, btc_up):
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        folds = generate_folds()
+        wf = score_walk_forward(df, folds)
+        if wf.get('fold_scores'):
+            for score in wf['fold_scores']:
+                assert 0 <= score <= 100
+
+    def test_empty_folds_handled(self):
+        """Folds with no data should be handled gracefully."""
+        df = pd.DataFrame({
+            'date': ['2020-01-31', '2020-02-29'],
+            'correct': [1.0, 0.0],
+            'liquidity_bucket': ['Expanding', 'Contracting'],
+        })
+        folds = generate_folds(2014, 2025)
+        wf = score_walk_forward(df, folds)
+        # Should not crash
+        assert 'fold_details' in wf
+
+
+# ---------------------------------------------------------------------------
+# CPCV tests
+# ---------------------------------------------------------------------------
+
+
+class TestCPCV:
+    """Test Combinatorial Purged Cross-Validation."""
+
+    def test_returns_pbo(self, mixed_liquidity, btc_up):
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        result = run_cpcv(df)
+        if result.get('pbo') is not None:
+            assert 0 <= result['pbo'] <= 1
+
+    def test_oos_and_is_means(self, mixed_liquidity, btc_up):
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        result = run_cpcv(df)
+        if result.get('pbo') is not None:
+            assert 0 <= result['oos_mean'] <= 100
+            assert 0 <= result['is_mean'] <= 100
+
+    def test_insufficient_data(self):
+        """CPCV should handle insufficient data gracefully."""
+        df = pd.DataFrame({
+            'date': ['2020-01-31'],
+            'correct': [1.0],
+        })
+        result = run_cpcv(df)
+        assert result['pbo'] is None
+        assert result['n_paths'] == 0
+
+
+# ---------------------------------------------------------------------------
+# Plausibility checks tests
+# ---------------------------------------------------------------------------
+
+
+class TestPlausibility:
+    """Test economic plausibility checks."""
+
+    def test_2020_2021_expansion_check(self):
+        """2020-2021 should show expanding liquidity."""
+        dates = pd.date_range('2020-06-01', '2021-12-31', freq='ME')
+        df = pd.DataFrame({
+            'date': dates.strftime('%Y-%m-%d'),
+            'liquidity_bucket': ['Expanding'] * len(dates),
+            'btc_fwd_90d': [0.1] * len(dates),
+            'correct': [1.0] * len(dates),
+        })
+        result = check_plausibility(df)
+        assert result['checks']['2020_2021_liquidity_expansion']['pass'] is True
+
+    def test_2022_contraction_check(self):
+        """2022 should show contracting liquidity."""
+        dates = pd.date_range('2022-01-01', '2022-12-31', freq='ME')
+        df = pd.DataFrame({
+            'date': dates.strftime('%Y-%m-%d'),
+            'liquidity_bucket': ['Contracting'] * len(dates),
+            'btc_fwd_90d': [-0.1] * len(dates),
+            'correct': [1.0] * len(dates),
+        })
+        result = check_plausibility(df)
+        assert result['checks']['2022_liquidity_contraction']['pass'] is True
+
+    def test_2022_contraction_fails_when_expanding(self):
+        """If 2022 shows expanding, the check should fail."""
+        dates = pd.date_range('2022-01-01', '2022-12-31', freq='ME')
+        df = pd.DataFrame({
+            'date': dates.strftime('%Y-%m-%d'),
+            'liquidity_bucket': ['Expanding'] * len(dates),
+            'btc_fwd_90d': [0.1] * len(dates),
+            'correct': [1.0] * len(dates),
+        })
+        result = check_plausibility(df)
+        assert result['checks']['2022_liquidity_contraction']['pass'] is False
+
+    def test_expanding_beats_contracting_returns(self):
+        """Expanding should have higher avg returns than Contracting."""
+        df = pd.DataFrame({
+            'date': ['2020-01-31', '2020-02-29', '2020-03-31', '2020-04-30'],
+            'liquidity_bucket': ['Expanding', 'Expanding', 'Contracting', 'Contracting'],
+            'btc_fwd_90d': [0.2, 0.15, -0.1, -0.05],
+            'correct': [1.0, 1.0, 1.0, 1.0],
+        })
+        result = check_plausibility(df)
+        assert result['checks']['expanding_beats_contracting_returns']['pass'] is True
+
+    def test_all_pass_when_all_checks_pass(self):
+        # Create data spanning 2020-2022 with correct liquidity patterns
+        dates_exp = pd.date_range('2020-06-01', '2021-12-31', freq='ME')
+        dates_con = pd.date_range('2022-01-01', '2022-12-31', freq='ME')
+        df = pd.DataFrame({
+            'date': list(dates_exp.strftime('%Y-%m-%d')) + list(dates_con.strftime('%Y-%m-%d')),
+            'liquidity_bucket': ['Expanding'] * len(dates_exp) + ['Contracting'] * len(dates_con),
+            'btc_fwd_90d': [0.1] * len(dates_exp) + [-0.1] * len(dates_con),
+            'correct': [1.0] * (len(dates_exp) + len(dates_con)),
+        })
+        result = check_plausibility(df)
+        assert result['all_pass'] is True
+
+    def test_no_data_in_range(self):
+        """If no data covers the plausibility periods, checks should pass."""
+        df = pd.DataFrame({
+            'date': ['2018-01-31', '2018-02-28'],
+            'liquidity_bucket': ['Expanding', 'Contracting'],
+            'btc_fwd_90d': [0.1, -0.1],
+            'correct': [1.0, 1.0],
+        })
+        result = check_plausibility(df)
+        # The 2020_2021 and 2022 checks pass by default (no data)
+        # expanding_beats_contracting still runs
+        exp_vs_con = result['checks'].get('expanding_beats_contracting_returns', {})
+        if 'pass' in exp_vs_con:
+            assert exp_vs_con['pass'] is True
+
+
+# ---------------------------------------------------------------------------
+# Report generation tests
+# ---------------------------------------------------------------------------
+
+
+class TestReport:
+    """Test report generation."""
+
+    def test_generates_markdown(self, mixed_liquidity, btc_up):
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        agg = score_results(df)
+        folds = generate_folds()
+        wf = score_walk_forward(df, folds)
+        plaus = check_plausibility(df)
+        cpcv = run_cpcv(df)
+        report = generate_report(df, agg, wf, plaus, cpcv)
+
+        assert isinstance(report, str)
+        assert '# Bitcoin / Liquidity Dimension Validation Report' in report
+
+    def test_report_includes_per_bucket_table(self, mixed_liquidity, btc_up):
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        agg = score_results(df)
+        folds = generate_folds()
+        wf = score_walk_forward(df, folds)
+        plaus = check_plausibility(df)
+        cpcv = run_cpcv(df)
+        report = generate_report(df, agg, wf, plaus, cpcv)
+
+        assert 'Expanding' in report
+        assert 'Contracting' in report
+
+    def test_report_includes_recommendation(self, mixed_liquidity, btc_up):
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        agg = score_results(df)
+        folds = generate_folds()
+        wf = score_walk_forward(df, folds)
+        plaus = check_plausibility(df)
+        cpcv = run_cpcv(df)
+        report = generate_report(df, agg, wf, plaus, cpcv)
+
+        assert 'Recommendation for Phase 11' in report
+
+    def test_report_includes_walk_forward(self, mixed_liquidity, btc_up):
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        agg = score_results(df)
+        folds = generate_folds()
+        wf = score_walk_forward(df, folds)
+        plaus = check_plausibility(df)
+        cpcv = run_cpcv(df)
+        report = generate_report(df, agg, wf, plaus, cpcv)
+
+        assert 'Walk-Forward Validation' in report
+
+    def test_report_includes_baseline_comparison(self, mixed_liquidity, btc_up):
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        agg = score_results(df)
+        folds = generate_folds()
+        wf = score_walk_forward(df, folds)
+        plaus = check_plausibility(df)
+        cpcv = run_cpcv(df)
+        report = generate_report(df, agg, wf, plaus, cpcv)
+
+        assert '34.8' in report  # Baseline comparison
+
+    def test_report_recommendation_strong_signal(self):
+        """Strong signal recommendation when accuracy is high."""
+        df = pd.DataFrame({
+            'date': ['2020-01-31'],
+            'liquidity_state': ['Expanding'],
+            'liquidity_bucket': ['Expanding'],
+            'correct': [1.0],
+            'btc_fwd_90d': [0.1],
+        })
+        agg = {
+            'overall': {'accuracy': 65.0, 'total_evaluations': 100},
+            'per_state': {},
+            'per_bucket': {
+                'Expanding': {'count': 50, 'accuracy': 70.0},
+                'Contracting': {'count': 50, 'accuracy': 60.0},
+            },
+        }
+        wf = {'mean': 65.0, 'std': 5.0, 'sharpe': 13.0, 'n_folds': 6, 'fold_details': []}
+        plaus = {'all_pass': True, 'checks': {}}
+        cpcv = {'pbo': 0.3, 'n_paths': 15, 'oos_mean': 64.0, 'oos_std': 3.0, 'is_mean': 65.0}
+        report = generate_report(df, agg, wf, plaus, cpcv)
+        assert 'STRONG SIGNAL' in report
+
+    def test_report_recommendation_weak_signal(self):
+        """Weak signal recommendation when accuracy is low."""
+        df = pd.DataFrame({
+            'date': ['2020-01-31'],
+            'liquidity_state': ['Expanding'],
+            'liquidity_bucket': ['Expanding'],
+            'correct': [0.0],
+            'btc_fwd_90d': [-0.1],
+        })
+        agg = {
+            'overall': {'accuracy': 35.0, 'total_evaluations': 100},
+            'per_state': {},
+            'per_bucket': {},
+        }
+        wf = {'mean': 35.0, 'std': 10.0, 'sharpe': 3.5, 'n_folds': 6, 'fold_details': []}
+        plaus = {'all_pass': False, 'checks': {}}
+        cpcv = {'pbo': 0.7, 'n_paths': 15, 'oos_mean': 34.0, 'oos_std': 5.0, 'is_mean': 40.0}
+        report = generate_report(df, agg, wf, plaus, cpcv)
+        assert 'WEAK SIGNAL' in report
+
+
+# ---------------------------------------------------------------------------
+# Data loading tests
+# ---------------------------------------------------------------------------
+
+
+class TestDataLoading:
+    """Test data loading functions."""
+
+    def test_load_bitcoin_price_returns_series_or_none(self):
+        """Should return a Series or None if file missing."""
+        result = load_bitcoin_price()
+        # In test environment, may or may not exist
+        assert result is None or isinstance(result, pd.Series)
+
+    @pytest.mark.skipif(
+        not Path(__file__).resolve().parent.parent.joinpath(
+            'signaltrackers', 'data', 'bitcoin_price.csv'
+        ).exists(),
+        reason='bitcoin_price.csv not present (data not collected)',
+    )
+    def test_bitcoin_price_has_data(self):
+        result = load_bitcoin_price()
+        assert result is not None
+        assert len(result) > 100  # Should have substantial data
+        assert result.index[0] <= pd.Timestamp('2015-01-01')
+
+
+# ---------------------------------------------------------------------------
+# Edge case tests
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Test edge cases and error handling."""
+
+    def test_short_bitcoin_history(self):
+        """Should handle short Bitcoin history gracefully."""
+        liq = _make_liquidity_history(start='2014-01-01', end='2025-12-31')
+        btc = _make_bitcoin_price(start='2024-01-01', end='2025-06-30')
+        df = run_bitcoin_liquidity_backtest(liq, btc, start_year=2024, end_year=2025)
+        # Should produce results for the overlap period
+        if not df.empty:
+            assert len(df) >= 1
+
+    def test_handles_weekends_holidays(self):
+        """Bitcoin trades 24/7 but some FRED series have gaps."""
+        liq = _make_liquidity_history(freq='ME')  # Monthly only
+        btc = _make_bitcoin_price()
+        df = run_bitcoin_liquidity_backtest(liq, btc)
+        # Should still produce results despite different frequencies
+        assert not df.empty
+
+    def test_extreme_volatility_included(self, mixed_liquidity):
+        """Extreme periods (COVID, FTX) should not be filtered out."""
+        btc = _make_bitcoin_price(trend='volatile')
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc)
+        # Should include the full date range, including volatile periods
+        if not df.empty:
+            dates = pd.to_datetime(df['date'])
+            # Should cover both stable and volatile periods
+            assert (dates.max() - dates.min()).days > 365
+
+    def test_single_liquidity_state(self):
+        """If only one liquidity state exists, scoring still works."""
+        liq = _make_liquidity_history(pattern='expanding')
+        btc = _make_bitcoin_price(trend='up')
+        df = run_bitcoin_liquidity_backtest(liq, btc)
+        if not df.empty:
+            scores = score_results(df)
+            assert 'accuracy' in scores['overall']
+
+    def test_deterministic_results(self, mixed_liquidity, btc_up):
+        """Same inputs should produce same outputs."""
+        df1 = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        df2 = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        pd.testing.assert_frame_equal(df1, df2)
+
+
+# ---------------------------------------------------------------------------
+# Integration test — full pipeline with synthetic data
+# ---------------------------------------------------------------------------
+
+
+class TestIntegration:
+    """Test full pipeline end-to-end with synthetic data."""
+
+    def test_full_pipeline(self, mixed_liquidity, btc_volatile):
+        """Run full pipeline: backtest → score → walk-forward → CPCV → plausibility → report."""
+        # Run backtest
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_volatile)
+        assert not df.empty
+
+        # Score
+        agg = score_results(df)
+        assert agg['overall']['accuracy'] is not None
+
+        # Walk-forward
+        folds = generate_folds()
+        wf = score_walk_forward(df, folds)
+        assert wf.get('mean') is not None
+
+        # CPCV
+        cpcv = run_cpcv(df)
+        # May or may not compute depending on data size
+        assert 'pbo' in cpcv
+
+        # Plausibility
+        plaus = check_plausibility(df)
+        assert 'all_pass' in plaus
+
+        # Report
+        report = generate_report(df, agg, wf, plaus, cpcv)
+        assert len(report) > 100
+        assert '# Bitcoin / Liquidity Dimension Validation Report' in report
+
+    def test_not_included_in_main_composite(self, mixed_liquidity, btc_up):
+        """Bitcoin accuracy must NOT be included in the main composite score.
+
+        Verify by checking that the output does not contain 'composite_score'
+        in the results — this is a Bitcoin-only validation, not part of
+        the multi-asset composite.
+        """
+        df = run_bitcoin_liquidity_backtest(mixed_liquidity, btc_up)
+        agg = score_results(df)
+        # The overall section should have 'accuracy' but NOT 'composite_score'
+        assert 'accuracy' in agg['overall']
+        assert 'composite_score' not in agg['overall']


### PR DESCRIPTION
Fixes #304

## Summary
Walk-forward validation testing the Liquidity dimension against Bitcoin 90-day forward returns, separate from the main Market Conditions composite backtest.

## Changes
- `signaltrackers/backtesting/bitcoin_liquidity_backtest.py`: Walk-forward backtest using same methodology as main conditions backtest (monthly eval dates, 2-year expanding window, CPCV k=6/p=2)
- Liquidity expectations: Expanding→positive, Neutral→neutral, Contracting→negative; 3-bucket and 5-state breakdowns
- Plausibility checks: 2020-2021 expansion, 2022 contraction, return ordering
- Report generates Phase 11 crypto page guidance recommendation (strong/moderate/weak signal)
- Results kept separate from main composite score
- 61 tests; all passing

## Testing
- ✅ All unit tests passing
- ✅ Design review approved
- ✅ QA verification complete

## Design Spec
Implements [docs/MARKET-CONDITIONS-FRAMEWORK.md — Section 11](docs/MARKET-CONDITIONS-FRAMEWORK.md#11-migration-strategy)