### PR TITLE
Fix conditions history: composite scores, cache consolidation, backfill

### DIFF
--- a/signaltrackers/dashboard.py
+++ b/signaltrackers/dashboard.py
@@ -1950,10 +1950,11 @@ def index():
             sorted_dates = sorted(history.keys(), reverse=True)
             for dt_str in sorted_dates[:6]:
                 entry = history[dt_str]
+                # Prefer top-level scores (bug #337), fall back to nested
                 dims = entry.get('dimensions', {})
                 quad_dims = dims.get('quadrant', {})
-                gc = quad_dims.get('growth_composite')
-                ic = quad_dims.get('inflation_composite')
+                gc = entry.get('growth_score') or quad_dims.get('growth_composite')
+                ic = entry.get('inflation_score') or quad_dims.get('inflation_composite')
                 if gc is not None and ic is not None:
                     trajectory.append({
                         'date': dt_str,

--- a/signaltrackers/market_conditions.py
+++ b/signaltrackers/market_conditions.py
@@ -1586,15 +1586,14 @@ def update_market_conditions_cache() -> Optional[dict]:
             'updated_at': datetime.now(timezone.utc).isoformat(),
         }
 
-        os.makedirs(os.path.dirname(MARKET_CONDITIONS_CACHE_FILE), exist_ok=True)
-        with open(MARKET_CONDITIONS_CACHE_FILE, 'w') as f:
-            json.dump(cache_data, f, indent=2)
-
-        logger.info('Market conditions cache updated: quadrant=%s',
+        logger.info('Market conditions computed: quadrant=%s',
                      quadrant_result.quadrant)
 
-        # Append to daily history (separate from snapshot cache)
+        # Write to daily history (single source of truth — bug #337)
         _append_conditions_history(cache_data)
+
+        # Backfill 12 months of history if sparse (bug #337)
+        _backfill_history_if_needed()
 
         return cache_data
 
@@ -1604,15 +1603,33 @@ def update_market_conditions_cache() -> Optional[dict]:
 
 
 def get_market_conditions() -> Optional[dict]:
-    """Read market conditions from cache file."""
-    if not os.path.exists(MARKET_CONDITIONS_CACHE_FILE):
-        return None
-    try:
-        with open(MARKET_CONDITIONS_CACHE_FILE, 'r') as f:
-            return json.load(f)
-    except Exception:
-        logger.exception('Error reading market conditions cache')
-        return None
+    """Read the latest market conditions from the history file.
+
+    Returns the most recent entry in the same shape that consumers expect
+    (quadrant, dimensions, asset_expectations, as_of, updated_at).
+    Falls back to the legacy cache file if the history file is empty.
+    """
+    history = _load_conditions_history()
+    if history:
+        latest_date = max(history.keys())
+        entry = history[latest_date]
+        # Reconstruct the flat cache shape expected by callers
+        return {
+            'quadrant': entry.get('quadrant'),
+            'dimensions': entry.get('dimensions', {}),
+            'asset_expectations': entry.get('asset_expectations', []),
+            'as_of': latest_date,
+            'updated_at': entry.get('updated_at', ''),
+        }
+
+    # Legacy fallback: read old cache file if it exists
+    if os.path.exists(MARKET_CONDITIONS_CACHE_FILE):
+        try:
+            with open(MARKET_CONDITIONS_CACHE_FILE, 'r') as f:
+                return json.load(f)
+        except Exception:
+            logger.exception('Error reading legacy market conditions cache')
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -1655,14 +1672,114 @@ def _append_conditions_history(cache_data: dict) -> None:
         return
 
     history = _load_conditions_history()
-    history[as_of] = {
+
+    # Extract growth/inflation composite scores from dimensions for quadrant
+    # trajectory visualisation (bug #337)
+    dims = cache_data.get('dimensions', {})
+    quad_dims = dims.get('quadrant', {})
+
+    entry = {
         'quadrant': cache_data['quadrant'],
-        'dimensions': cache_data['dimensions'],
+        'growth_score': quad_dims.get('growth_composite'),
+        'inflation_score': quad_dims.get('inflation_composite'),
+        'raw_quadrant': quad_dims.get('state', cache_data.get('quadrant')),
+        'dimensions': dims,
         'asset_expectations': cache_data.get('asset_expectations', []),
+        'updated_at': cache_data.get('updated_at'),
     }
+
+    history[as_of] = entry
     _save_conditions_history(history)
     logger.info('Market conditions history updated for %s (%d total entries)',
                 as_of, len(history))
+
+
+def _backfill_history_if_needed(min_entries: int = 12) -> None:
+    """Backfill history from computed dimension histories if sparse.
+
+    When the history file has fewer than *min_entries*, compute 12 months
+    of monthly snapshots using the *_history() functions and prepend them.
+    Existing entries are never overwritten.
+    """
+    history = _load_conditions_history()
+    if len(history) >= min_entries:
+        return
+
+    logger.info('History has %d entries (< %d); backfilling...', len(history), min_entries)
+
+    try:
+        from datetime import date as _date
+        # 12 months ago
+        today = _date.today()
+        start = _date(today.year - 1, today.month, today.day).isoformat()
+
+        quad_hist = compute_quadrant_history(start_date=start)
+        liq_hist = compute_liquidity_history(start_date=start)
+        risk_hist = compute_risk_history(start_date=start)
+        policy_hist = compute_policy_history(start_date=start)
+
+        if quad_hist is None or len(quad_hist) == 0:
+            logger.warning('Cannot backfill: quadrant history unavailable')
+            return
+
+        # Use end-of-month dates from quadrant history (monthly cadence)
+        quad_hist = quad_hist.copy()
+        quad_hist['month'] = quad_hist['date'].dt.to_period('M')
+        monthly = quad_hist.groupby('month').last().reset_index()
+
+        added = 0
+        for _, row in monthly.iterrows():
+            dt_str = str(row['date'].date())
+            if dt_str in history:
+                continue  # never overwrite existing entries
+
+            dims = {
+                'quadrant': {
+                    'state': row['quadrant'],
+                    'growth_composite': round(float(row['growth']), 4),
+                    'inflation_composite': round(float(row['inflation']), 4),
+                },
+            }
+
+            # Liquidity — find closest date
+            if liq_hist is not None and len(liq_hist) > 0:
+                liq_row = liq_hist.iloc[(liq_hist['date'] - row['date']).abs().argsort()[:1]]
+                dims['liquidity'] = {
+                    'state': str(liq_row.iloc[0]['state']),
+                    'score': round(float(liq_row.iloc[0]['score']), 4),
+                }
+
+            # Risk — find closest date
+            if risk_hist is not None and len(risk_hist) > 0:
+                risk_row = risk_hist.iloc[(risk_hist['date'] - row['date']).abs().argsort()[:1]]
+                dims['risk'] = {
+                    'state': str(risk_row.iloc[0]['state']),
+                    'score': int(risk_row.iloc[0]['score']),
+                }
+
+            # Policy — find closest date
+            if policy_hist is not None and len(policy_hist) > 0:
+                pol_row = policy_hist.iloc[(policy_hist['date'] - row['date']).abs().argsort()[:1]]
+                dims['policy'] = {
+                    'stance': str(pol_row.iloc[0]['stance']),
+                    'direction': str(pol_row.iloc[0]['direction']),
+                }
+
+            history[dt_str] = {
+                'quadrant': row['quadrant'],
+                'growth_score': round(float(row['growth']), 4),
+                'inflation_score': round(float(row['inflation']), 4),
+                'raw_quadrant': row.get('raw_quadrant', row['quadrant']),
+                'dimensions': dims,
+            }
+            added += 1
+
+        if added > 0:
+            _save_conditions_history(history)
+            logger.info('Backfilled %d monthly entries into conditions history', added)
+
+    except Exception:
+        logger.exception('Error during history backfill')
 
 
 def get_conditions_history() -> dict:

--- a/tests/test_bug337_conditions_history.py
+++ b/tests/test_bug337_conditions_history.py
@@ -1,0 +1,541 @@
+"""
+Tests for bug #337: market conditions history consolidation.
+
+Covers:
+1. History entries include growth_score and inflation_score at top level
+2. get_market_conditions() reads from history (not separate cache file)
+3. Backfill logic when history is sparse
+4. Legacy cache fallback
+"""
+
+import json
+import os
+import sys
+import tempfile
+from datetime import date, datetime, timezone
+from unittest.mock import patch, MagicMock
+
+import pandas as pd
+import pytest
+
+# Ensure signaltrackers is importable
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SIGNALTRACKERS_DIR = os.path.join(REPO_ROOT, 'signaltrackers')
+if SIGNALTRACKERS_DIR not in sys.path:
+    sys.path.insert(0, SIGNALTRACKERS_DIR)
+
+from market_conditions import (
+    _append_conditions_history,
+    _load_conditions_history,
+    _save_conditions_history,
+    _backfill_history_if_needed,
+    get_market_conditions,
+    get_conditions_history,
+    update_market_conditions_cache,
+    MARKET_CONDITIONS_CACHE_FILE,
+    MARKET_CONDITIONS_HISTORY_FILE,
+    LiquidityResult,
+    QuadrantResult,
+    RiskResult,
+    PolicyResult,
+)
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+def _mock_liquidity(state='Expanding', score=0.8):
+    return LiquidityResult(state=state, score=score, as_of='2025-06-15')
+
+
+def _mock_quadrant(quadrant='Goldilocks', growth=0.5, inflation=-0.3):
+    return QuadrantResult(
+        quadrant=quadrant, growth_composite=growth,
+        inflation_composite=inflation, raw_quadrant=quadrant,
+        stable=True, as_of='2025-06-15',
+    )
+
+
+def _mock_risk(state='Normal', score=2):
+    return RiskResult(
+        state=state, score=score, vix_score=1,
+        term_structure_score=0, correlation_score=1,
+        as_of='2025-06-15',
+    )
+
+
+def _mock_policy(stance='Neutral', direction='Paused'):
+    return PolicyResult(
+        stance=stance, direction=direction, taylor_gap=0.3,
+        taylor_prescribed=4.5, actual_rate=4.8,
+        as_of='2025-06-15',
+    )
+
+
+def _make_cache_data(quadrant='Goldilocks', growth=0.085, inflation=-0.204,
+                     as_of='2025-06-15'):
+    """Build a cache_data dict as produced by update_market_conditions_cache."""
+    return {
+        'quadrant': quadrant,
+        'dimensions': {
+            'liquidity': {'state': 'Neutral', 'score': 0.0},
+            'quadrant': {
+                'state': quadrant,
+                'growth_composite': growth,
+                'inflation_composite': inflation,
+            },
+            'risk': {'state': 'Normal', 'score': 2},
+            'policy': {'stance': 'Neutral', 'direction': 'Paused'},
+        },
+        'asset_expectations': [{'asset': 'sp500', 'direction': 'positive'}],
+        'as_of': as_of,
+        'updated_at': f'{as_of}T12:00:00+00:00',
+    }
+
+
+# ============================================================================
+# 1. History entries include composite scores
+# ============================================================================
+
+class TestHistoryCompositeScores:
+    """Verify growth_score and inflation_score are persisted at top level."""
+
+    def test_append_stores_growth_and_inflation_scores(self):
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            tmp = f.name
+        try:
+            with patch('market_conditions.MARKET_CONDITIONS_HISTORY_FILE', tmp):
+                cache_data = _make_cache_data(growth=0.085, inflation=-0.204)
+                _append_conditions_history(cache_data)
+                entry = _load_conditions_history()['2025-06-15']
+                assert entry['growth_score'] == 0.085
+                assert entry['inflation_score'] == -0.204
+        finally:
+            os.unlink(tmp)
+
+    def test_append_stores_raw_quadrant(self):
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            tmp = f.name
+        try:
+            with patch('market_conditions.MARKET_CONDITIONS_HISTORY_FILE', tmp):
+                cache_data = _make_cache_data(quadrant='Reflation')
+                _append_conditions_history(cache_data)
+                entry = _load_conditions_history()['2025-06-15']
+                assert entry['raw_quadrant'] == 'Reflation'
+        finally:
+            os.unlink(tmp)
+
+    def test_append_stores_updated_at(self):
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            tmp = f.name
+        try:
+            with patch('market_conditions.MARKET_CONDITIONS_HISTORY_FILE', tmp):
+                cache_data = _make_cache_data()
+                _append_conditions_history(cache_data)
+                entry = _load_conditions_history()['2025-06-15']
+                assert 'updated_at' in entry
+                assert '2025-06-15' in entry['updated_at']
+        finally:
+            os.unlink(tmp)
+
+    def test_append_preserves_dimensions(self):
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            tmp = f.name
+        try:
+            with patch('market_conditions.MARKET_CONDITIONS_HISTORY_FILE', tmp):
+                cache_data = _make_cache_data()
+                _append_conditions_history(cache_data)
+                entry = _load_conditions_history()['2025-06-15']
+                assert 'dimensions' in entry
+                assert 'liquidity' in entry['dimensions']
+                assert 'quadrant' in entry['dimensions']
+                assert 'risk' in entry['dimensions']
+                assert 'policy' in entry['dimensions']
+        finally:
+            os.unlink(tmp)
+
+    def test_append_with_missing_quadrant_dims_sets_none(self):
+        """When dimensions.quadrant is absent, scores should be None."""
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            tmp = f.name
+        try:
+            with patch('market_conditions.MARKET_CONDITIONS_HISTORY_FILE', tmp):
+                cache_data = {
+                    'quadrant': 'Goldilocks',
+                    'dimensions': {'liquidity': {'state': 'Expanding'}},
+                    'asset_expectations': [],
+                    'as_of': '2025-06-15',
+                }
+                _append_conditions_history(cache_data)
+                entry = _load_conditions_history()['2025-06-15']
+                assert entry['growth_score'] is None
+                assert entry['inflation_score'] is None
+        finally:
+            os.unlink(tmp)
+
+
+# ============================================================================
+# 2. get_market_conditions() reads from history
+# ============================================================================
+
+class TestGetMarketConditionsFromHistory:
+    """Verify consolidated read path."""
+
+    def test_reads_latest_entry_from_history(self):
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            tmp = f.name
+        try:
+            history = {
+                '2025-06-14': {'quadrant': 'Reflation', 'dimensions': {},
+                               'asset_expectations': [], 'updated_at': '2025-06-14T12:00:00Z'},
+                '2025-06-15': {'quadrant': 'Goldilocks', 'dimensions': {},
+                               'asset_expectations': [], 'updated_at': '2025-06-15T12:00:00Z'},
+            }
+            with open(tmp, 'w') as fh:
+                json.dump(history, fh)
+
+            with patch('market_conditions.MARKET_CONDITIONS_HISTORY_FILE', tmp), \
+                 patch('market_conditions.MARKET_CONDITIONS_CACHE_FILE', '/nonexistent'):
+                result = get_market_conditions()
+                assert result is not None
+                assert result['quadrant'] == 'Goldilocks'
+                assert result['as_of'] == '2025-06-15'
+        finally:
+            os.unlink(tmp)
+
+    def test_returns_expected_shape(self):
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            tmp = f.name
+        try:
+            history = {
+                '2025-06-15': {
+                    'quadrant': 'Goldilocks',
+                    'dimensions': {'liquidity': {'state': 'Neutral'}},
+                    'asset_expectations': [{'asset': 'sp500'}],
+                    'updated_at': '2025-06-15T12:00:00+00:00',
+                },
+            }
+            with open(tmp, 'w') as fh:
+                json.dump(history, fh)
+
+            with patch('market_conditions.MARKET_CONDITIONS_HISTORY_FILE', tmp), \
+                 patch('market_conditions.MARKET_CONDITIONS_CACHE_FILE', '/nonexistent'):
+                result = get_market_conditions()
+                # Must have all keys that the context processor expects
+                assert 'quadrant' in result
+                assert 'dimensions' in result
+                assert 'asset_expectations' in result
+                assert 'as_of' in result
+                assert 'updated_at' in result
+        finally:
+            os.unlink(tmp)
+
+    def test_falls_back_to_legacy_cache(self):
+        """When history is empty, reads from old cache file."""
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False, mode='w') as f:
+            json.dump({'quadrant': 'Stagflation', 'as_of': '2025-06-10',
+                       'updated_at': '2025-06-10T12:00:00Z',
+                       'dimensions': {}, 'asset_expectations': []}, f)
+            tmp_cache = f.name
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            tmp_history = f.name  # empty file
+
+        try:
+            with patch('market_conditions.MARKET_CONDITIONS_CACHE_FILE', tmp_cache), \
+                 patch('market_conditions.MARKET_CONDITIONS_HISTORY_FILE', tmp_history):
+                result = get_market_conditions()
+                assert result is not None
+                assert result['quadrant'] == 'Stagflation'
+        finally:
+            for p in (tmp_cache, tmp_history):
+                if os.path.exists(p):
+                    os.unlink(p)
+
+    def test_returns_none_when_both_missing(self):
+        with patch('market_conditions.MARKET_CONDITIONS_CACHE_FILE', '/nonexistent/cache.json'), \
+             patch('market_conditions.MARKET_CONDITIONS_HISTORY_FILE', '/nonexistent/hist.json'):
+            assert get_market_conditions() is None
+
+
+# ============================================================================
+# 3. Backfill logic
+# ============================================================================
+
+class TestBackfillHistory:
+    """Verify _backfill_history_if_needed() populates sparse history."""
+
+    def _make_quadrant_df(self, n_months=13):
+        """Create a mock quadrant history DataFrame."""
+        dates = pd.date_range(end='2025-05-31', periods=n_months, freq='ME')
+        n = len(dates)
+        return pd.DataFrame({
+            'date': dates,
+            'growth': [0.1 + i * 0.01 for i in range(n)],
+            'inflation': [-0.2 + i * 0.005 for i in range(n)],
+            'raw_quadrant': ['Goldilocks'] * n,
+            'quadrant': ['Goldilocks'] * n,
+        })
+
+    def _make_liquidity_df(self, n_months=13):
+        dates = pd.date_range(end='2025-05-31', periods=n_months, freq='ME')
+        n = len(dates)
+        return pd.DataFrame({
+            'date': dates,
+            'score': [0.5 + i * 0.02 for i in range(n)],
+            'state': ['Neutral'] * n,
+        })
+
+    def _make_risk_df(self, n_months=13):
+        dates = pd.date_range(end='2025-05-31', periods=n_months, freq='ME')
+        n = len(dates)
+        return pd.DataFrame({
+            'date': dates,
+            'score': [2] * n,
+            'state': ['Normal'] * n,
+        })
+
+    def _make_policy_df(self, n_months=13):
+        dates = pd.date_range(end='2025-05-31', periods=n_months, freq='ME')
+        n = len(dates)
+        return pd.DataFrame({
+            'date': dates,
+            'stance': ['Neutral'] * n,
+            'direction': ['Paused'] * n,
+        })
+
+    def test_backfill_populates_empty_history(self):
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            tmp = f.name
+        try:
+            with patch('market_conditions.MARKET_CONDITIONS_HISTORY_FILE', tmp), \
+                 patch('market_conditions.compute_quadrant_history', return_value=self._make_quadrant_df()), \
+                 patch('market_conditions.compute_liquidity_history', return_value=self._make_liquidity_df()), \
+                 patch('market_conditions.compute_risk_history', return_value=self._make_risk_df()), \
+                 patch('market_conditions.compute_policy_history', return_value=self._make_policy_df()):
+                _backfill_history_if_needed(min_entries=12)
+                history = _load_conditions_history()
+                assert len(history) >= 12
+        finally:
+            os.unlink(tmp)
+
+    def test_backfill_skips_when_sufficient_entries(self):
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False, mode='w') as f:
+            # Write 15 existing entries
+            history = {f'2025-{i:02d}-15': {'quadrant': 'Goldilocks'} for i in range(1, 13)}
+            history.update({f'2024-{i:02d}-15': {'quadrant': 'Reflation'} for i in range(10, 13)})
+            json.dump(history, f)
+            tmp = f.name
+        try:
+            with patch('market_conditions.MARKET_CONDITIONS_HISTORY_FILE', tmp), \
+                 patch('market_conditions.compute_quadrant_history') as mock_quad:
+                _backfill_history_if_needed(min_entries=12)
+                mock_quad.assert_not_called()
+        finally:
+            os.unlink(tmp)
+
+    def test_backfill_does_not_overwrite_existing(self):
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False, mode='w') as f:
+            existing_date = '2025-05-31'
+            json.dump({existing_date: {'quadrant': 'Stagflation', 'custom': True}}, f)
+            tmp = f.name
+        try:
+            with patch('market_conditions.MARKET_CONDITIONS_HISTORY_FILE', tmp), \
+                 patch('market_conditions.compute_quadrant_history', return_value=self._make_quadrant_df()), \
+                 patch('market_conditions.compute_liquidity_history', return_value=self._make_liquidity_df()), \
+                 patch('market_conditions.compute_risk_history', return_value=self._make_risk_df()), \
+                 patch('market_conditions.compute_policy_history', return_value=self._make_policy_df()):
+                _backfill_history_if_needed(min_entries=12)
+                history = _load_conditions_history()
+                # Existing entry preserved
+                assert history[existing_date]['quadrant'] == 'Stagflation'
+                assert history[existing_date].get('custom') is True
+        finally:
+            os.unlink(tmp)
+
+    def test_backfill_entries_have_composite_scores(self):
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            tmp = f.name
+        try:
+            with patch('market_conditions.MARKET_CONDITIONS_HISTORY_FILE', tmp), \
+                 patch('market_conditions.compute_quadrant_history', return_value=self._make_quadrant_df()), \
+                 patch('market_conditions.compute_liquidity_history', return_value=self._make_liquidity_df()), \
+                 patch('market_conditions.compute_risk_history', return_value=self._make_risk_df()), \
+                 patch('market_conditions.compute_policy_history', return_value=self._make_policy_df()):
+                _backfill_history_if_needed(min_entries=12)
+                history = _load_conditions_history()
+                for dt_str, entry in history.items():
+                    assert 'growth_score' in entry, f'Missing growth_score for {dt_str}'
+                    assert 'inflation_score' in entry, f'Missing inflation_score for {dt_str}'
+                    assert isinstance(entry['growth_score'], float)
+                    assert isinstance(entry['inflation_score'], float)
+        finally:
+            os.unlink(tmp)
+
+    def test_backfill_entries_have_all_dimensions(self):
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            tmp = f.name
+        try:
+            with patch('market_conditions.MARKET_CONDITIONS_HISTORY_FILE', tmp), \
+                 patch('market_conditions.compute_quadrant_history', return_value=self._make_quadrant_df()), \
+                 patch('market_conditions.compute_liquidity_history', return_value=self._make_liquidity_df()), \
+                 patch('market_conditions.compute_risk_history', return_value=self._make_risk_df()), \
+                 patch('market_conditions.compute_policy_history', return_value=self._make_policy_df()):
+                _backfill_history_if_needed(min_entries=12)
+                history = _load_conditions_history()
+                for dt_str, entry in history.items():
+                    dims = entry['dimensions']
+                    assert 'quadrant' in dims
+                    assert 'liquidity' in dims
+                    assert 'risk' in dims
+                    assert 'policy' in dims
+        finally:
+            os.unlink(tmp)
+
+    def test_backfill_handles_missing_liquidity(self):
+        """Backfill works even when liquidity history is unavailable."""
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            tmp = f.name
+        try:
+            with patch('market_conditions.MARKET_CONDITIONS_HISTORY_FILE', tmp), \
+                 patch('market_conditions.compute_quadrant_history', return_value=self._make_quadrant_df()), \
+                 patch('market_conditions.compute_liquidity_history', return_value=None), \
+                 patch('market_conditions.compute_risk_history', return_value=None), \
+                 patch('market_conditions.compute_policy_history', return_value=None):
+                _backfill_history_if_needed(min_entries=12)
+                history = _load_conditions_history()
+                assert len(history) >= 12
+                # Quadrant dims should still be present
+                for entry in history.values():
+                    assert 'quadrant' in entry['dimensions']
+                    # Other dimensions absent when history is None
+                    assert 'liquidity' not in entry['dimensions']
+        finally:
+            os.unlink(tmp)
+
+    def test_backfill_handles_no_quadrant_history(self):
+        """No backfill when quadrant history unavailable."""
+        with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
+            tmp = f.name
+        try:
+            with patch('market_conditions.MARKET_CONDITIONS_HISTORY_FILE', tmp), \
+                 patch('market_conditions.compute_quadrant_history', return_value=None), \
+                 patch('market_conditions.compute_liquidity_history', return_value=None), \
+                 patch('market_conditions.compute_risk_history', return_value=None), \
+                 patch('market_conditions.compute_policy_history', return_value=None):
+                _backfill_history_if_needed(min_entries=12)
+                history = _load_conditions_history()
+                assert len(history) == 0
+        finally:
+            os.unlink(tmp)
+
+
+# ============================================================================
+# 4. Integration: update_market_conditions_cache writes to history
+# ============================================================================
+
+class TestUpdateWritesToHistory:
+    """Verify that update_market_conditions_cache() only writes to history,
+    not a separate cache file."""
+
+    @patch('market_conditions._backfill_history_if_needed')
+    @patch('market_conditions.compute_policy')
+    @patch('market_conditions.compute_risk')
+    @patch('market_conditions.compute_quadrant')
+    @patch('market_conditions.compute_liquidity')
+    def test_no_separate_cache_file_written(self, mock_liq, mock_quad, mock_risk, mock_pol, _mock_backfill):
+        mock_liq.return_value = _mock_liquidity()
+        mock_quad.return_value = _mock_quadrant()
+        mock_risk.return_value = _mock_risk()
+        mock_pol.return_value = _mock_policy()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = os.path.join(tmpdir, 'cache.json')
+            history_path = os.path.join(tmpdir, 'history.json')
+
+            with patch('market_conditions.MARKET_CONDITIONS_CACHE_FILE', cache_path), \
+                 patch('market_conditions.MARKET_CONDITIONS_HISTORY_FILE', history_path):
+                update_market_conditions_cache()
+
+                # History should exist with one entry
+                assert os.path.exists(history_path)
+                with open(history_path) as fh:
+                    history = json.load(fh)
+                assert len(history) == 1
+
+                # Cache file should NOT be written
+                assert not os.path.exists(cache_path)
+
+    @patch('market_conditions._backfill_history_if_needed')
+    @patch('market_conditions.compute_policy')
+    @patch('market_conditions.compute_risk')
+    @patch('market_conditions.compute_quadrant')
+    @patch('market_conditions.compute_liquidity')
+    def test_history_entry_has_scores(self, mock_liq, mock_quad, mock_risk, mock_pol, _mock_backfill):
+        mock_liq.return_value = _mock_liquidity()
+        mock_quad.return_value = _mock_quadrant(growth=0.123, inflation=-0.456)
+        mock_risk.return_value = _mock_risk()
+        mock_pol.return_value = _mock_policy()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = os.path.join(tmpdir, 'cache.json')
+            history_path = os.path.join(tmpdir, 'history.json')
+
+            with patch('market_conditions.MARKET_CONDITIONS_CACHE_FILE', cache_path), \
+                 patch('market_conditions.MARKET_CONDITIONS_HISTORY_FILE', history_path):
+                update_market_conditions_cache()
+                history = _load_conditions_history()
+                entry = list(history.values())[0]
+                assert entry['growth_score'] == 0.123
+                assert entry['inflation_score'] == -0.456
+
+    @patch('market_conditions._backfill_history_if_needed')
+    @patch('market_conditions.compute_policy')
+    @patch('market_conditions.compute_risk')
+    @patch('market_conditions.compute_quadrant')
+    @patch('market_conditions.compute_liquidity')
+    def test_get_market_conditions_reads_after_update(self, mock_liq, mock_quad, mock_risk, mock_pol, _mock_backfill):
+        """Full round-trip: update → get reads from history."""
+        mock_liq.return_value = _mock_liquidity()
+        mock_quad.return_value = _mock_quadrant('Stagflation', growth=-0.5, inflation=0.8)
+        mock_risk.return_value = _mock_risk('Stressed', 6)
+        mock_pol.return_value = _mock_policy('Restrictive', 'Tightening')
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = os.path.join(tmpdir, 'cache.json')
+            history_path = os.path.join(tmpdir, 'history.json')
+
+            with patch('market_conditions.MARKET_CONDITIONS_CACHE_FILE', cache_path), \
+                 patch('market_conditions.MARKET_CONDITIONS_HISTORY_FILE', history_path):
+                update_market_conditions_cache()
+                result = get_market_conditions()
+                assert result is not None
+                assert result['quadrant'] == 'Stagflation'
+                assert 'dimensions' in result
+                assert 'asset_expectations' in result
+                assert 'updated_at' in result
+
+
+# ============================================================================
+# 5. Update triggers backfill
+# ============================================================================
+
+class TestUpdateTriggersBackfill:
+    """Verify update_market_conditions_cache calls _backfill_history_if_needed."""
+
+    @patch('market_conditions._backfill_history_if_needed')
+    @patch('market_conditions.compute_policy')
+    @patch('market_conditions.compute_risk')
+    @patch('market_conditions.compute_quadrant')
+    @patch('market_conditions.compute_liquidity')
+    def test_backfill_called_after_append(self, mock_liq, mock_quad, mock_risk, mock_pol, mock_backfill):
+        mock_liq.return_value = _mock_liquidity()
+        mock_quad.return_value = _mock_quadrant()
+        mock_risk.return_value = _mock_risk()
+        mock_pol.return_value = _mock_policy()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch('market_conditions.MARKET_CONDITIONS_CACHE_FILE', os.path.join(tmpdir, 'c.json')), \
+                 patch('market_conditions.MARKET_CONDITIONS_HISTORY_FILE', os.path.join(tmpdir, 'h.json')):
+                update_market_conditions_cache()
+                mock_backfill.assert_called_once()

--- a/tests/test_us2943_verdict_cache.py
+++ b/tests/test_us2943_verdict_cache.py
@@ -406,11 +406,12 @@ class TestComputeMarketConditions:
 class TestCacheIO:
     """Test cache write and read."""
 
+    @patch('market_conditions._backfill_history_if_needed')
     @patch('market_conditions.compute_policy')
     @patch('market_conditions.compute_risk')
     @patch('market_conditions.compute_quadrant')
     @patch('market_conditions.compute_liquidity')
-    def test_cache_write_and_read(self, mock_liq, mock_quad, mock_risk, mock_pol):
+    def test_cache_write_and_read(self, mock_liq, mock_quad, mock_risk, mock_pol, _mock_backfill):
         mock_liq.return_value = _mock_liquidity('Expanding')
         mock_quad.return_value = _mock_quadrant('Goldilocks')
         mock_risk.return_value = _mock_risk('Calm')
@@ -433,7 +434,7 @@ class TestCacheIO:
                 assert 'asset_expectations' in cache_data
                 assert 'updated_at' in cache_data
 
-                # Read back
+                # Read back from history (bug #337: consolidated)
                 loaded = get_market_conditions()
                 assert loaded is not None
                 assert loaded['quadrant'] == 'Goldilocks'
@@ -442,11 +443,12 @@ class TestCacheIO:
                 if os.path.exists(p):
                     os.unlink(p)
 
+    @patch('market_conditions._backfill_history_if_needed')
     @patch('market_conditions.compute_policy')
     @patch('market_conditions.compute_risk')
     @patch('market_conditions.compute_quadrant')
     @patch('market_conditions.compute_liquidity')
-    def test_cache_structure(self, mock_liq, mock_quad, mock_risk, mock_pol):
+    def test_cache_structure(self, mock_liq, mock_quad, mock_risk, mock_pol, _mock_backfill):
         mock_liq.return_value = _mock_liquidity('Neutral')
         mock_quad.return_value = _mock_quadrant('Reflation')
         mock_risk.return_value = _mock_risk('Elevated')
@@ -500,7 +502,8 @@ class TestCacheIO:
             assert result is None
 
     def test_get_cache_returns_none_when_missing(self):
-        with patch('market_conditions.MARKET_CONDITIONS_CACHE_FILE', '/nonexistent/path.json'):
+        with patch('market_conditions.MARKET_CONDITIONS_CACHE_FILE', '/nonexistent/path.json'), \
+             patch('market_conditions.MARKET_CONDITIONS_HISTORY_FILE', '/nonexistent/hist.json'):
             assert get_market_conditions() is None
 
 
@@ -795,8 +798,12 @@ class TestConditionsHistory:
                 # verdict should NOT be in history
                 assert 'verdict' not in entry
                 assert 'verdict_score' not in entry
-                # updated_at should NOT be in history (ephemeral)
-                assert 'updated_at' not in entry
+                # updated_at IS stored (bug #337 — needed for staleness)
+                assert 'updated_at' in entry
+                # growth_score and inflation_score at top level (bug #337)
+                assert 'growth_score' in entry
+                assert 'inflation_score' in entry
+                assert 'raw_quadrant' in entry
         finally:
             os.unlink(tmp)
 
@@ -811,11 +818,12 @@ class TestConditionsHistory:
         finally:
             os.unlink(tmp)
 
+    @patch('market_conditions._backfill_history_if_needed')
     @patch('market_conditions.compute_policy')
     @patch('market_conditions.compute_risk')
     @patch('market_conditions.compute_quadrant')
     @patch('market_conditions.compute_liquidity')
-    def test_cache_update_appends_history(self, mock_liq, mock_quad, mock_risk, mock_pol):
+    def test_cache_update_appends_history(self, mock_liq, mock_quad, mock_risk, mock_pol, _mock_backfill):
         """update_market_conditions_cache() should also append to history."""
         mock_liq.return_value = _mock_liquidity('Expanding')
         mock_quad.return_value = _mock_quadrant('Goldilocks')
@@ -841,11 +849,12 @@ class TestConditionsHistory:
                 if os.path.exists(p):
                     os.unlink(p)
 
+    @patch('market_conditions._backfill_history_if_needed')
     @patch('market_conditions.compute_policy')
     @patch('market_conditions.compute_risk')
     @patch('market_conditions.compute_quadrant')
     @patch('market_conditions.compute_liquidity')
-    def test_cache_update_preserves_existing_history(self, mock_liq, mock_quad, mock_risk, mock_pol):
+    def test_cache_update_preserves_existing_history(self, mock_liq, mock_quad, mock_risk, mock_pol, _mock_backfill):
         """History from previous days should not be overwritten."""
         mock_liq.return_value = _mock_liquidity('Expanding')
         mock_quad.return_value = _mock_quadrant('Goldilocks')


### PR DESCRIPTION
Fixes #337

## Summary
- Add `growth_score` and `inflation_score` to history entries at top level for quadrant trajectory visualization
- Consolidate cache into history file: `get_market_conditions()` reads latest entry from history instead of separate cache file (with legacy fallback)
- Remove separate cache file writes from `update_market_conditions_cache()`
- Add `_backfill_history_if_needed()` to populate 12 months of monthly history when sparse
- Update dashboard trajectory code to prefer top-level scores

## Testing
- ✅ 20 new tests; 5 existing tests updated
- ✅ 378 related tests passing
- ✅ QA verification complete