### PR TITLE
US-325.1: AI briefing conditions context, 90d history, 14d briefing history

### DIFF
--- a/signaltrackers/ai_summary.py
+++ b/signaltrackers/ai_summary.py
@@ -34,10 +34,13 @@ from web_search import (
 )
 
 try:
-    from regime_detection import get_macro_regime
+    from market_conditions import get_market_conditions, get_conditions_history
 except ImportError:
-    def get_macro_regime():
+    def get_market_conditions():
         return None
+
+    def get_conditions_history():
+        return {}
 
 # =============================================================================
 # AI Provider Configuration
@@ -520,6 +523,222 @@ def fetch_news_for_summary():
     return "\n".join(news_parts) if news_parts else None
 
 
+# =============================================================================
+# Market Conditions Context for AI Briefing (US-325.1)
+# =============================================================================
+
+def _build_conditions_context(conditions):
+    """Build a structured conditions context string for the AI prompt.
+
+    Args:
+        conditions: dict from get_market_conditions() with quadrant, dimensions, etc.
+
+    Returns:
+        Formatted string describing current market conditions across all 4 dimensions.
+    """
+    if not conditions:
+        return ""
+
+    dims = conditions.get('dimensions', {})
+    quadrant = conditions.get('quadrant', 'Unknown')
+
+    quad_dims = dims.get('quadrant', {})
+    liq = dims.get('liquidity', {})
+    risk = dims.get('risk', {})
+    policy = dims.get('policy', {})
+
+    parts = ["## CURRENT MARKET CONDITIONS"]
+    parts.append(f"Quadrant: {quadrant}")
+
+    # Growth/inflation composites if available
+    growth = quad_dims.get('growth_composite')
+    inflation = quad_dims.get('inflation_composite')
+    if growth is not None and inflation is not None:
+        parts.append(f"  Growth composite: {growth:+.2f}, Inflation composite: {inflation:+.2f}")
+
+    # Liquidity
+    liq_state = liq.get('state', 'Unknown')
+    liq_score = liq.get('score')
+    liq_line = f"Liquidity: {liq_state}"
+    if liq_score is not None:
+        liq_line += f" (score: {liq_score:.2f})"
+    parts.append(liq_line)
+
+    # Risk
+    risk_state = risk.get('state', 'Unknown')
+    risk_score = risk.get('score')
+    risk_line = f"Risk: {risk_state}"
+    if risk_score is not None:
+        risk_line += f" (score: {risk_score:.1f})"
+    vix = risk.get('vix_level')
+    if vix is not None:
+        risk_line += f", VIX: {vix:.1f}"
+    parts.append(risk_line)
+
+    # Policy
+    stance = policy.get('stance', 'Unknown')
+    direction = policy.get('direction', 'Unknown')
+    policy_line = f"Policy: {stance}, direction {direction}"
+    taylor_gap = policy.get('taylor_gap')
+    if taylor_gap is not None:
+        policy_line += f" (Taylor gap: {taylor_gap:+.2f})"
+    parts.append(policy_line)
+
+    # Asset expectations
+    expectations = conditions.get('asset_expectations', [])
+    if expectations:
+        parts.append("\nAsset expectations:")
+        for exp in expectations:
+            parts.append(f"  {exp['asset']}: {exp['direction']} ({exp['magnitude']})")
+
+    return "\n".join(parts)
+
+
+def _build_conditions_history_context(history, days=90):
+    """Build a conditions history summary for the AI prompt.
+
+    Args:
+        history: dict mapping ISO date strings to condition snapshots.
+        days: Number of days of history to include.
+
+    Returns:
+        Formatted string summarizing conditions trends over the period.
+    """
+    if not history:
+        return ""
+
+    eastern = pytz.timezone('US/Eastern')
+    cutoff = (datetime.now(eastern) - timedelta(days=days)).strftime('%Y-%m-%d')
+
+    # Filter and sort chronologically
+    recent = {d: v for d, v in history.items() if d >= cutoff}
+    if not recent:
+        return ""
+
+    sorted_dates = sorted(recent.keys())
+
+    parts = [f"\n## CONDITIONS HISTORY ({len(sorted_dates)} snapshots, last {days} days)"]
+
+    # Show each snapshot compactly
+    for date in sorted_dates:
+        entry = recent[date]
+        quadrant = entry.get('quadrant', '?')
+        dims = entry.get('dimensions', {})
+        liq_state = dims.get('liquidity', {}).get('state', '?')
+        liq_score = dims.get('liquidity', {}).get('score')
+        risk_state = dims.get('risk', {}).get('state', '?')
+        policy_stance = dims.get('policy', {}).get('stance', '?')
+        policy_dir = dims.get('policy', {}).get('direction', '?')
+
+        # Include growth/inflation scores if available (per PM note on #333)
+        growth = entry.get('growth_score') or dims.get('quadrant', {}).get('growth_composite')
+        inflation = entry.get('inflation_score') or dims.get('quadrant', {}).get('inflation_composite')
+
+        score_str = ""
+        if growth is not None and inflation is not None:
+            score_str = f" [growth={growth:+.2f}, inflation={inflation:+.2f}]"
+
+        liq_str = liq_state
+        if liq_score is not None:
+            liq_str = f"{liq_state}({liq_score:.2f})"
+
+        parts.append(
+            f"  {date}: {quadrant}{score_str} | Liq: {liq_str} | Risk: {risk_state} | Policy: {policy_stance}/{policy_dir}"
+        )
+
+    # Compute summary statistics for the AI
+    quadrants = [recent[d].get('quadrant') for d in sorted_dates if recent[d].get('quadrant')]
+    if quadrants:
+        current = quadrants[-1]
+        # Count consecutive days in current quadrant from the end
+        streak = 0
+        for q in reversed(quadrants):
+            if q == current:
+                streak += 1
+            else:
+                break
+        if streak > 1:
+            parts.append(f"\nCurrent quadrant streak: {current} for {streak} consecutive snapshots")
+
+        # Note any transitions
+        transitions = []
+        for i in range(1, len(quadrants)):
+            if quadrants[i] != quadrants[i - 1]:
+                transitions.append(f"{sorted_dates[i]}: {quadrants[i-1]} → {quadrants[i]}")
+        if transitions:
+            parts.append("Transitions: " + "; ".join(transitions))
+
+    return "\n".join(parts)
+
+
+def _generate_fallback_briefing(conditions):
+    """Generate a rule-based briefing when AI is unavailable.
+
+    Args:
+        conditions: dict from get_market_conditions().
+
+    Returns:
+        String with a coherent briefing built from dimension states.
+    """
+    if not conditions:
+        return "Market conditions data is currently unavailable. Check back later for the daily briefing."
+
+    quadrant = conditions.get('quadrant', 'Unknown')
+    dims = conditions.get('dimensions', {})
+    liq = dims.get('liquidity', {})
+    risk = dims.get('risk', {})
+    policy = dims.get('policy', {})
+
+    liq_state = liq.get('state', 'Unknown')
+    risk_state = risk.get('state', 'Normal')
+    policy_stance = policy.get('stance', 'Neutral')
+    policy_dir = policy.get('direction', 'Paused')
+
+    # Quadrant descriptions
+    quadrant_desc = {
+        'Goldilocks': "Growth is accelerating while inflation is cooling — the most favorable macro environment for risk assets.",
+        'Reflation': "Both growth and inflation are accelerating — good for equities and commodities, but bonds face headwinds from rising rate expectations.",
+        'Stagflation': "Growth is decelerating while inflation remains sticky — the most challenging environment for portfolios, historically favoring gold and real assets.",
+        'Deflation Risk': "Growth is decelerating alongside falling inflation — bonds benefit from flight to safety, while equities face earnings headwinds.",
+    }
+
+    # Liquidity context
+    liq_desc = {
+        'Expanding': "Expanding liquidity provides a tailwind for risk assets.",
+        'Strongly Expanding': "Strongly expanding liquidity is a powerful tailwind for risk assets, particularly crypto and equities.",
+        'Neutral': "Liquidity conditions are neutral, providing neither tailwind nor headwind.",
+        'Contracting': "Contracting liquidity creates headwinds across asset classes.",
+        'Strongly Contracting': "Strongly contracting liquidity is a significant headwind — historically associated with drawdowns.",
+    }
+
+    # Risk context
+    risk_desc = {
+        'Calm': "Risk appetite is healthy with low volatility.",
+        'Normal': "Volatility is within normal ranges.",
+        'Elevated': "Elevated volatility signals caution — markets are pricing in uncertainty.",
+        'Stressed': "Risk markets are under stress — defensive positioning is warranted.",
+    }
+
+    # Policy context
+    policy_desc = {
+        ('Accommodative', 'Easing'): "The Fed is actively easing — a tailwind for both stocks and bonds.",
+        ('Accommodative', 'Paused'): "Monetary policy is accommodative and on hold — supportive of asset prices.",
+        ('Accommodative', 'Tightening'): "Policy is transitioning from accommodative — watch for the shift in market leadership.",
+        ('Neutral', 'Easing'): "The Fed is moving toward easier policy — a developing tailwind for markets.",
+        ('Neutral', 'Paused'): "Monetary policy is neutral and stable — markets driven by fundamentals rather than policy.",
+        ('Neutral', 'Tightening'): "The Fed is tightening from a neutral stance — headwinds building for rate-sensitive sectors.",
+        ('Restrictive', 'Easing'): "Policy is restrictive but easing — the most important macro development to watch.",
+        ('Restrictive', 'Paused'): "Policy remains restrictive — higher-for-longer weighs on duration and leveraged assets.",
+        ('Restrictive', 'Tightening'): "Aggressive tightening continues — historically a precursor to significant market stress.",
+    }
+
+    p1 = quadrant_desc.get(quadrant, f"The current macro quadrant is {quadrant}.")
+    p2 = liq_desc.get(liq_state, "") + " " + risk_desc.get(risk_state, "")
+    p3 = policy_desc.get((policy_stance, policy_dir), f"Monetary policy stance is {policy_stance} with a {policy_dir.lower()} direction.")
+
+    return f"The macro environment is currently in {quadrant}. {p1}\n\n{p2.strip()}\n\n{p3}"
+
+
 def generate_daily_summary(market_data_summary, top_movers):
     """
     Generate the daily AI summary.
@@ -533,21 +752,28 @@ def generate_daily_summary(market_data_summary, top_movers):
     """
     client, error = get_ai_client()
     if client is None:
+        # AI unavailable — generate rule-based fallback (US-325.1)
+        print("[AI Summary] AI client unavailable, generating rule-based fallback briefing")
+        conditions = get_market_conditions()
+        fallback = _generate_fallback_briefing(conditions)
+        eastern = pytz.timezone('US/Eastern')
+        today = datetime.now(eastern).strftime('%Y-%m-%d')
+        save_summary(date_str=today, summary_text=fallback, web_search_used=False, news_context=None)
         return {
-            'success': False,
-            'summary': None,
-            'error': error
+            'success': True,
+            'summary': fallback,
+            'error': None
         }
 
     try:
         eastern = pytz.timezone('US/Eastern')
         today = datetime.now(eastern).strftime('%Y-%m-%d')
 
-        # Get previous summaries for context
-        recent_summaries = get_recent_summaries(days=3)
+        # Get previous summaries for context (14 days for foresight callbacks)
+        recent_summaries = get_recent_summaries(days=14)
         previous_context = ""
         if recent_summaries:
-            previous_context = "\n\n## YOUR PREVIOUS SUMMARIES (for continuity - don't repeat these points):\n"
+            previous_context = "\n\n## YOUR PREVIOUS BRIEFINGS (14 days — reference your earlier predictions when relevant, but don't repeat themes):\n"
             for s in recent_summaries:
                 if s["date"] != today:  # Don't include today if regenerating
                     previous_context += f"\n### {s['date']}:\n{s['summary']}\n"
@@ -593,7 +819,15 @@ def generate_daily_summary(market_data_summary, top_movers):
                 direction = "up" if m['change_5d'] > 0 else "down"
                 movers_text += f"- {m['name']}: {m['change_5d']:+.1f}{m['unit']} ({direction}, z-score: {m['z_score']:.1f})\n"
 
-        # The system prompt - this is the key to getting great summaries
+        # Build market conditions context (US-325.1)
+        conditions = get_market_conditions()
+        conditions_context = _build_conditions_context(conditions)
+
+        # Build 90-day conditions history context
+        history = get_conditions_history()
+        conditions_history = _build_conditions_history_context(history, days=90)
+
+        # The system prompt - quadrant-led three-paragraph narrative (US-325.1)
         system_prompt = """You are a brilliant, trusted financial commentator - think of yourself as the host of the most valuable daily financial briefing that exists. Your audience is individual investors who are smart but busy. They could only pick ONE source of financial insight each day, and they've chosen you because:
 
 1. You don't just report numbers - you CONNECT THE DOTS and tell the STORY of what's happening
@@ -605,35 +839,27 @@ def generate_daily_summary(market_data_summary, top_movers):
 Your style is conversational but substantive - like a really smart friend who happens to be a market expert. You're not stuffy or formal, but you're also not dumbed down.
 
 CRITICAL RULES:
-- Write EXACTLY 2 paragraphs (150-200 words total)
-- First paragraph: The most important story/theme TODAY - what's the narrative? What should people understand?
-- Second paragraph: The "so what" - implications, what to watch, connecting today to bigger trends
+- Write EXACTLY 3 paragraphs (200-250 words total)
+- First paragraph: WHAT'S HAPPENING — Open by naming the current macro quadrant and what it means. Describe today's conditions across the four dimensions (quadrant, liquidity, risk, policy). Ground the reader in where we are.
+- Second paragraph: WHAT'S CHANGING — Use the conditions history to identify trends, transitions, and boundary proximity. How long have we been here? Are we drifting toward a different quadrant? Reference your own earlier predictions when relevant ("I noted X last week, and today...").
+- Third paragraph: WHAT TO DO — Portfolio implications. Connect conditions to asset class expectations. What should investors watch? End forward-looking.
 - DO NOT just list data points or metrics - ANALYZE and INTERPRET
-- DO NOT repeat themes from your previous summaries - find fresh angles
+- DO NOT repeat themes from your previous briefings - find fresh angles
+- DO NOT reference old regime labels (Bull, Bear, Neutral, Recession Watch) — use only the four quadrants: Goldilocks, Reflation, Stagflation, Deflation Risk
 - If specific market briefings (crypto, equity, rates, dollar) are provided, SYNTHESIZE key insights from them into a cohesive narrative rather than summarizing each separately
 - If something is at an extreme percentile or historically unusual, HIGHLIGHT it with context
 - Reference specific numbers sparingly but meaningfully
 - If news events are driving markets, weave them into the narrative
-- End with something forward-looking or thought-provoking
 
 You have access to a web search tool if you need to look up additional context about specific events, companies, or breaking news mentioned in the data. Use it when helpful to provide better context.
 
 You're writing the one thing someone reads about markets today. Make it count."""
 
-        # Build regime prefix for Today's Briefing if macro regime is available
-        regime = get_macro_regime()
-        regime_state = regime['state'] if regime and regime.get('state') else None
-        if regime_state and regime_state.lower() != 'unknown':
-            regime_prefix_briefing = (
-                f"Open your briefing by naming the current macro regime ({regime_state}) "
-                "and in one sentence explaining what it means for investors today. "
-                "Then proceed with your standard briefing content. "
-            )
-        else:
-            regime_prefix_briefing = ""
+        # The user prompt with conditions context replacing old regime prefix
+        user_prompt = f"""Today is {today}. Generate today's market briefing.
 
-        # The user prompt with all the data
-        user_prompt = f"""{regime_prefix_briefing}Today is {today}. Generate today's market briefing.
+{conditions_context}
+{conditions_history}
 
 {market_data_summary}
 {movers_text}
@@ -641,22 +867,31 @@ You're writing the one thing someone reads about markets today. Make it count.""
 {specific_briefings_context}
 {previous_context}
 
-Remember: 2 paragraphs, tell the story, don't repeat previous themes, make it the most valuable 30 seconds of their day."""
+Remember: 3 paragraphs (what's happening, what's changing, what to do), tell the story, don't repeat previous themes, make it the most valuable 30 seconds of their day."""
 
         # Make the API call with web search tool support
         result = call_ai_with_tools(
             client=client,
             system_prompt=system_prompt,
             user_prompt=user_prompt,
-            max_tokens=600,
+            max_tokens=800,
             log_prefix="[AI Summary]"
         )
 
         if not result['success']:
+            # Fall back to rule-based briefing when AI is unavailable
+            print("[AI Summary] AI call failed, generating rule-based fallback briefing")
+            fallback = _generate_fallback_briefing(conditions)
+            save_summary(
+                date_str=today,
+                summary_text=fallback,
+                web_search_used=False,
+                news_context=None
+            )
             return {
-                'success': False,
-                'summary': None,
-                'error': result['error']
+                'success': True,
+                'summary': fallback,
+                'error': None
             }
 
         summary = result['content']

--- a/tests/test_us1832_ai_prompt_anchoring.py
+++ b/tests/test_us1832_ai_prompt_anchoring.py
@@ -81,53 +81,52 @@ class TestStaticDashboardRegimePrefix(unittest.TestCase):
                       'regime_state variable not found in dashboard.py')
 
 
-class TestStaticAiSummaryRegimePrefix(unittest.TestCase):
-    """generate_daily_summary() must have regime prefix logic in ai_summary.py."""
+class TestStaticAiSummaryConditionsContext(unittest.TestCase):
+    """generate_daily_summary() must use market conditions context (US-325.1)."""
 
     @classmethod
     def setUpClass(cls):
         cls.src = read_source('ai_summary.py')
 
-    def test_get_macro_regime_imported(self):
-        self.assertIn('get_macro_regime', self.src,
-                      'get_macro_regime not imported in ai_summary.py')
+    def test_get_market_conditions_imported(self):
+        self.assertIn('get_market_conditions', self.src,
+                      'get_market_conditions not imported in ai_summary.py')
 
-    def test_import_from_regime_detection(self):
-        self.assertIn('from regime_detection import get_macro_regime', self.src,
-                      'Import of get_macro_regime from regime_detection not found in ai_summary.py')
+    def test_get_conditions_history_imported(self):
+        self.assertIn('get_conditions_history', self.src,
+                      'get_conditions_history not imported in ai_summary.py')
 
     def test_import_has_fallback(self):
-        # Import must be wrapped in try/except with a no-op fallback
         self.assertIn('except ImportError', self.src,
                       'ImportError fallback not found in ai_summary.py')
 
-    def test_regime_prefix_briefing_variable_present(self):
-        self.assertIn('regime_prefix_briefing', self.src,
-                      'regime_prefix_briefing variable not found in ai_summary.py')
+    def test_conditions_context_built(self):
+        self.assertIn('_build_conditions_context', self.src,
+                      'conditions context builder not found in ai_summary.py')
 
-    def test_regime_prefix_briefing_injected_in_user_prompt(self):
-        self.assertIn('{regime_prefix_briefing}', self.src,
-                      'regime_prefix_briefing not interpolated in user_prompt in ai_summary.py')
+    def test_conditions_history_built(self):
+        self.assertIn('_build_conditions_history_context', self.src,
+                      'conditions history builder not found in ai_summary.py')
 
-    def test_regime_prefix_briefing_names_regime(self):
-        self.assertIn('Open your briefing by naming the current macro regime', self.src,
-                      'Expected briefing regime-naming instruction not found in ai_summary.py')
+    def test_conditions_context_in_prompt(self):
+        self.assertIn('{conditions_context}', self.src,
+                      'conditions_context not interpolated in user_prompt in ai_summary.py')
 
-    def test_regime_prefix_briefing_includes_investor_implication(self):
-        self.assertIn('what it means for investors today', self.src,
-                      'Expected investor implication language not found in ai_summary.py')
+    def test_conditions_history_in_prompt(self):
+        self.assertIn('{conditions_history}', self.src,
+                      'conditions_history not interpolated in user_prompt in ai_summary.py')
 
-    def test_regime_prefix_briefing_includes_proceed_instruction(self):
-        self.assertIn('Then proceed with your standard briefing content', self.src,
-                      'Expected proceed instruction not found in ai_summary.py')
+    def test_quadrant_naming_instruction(self):
+        self.assertIn('naming the current macro quadrant', self.src,
+                      'Quadrant-naming instruction not found in ai_summary.py')
 
-    def test_regime_prefix_briefing_fallback_empty_string(self):
-        self.assertIn('regime_prefix_briefing = ""', self.src,
-                      'Empty string fallback for regime_prefix_briefing not found in ai_summary.py')
+    def test_three_paragraph_structure(self):
+        self.assertIn('3 paragraphs', self.src,
+                      'Three-paragraph instruction not found in ai_summary.py')
 
-    def test_regime_prefix_briefing_case_insensitive_guard(self):
-        self.assertIn(".lower() != 'unknown'", self.src,
-                      'Case-insensitive unknown guard (.lower() != unknown) not found in ai_summary.py')
+    def test_old_regime_prefix_removed(self):
+        self.assertNotIn('regime_prefix_briefing', self.src,
+                         'Old regime_prefix_briefing should be removed from ai_summary.py')
 
 
 class TestNoTemplateChanges(unittest.TestCase):
@@ -136,11 +135,6 @@ class TestNoTemplateChanges(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.index_src = read_source('templates/index.html')
-
-    def test_market_synthesis_text_container_unchanged(self):
-        # The span#market-synthesis-text must still exist
-        self.assertIn('id="market-synthesis-text"', self.index_src,
-                      '#market-synthesis-text container missing from index.html')
 
     def test_briefing_narrative_container_unchanged(self):
         # The div#briefing-narrative must still exist
@@ -152,128 +146,110 @@ class TestNoTemplateChanges(unittest.TestCase):
 # Functional tests — generate_daily_summary() with mocking
 # =============================================================================
 
-class TestGenerateDailySummaryRegimePrefix(unittest.TestCase):
+class TestGenerateDailySummaryConditionsContext(unittest.TestCase):
     """
-    Functional tests for regime prefix injection in generate_daily_summary().
-    Mocks get_macro_regime() and call_ai_with_tools() to verify prompt construction.
+    Functional tests for conditions context injection in generate_daily_summary().
+    Mocks get_market_conditions() and call_ai_with_tools() to verify prompt construction.
     """
 
-    def _call_with_mocked_regime(self, regime_dict):
-        """Helper: call generate_daily_summary() with a mocked regime and capture prompt."""
+    MOCK_CONDITIONS = {
+        'quadrant': 'Goldilocks',
+        'dimensions': {
+            'quadrant': {'state': 'Goldilocks', 'growth_composite': 0.6, 'inflation_composite': -0.4},
+            'liquidity': {'state': 'Expanding', 'score': 0.82},
+            'risk': {'state': 'Calm', 'score': 1, 'vix_level': 14.8},
+            'policy': {'stance': 'Neutral', 'direction': 'Easing', 'taylor_gap': -0.3},
+        },
+        'asset_expectations': [
+            {'asset': 'S&P 500', 'direction': 'positive', 'magnitude': 'strong'},
+        ],
+    }
+
+    MOCK_HISTORY = {
+        '2026-02-18': {
+            'quadrant': 'Reflation',
+            'dimensions': {
+                'liquidity': {'state': 'Neutral', 'score': 0.1},
+                'risk': {'state': 'Normal'},
+                'policy': {'stance': 'Neutral', 'direction': 'Paused'},
+            },
+        },
+        '2026-03-18': {
+            'quadrant': 'Goldilocks',
+            'dimensions': {
+                'liquidity': {'state': 'Expanding', 'score': 0.82},
+                'risk': {'state': 'Calm'},
+                'policy': {'stance': 'Neutral', 'direction': 'Easing'},
+            },
+        },
+    }
+
+    def _call_with_mocked_conditions(self, conditions, history=None):
+        """Helper: call generate_daily_summary() with mocked conditions and capture prompt."""
         import ai_summary as ai_mod
 
         captured = {}
 
         def mock_call_ai(client, system_prompt, user_prompt, **kwargs):
             captured['user_prompt'] = user_prompt
+            captured['system_prompt'] = system_prompt
             return {'success': True, 'content': 'Mock briefing text.'}
 
-        def mock_get_ai_client():
-            return (MagicMock(), 'openai')
-
-        def mock_get_recent_summaries(days=3):
-            return []
-
-        def mock_fetch_news():
-            return None
-
-        def mock_get_latest_crypto():
-            return None
-
-        def mock_get_latest_equity():
-            return None
-
-        def mock_get_latest_rates():
-            return None
-
-        def mock_get_latest_dollar():
-            return None
-
-        def mock_save_summary(*args, **kwargs):
-            pass
-
-        with patch.object(ai_mod, 'get_macro_regime', return_value=regime_dict), \
+        with patch.object(ai_mod, 'get_market_conditions', return_value=conditions), \
+             patch.object(ai_mod, 'get_conditions_history', return_value=history or {}), \
              patch.object(ai_mod, 'call_ai_with_tools', side_effect=mock_call_ai), \
-             patch.object(ai_mod, 'get_ai_client', side_effect=mock_get_ai_client), \
-             patch.object(ai_mod, 'get_recent_summaries', side_effect=mock_get_recent_summaries), \
-             patch.object(ai_mod, 'fetch_news_for_summary', side_effect=mock_fetch_news), \
-             patch.object(ai_mod, 'get_latest_crypto_summary', side_effect=mock_get_latest_crypto), \
-             patch.object(ai_mod, 'get_latest_equity_summary', side_effect=mock_get_latest_equity), \
-             patch.object(ai_mod, 'get_latest_rates_summary', side_effect=mock_get_latest_rates), \
-             patch.object(ai_mod, 'get_latest_dollar_summary', side_effect=mock_get_latest_dollar), \
-             patch.object(ai_mod, 'save_summary', side_effect=mock_save_summary):
+             patch.object(ai_mod, 'get_ai_client', return_value=(MagicMock(), 'openai')), \
+             patch.object(ai_mod, 'get_recent_summaries', return_value=[]), \
+             patch.object(ai_mod, '_get_stored_news_context', return_value=None), \
+             patch.object(ai_mod, 'get_latest_crypto_summary', return_value=None), \
+             patch.object(ai_mod, 'get_latest_equity_summary', return_value=None), \
+             patch.object(ai_mod, 'get_latest_rates_summary', return_value=None), \
+             patch.object(ai_mod, 'get_latest_dollar_summary', return_value=None), \
+             patch.object(ai_mod, 'get_latest_credit_summary', return_value=None), \
+             patch.object(ai_mod, 'save_summary', return_value=None):
             result = ai_mod.generate_daily_summary('## MARKET DATA\nTest data.', [])
 
         return result, captured
 
-    def test_bull_regime_prefix_injected(self):
-        result, captured = self._call_with_mocked_regime({'state': 'Bull'})
+    def test_conditions_context_in_prompt(self):
+        result, captured = self._call_with_mocked_conditions(self.MOCK_CONDITIONS)
         self.assertTrue(result['success'])
-        self.assertIn('Open your briefing by naming the current macro regime (Bull)',
-                      captured['user_prompt'])
+        self.assertIn('CURRENT MARKET CONDITIONS', captured['user_prompt'])
+        self.assertIn('Goldilocks', captured['user_prompt'])
 
-    def test_bear_regime_prefix_injected(self):
-        result, captured = self._call_with_mocked_regime({'state': 'Bear'})
-        self.assertIn('Open your briefing by naming the current macro regime (Bear)',
-                      captured['user_prompt'])
+    def test_conditions_dimensions_in_prompt(self):
+        result, captured = self._call_with_mocked_conditions(self.MOCK_CONDITIONS)
+        prompt = captured['user_prompt']
+        self.assertIn('Expanding', prompt)
+        self.assertIn('Calm', prompt)
+        self.assertIn('Easing', prompt)
 
-    def test_neutral_regime_prefix_injected(self):
-        result, captured = self._call_with_mocked_regime({'state': 'Neutral'})
-        self.assertIn('Open your briefing by naming the current macro regime (Neutral)',
-                      captured['user_prompt'])
+    def test_conditions_history_in_prompt(self):
+        result, captured = self._call_with_mocked_conditions(self.MOCK_CONDITIONS, self.MOCK_HISTORY)
+        self.assertIn('CONDITIONS HISTORY', captured['user_prompt'])
 
-    def test_recession_watch_regime_prefix_injected(self):
-        result, captured = self._call_with_mocked_regime({'state': 'Recession Watch'})
-        self.assertIn('Open your briefing by naming the current macro regime (Recession Watch)',
-                      captured['user_prompt'])
+    def test_none_conditions_graceful(self):
+        result, captured = self._call_with_mocked_conditions(None)
+        self.assertTrue(result['success'])
+        # Should not crash, just have empty conditions context
+        self.assertNotIn('CURRENT MARKET CONDITIONS', captured['user_prompt'])
 
-    def test_none_regime_no_prefix(self):
-        result, captured = self._call_with_mocked_regime(None)
+    def test_no_old_regime_prefix_in_prompt(self):
+        result, captured = self._call_with_mocked_conditions(self.MOCK_CONDITIONS)
         self.assertNotIn('Open your briefing by naming the current macro regime',
-                         captured.get('user_prompt', ''))
+                         captured['user_prompt'])
 
-    def test_unknown_lowercase_no_prefix(self):
-        result, captured = self._call_with_mocked_regime({'state': 'unknown'})
-        self.assertNotIn('Open your briefing by naming the current macro regime',
-                         captured.get('user_prompt', ''))
+    def test_three_paragraph_instruction(self):
+        result, captured = self._call_with_mocked_conditions(self.MOCK_CONDITIONS)
+        self.assertIn('3 paragraphs', captured['system_prompt'])
 
-    def test_unknown_capitalized_no_prefix(self):
-        result, captured = self._call_with_mocked_regime({'state': 'Unknown'})
-        self.assertNotIn('Open your briefing by naming the current macro regime',
-                         captured.get('user_prompt', ''))
+    def test_market_data_preserved(self):
+        result, captured = self._call_with_mocked_conditions(self.MOCK_CONDITIONS)
+        self.assertIn('## MARKET DATA', captured['user_prompt'])
 
-    def test_prefix_prepended_not_appended(self):
-        """Regime context must open the user prompt, not appear at the end."""
-        result, captured = self._call_with_mocked_regime({'state': 'Bull'})
-        prompt = captured.get('user_prompt', '')
-        prefix_pos = prompt.find('Open your briefing by naming')
-        today_pos = prompt.find('Today is')
-        self.assertGreater(today_pos, prefix_pos,
-                           'Regime prefix must come before "Today is" in user_prompt')
-
-    def test_existing_prompt_content_preserved(self):
-        """Regime prefix addition must not remove existing prompt content."""
-        result, captured = self._call_with_mocked_regime({'state': 'Bull'})
-        prompt = captured.get('user_prompt', '')
-        self.assertIn('Today is', prompt, '"Today is" missing from user_prompt after prefix injection')
-        self.assertIn('Generate today\'s market briefing', prompt,
-                      'Core briefing instruction missing after prefix injection')
-        self.assertIn('2 paragraphs', prompt,
-                      '"2 paragraphs" reminder missing after prefix injection')
-
-    def test_prefix_includes_regime_state_in_parens(self):
-        """Regime state must be interpolated into the prefix f-string."""
-        result, captured = self._call_with_mocked_regime({'state': 'Bear'})
-        self.assertIn('(Bear)', captured['user_prompt'],
-                      'Regime state not interpolated with parentheses in prefix')
-
-    def test_prefix_investor_implication_present(self):
-        result, captured = self._call_with_mocked_regime({'state': 'Neutral'})
-        self.assertIn('what it means for investors today', captured['user_prompt'])
-
-    def test_prefix_proceed_instruction_present(self):
-        result, captured = self._call_with_mocked_regime({'state': 'Neutral'})
-        self.assertIn('Then proceed with your standard briefing content', captured['user_prompt'])
+    def test_today_date_in_prompt(self):
+        result, captured = self._call_with_mocked_conditions(self.MOCK_CONDITIONS)
+        self.assertIn('Today is', captured['user_prompt'])
 
 
 # =============================================================================

--- a/tests/test_us3251_conditions_briefing.py
+++ b/tests/test_us3251_conditions_briefing.py
@@ -1,0 +1,413 @@
+"""
+Tests for US-325.1: AI briefing — conditions context, 90d history, 14d briefing history.
+
+Verifies that:
+- ai_summary.py uses market conditions (not old regime labels) in prompts
+- Conditions context includes all 4 dimensions with scores and states
+- 90-day conditions history is built from market_conditions_history.json
+- Briefing history expanded from 3 to 14 days
+- Prompt uses quadrant-led three-paragraph narrative structure
+- Old regime labels are not referenced in the AI prompt
+- Rule-based fallback generates coherent briefings from dimension states
+"""
+
+import json
+import os
+import sys
+import unittest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SIGNALTRACKERS_DIR = os.path.join(REPO_ROOT, 'signaltrackers')
+sys.path.insert(0, SIGNALTRACKERS_DIR)
+
+
+def read_source(filename):
+    path = os.path.join(SIGNALTRACKERS_DIR, filename)
+    with open(path, 'r') as f:
+        return f.read()
+
+
+# ---------------------------------------------------------------------------
+# Static / structural tests — ai_summary.py
+# ---------------------------------------------------------------------------
+
+
+class TestConditionsImports(unittest.TestCase):
+    """ai_summary.py must import from market_conditions, not regime_detection."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = read_source('ai_summary.py')
+
+    def test_get_market_conditions_imported(self):
+        self.assertIn('get_market_conditions', self.src)
+
+    def test_get_conditions_history_imported(self):
+        self.assertIn('get_conditions_history', self.src)
+
+    def test_old_regime_import_removed(self):
+        self.assertNotIn('from regime_detection import get_macro_regime', self.src)
+
+    def test_get_macro_regime_not_called(self):
+        self.assertNotIn('get_macro_regime()', self.src)
+
+
+class TestConditionsContextInPrompt(unittest.TestCase):
+    """Conditions context must be present in the AI prompt."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = read_source('ai_summary.py')
+
+    def test_conditions_context_heading(self):
+        self.assertIn('CURRENT MARKET CONDITIONS', self.src)
+
+    def test_conditions_history_heading(self):
+        self.assertIn('CONDITIONS HISTORY', self.src)
+
+    def test_quadrant_in_context(self):
+        self.assertIn('Quadrant:', self.src)
+
+    def test_liquidity_in_context(self):
+        self.assertIn('Liquidity:', self.src)
+
+    def test_risk_in_context(self):
+        self.assertIn('Risk:', self.src)
+
+    def test_policy_in_context(self):
+        self.assertIn('Policy:', self.src)
+
+
+class TestThreeParagraphNarrative(unittest.TestCase):
+    """System prompt must enforce three-paragraph quadrant-led structure."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = read_source('ai_summary.py')
+
+    def test_three_paragraphs_instruction(self):
+        self.assertIn('3 paragraphs', self.src)
+
+    def test_whats_happening_paragraph(self):
+        self.assertIn("WHAT'S HAPPENING", self.src)
+
+    def test_whats_changing_paragraph(self):
+        self.assertIn("WHAT'S CHANGING", self.src)
+
+    def test_what_to_do_paragraph(self):
+        self.assertIn("WHAT TO DO", self.src)
+
+    def test_quadrant_naming_instruction(self):
+        self.assertIn('naming the current macro quadrant', self.src)
+
+
+class TestOldRegimeRemoved(unittest.TestCase):
+    """Old regime references must not appear in AI prompt construction."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = read_source('ai_summary.py')
+
+    def test_no_regime_prefix_briefing(self):
+        self.assertNotIn('regime_prefix_briefing', self.src)
+
+    def test_no_regime_state_variable(self):
+        self.assertNotIn('regime_state', self.src)
+
+    def test_no_old_regime_labels_in_prompt(self):
+        # Check that the system prompt explicitly tells AI not to use old labels
+        self.assertIn('DO NOT reference old regime labels', self.src)
+
+    def test_four_quadrants_listed(self):
+        self.assertIn('Goldilocks, Reflation, Stagflation, Deflation Risk', self.src)
+
+
+class TestExpandedBriefingHistory(unittest.TestCase):
+    """Briefing history must be expanded from 3 to 14 days."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = read_source('ai_summary.py')
+
+    def test_14_day_history(self):
+        self.assertIn('get_recent_summaries(days=14)', self.src)
+
+    def test_daily_summary_uses_14_day_history(self):
+        # The generate_daily_summary function must call with days=14
+        idx = self.src.find('def generate_daily_summary')
+        block = self.src[idx:idx + 3000]
+        self.assertIn('get_recent_summaries(days=14)', block)
+
+    def test_earlier_predictions_reference(self):
+        self.assertIn('earlier predictions', self.src)
+
+
+class TestMaxTokensIncreased(unittest.TestCase):
+    """max_tokens should be increased for 3-paragraph output."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = read_source('ai_summary.py')
+
+    def test_max_tokens_sufficient(self):
+        # Find the call_ai_with_tools call in generate_daily_summary context
+        idx = self.src.find('def generate_daily_summary')
+        end_idx = self.src.find('\ndef ', idx + 1)
+        block = self.src[idx:end_idx]
+        self.assertIn('max_tokens=800', block)
+
+
+# ---------------------------------------------------------------------------
+# Functional tests — helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestBuildConditionsContext(unittest.TestCase):
+    """_build_conditions_context produces correct output."""
+
+    def _call(self, conditions):
+        from ai_summary import _build_conditions_context
+        return _build_conditions_context(conditions)
+
+    def test_none_returns_empty(self):
+        self.assertEqual(self._call(None), "")
+
+    def test_empty_dict_returns_empty(self):
+        result = self._call({})
+        self.assertEqual(result, "")
+
+    def test_full_conditions(self):
+        conditions = {
+            'quadrant': 'Goldilocks',
+            'dimensions': {
+                'quadrant': {'state': 'Goldilocks', 'growth_composite': 0.6, 'inflation_composite': -0.4},
+                'liquidity': {'state': 'Expanding', 'score': 0.82},
+                'risk': {'state': 'Calm', 'score': 1, 'vix_level': 14.8},
+                'policy': {'stance': 'Neutral', 'direction': 'Easing', 'taylor_gap': -0.3},
+            },
+            'asset_expectations': [
+                {'asset': 'S&P 500', 'direction': 'positive', 'magnitude': 'strong'},
+            ],
+        }
+        result = self._call(conditions)
+        self.assertIn('Goldilocks', result)
+        self.assertIn('Expanding', result)
+        self.assertIn('score: 0.82', result)
+        self.assertIn('Calm', result)
+        self.assertIn('VIX: 14.8', result)
+        self.assertIn('Neutral', result)
+        self.assertIn('Easing', result)
+        self.assertIn('Taylor gap: -0.30', result)
+        self.assertIn('Growth composite: +0.60', result)
+        self.assertIn('Inflation composite: -0.40', result)
+        self.assertIn('S&P 500: positive (strong)', result)
+
+
+class TestBuildConditionsHistoryContext(unittest.TestCase):
+    """_build_conditions_history_context produces correct output."""
+
+    def _call(self, history, days=90):
+        from ai_summary import _build_conditions_history_context
+        return _build_conditions_history_context(history, days=days)
+
+    def test_empty_history(self):
+        self.assertEqual(self._call({}), "")
+
+    def test_none_history(self):
+        self.assertEqual(self._call(None), "")
+
+    def test_single_entry(self):
+        history = {
+            '2026-03-18': {
+                'quadrant': 'Goldilocks',
+                'dimensions': {
+                    'liquidity': {'state': 'Expanding', 'score': 0.82},
+                    'risk': {'state': 'Calm'},
+                    'policy': {'stance': 'Neutral', 'direction': 'Easing'},
+                },
+            }
+        }
+        result = self._call(history, days=90)
+        self.assertIn('CONDITIONS HISTORY', result)
+        self.assertIn('2026-03-18', result)
+        self.assertIn('Goldilocks', result)
+
+    def test_transition_detection(self):
+        history = {
+            '2026-01-15': {
+                'quadrant': 'Reflation',
+                'dimensions': {
+                    'liquidity': {'state': 'Neutral', 'score': 0.1},
+                    'risk': {'state': 'Normal'},
+                    'policy': {'stance': 'Neutral', 'direction': 'Paused'},
+                },
+            },
+            '2026-02-15': {
+                'quadrant': 'Goldilocks',
+                'dimensions': {
+                    'liquidity': {'state': 'Expanding', 'score': 0.5},
+                    'risk': {'state': 'Calm'},
+                    'policy': {'stance': 'Neutral', 'direction': 'Easing'},
+                },
+            },
+        }
+        result = self._call(history, days=90)
+        self.assertIn('Transitions:', result)
+        self.assertIn('Reflation', result)
+
+    def test_growth_inflation_scores_included(self):
+        history = {
+            '2026-03-10': {
+                'quadrant': 'Goldilocks',
+                'growth_score': 0.309,
+                'inflation_score': -0.552,
+                'dimensions': {
+                    'quadrant': {'state': 'Goldilocks'},
+                    'liquidity': {'state': 'Expanding', 'score': 0.7},
+                    'risk': {'state': 'Calm'},
+                    'policy': {'stance': 'Neutral', 'direction': 'Easing'},
+                },
+            },
+        }
+        result = self._call(history, days=90)
+        self.assertIn('growth=+0.31', result)
+        self.assertIn('inflation=-0.55', result)
+
+    def test_streak_counting(self):
+        history = {
+            '2026-01-15': {
+                'quadrant': 'Goldilocks',
+                'dimensions': {
+                    'liquidity': {'state': 'Expanding', 'score': 0.5},
+                    'risk': {'state': 'Calm'},
+                    'policy': {'stance': 'Neutral', 'direction': 'Easing'},
+                },
+            },
+            '2026-02-15': {
+                'quadrant': 'Goldilocks',
+                'dimensions': {
+                    'liquidity': {'state': 'Expanding', 'score': 0.6},
+                    'risk': {'state': 'Calm'},
+                    'policy': {'stance': 'Neutral', 'direction': 'Easing'},
+                },
+            },
+            '2026-03-15': {
+                'quadrant': 'Goldilocks',
+                'dimensions': {
+                    'liquidity': {'state': 'Expanding', 'score': 0.82},
+                    'risk': {'state': 'Calm'},
+                    'policy': {'stance': 'Neutral', 'direction': 'Easing'},
+                },
+            },
+        }
+        result = self._call(history, days=90)
+        self.assertIn('Goldilocks for 3 consecutive snapshots', result)
+
+
+class TestFallbackBriefing(unittest.TestCase):
+    """_generate_fallback_briefing produces coherent output for all quadrants."""
+
+    def _call(self, conditions):
+        from ai_summary import _generate_fallback_briefing
+        return _generate_fallback_briefing(conditions)
+
+    def test_none_conditions(self):
+        result = self._call(None)
+        self.assertIn('unavailable', result)
+
+    def test_goldilocks_expanding(self):
+        conditions = {
+            'quadrant': 'Goldilocks',
+            'dimensions': {
+                'liquidity': {'state': 'Expanding'},
+                'risk': {'state': 'Calm'},
+                'policy': {'stance': 'Neutral', 'direction': 'Easing'},
+            },
+        }
+        result = self._call(conditions)
+        self.assertIn('Goldilocks', result)
+        self.assertIn('Expanding', result)
+        self.assertIn('tailwind', result.lower())
+
+    def test_stagflation_contracting(self):
+        conditions = {
+            'quadrant': 'Stagflation',
+            'dimensions': {
+                'liquidity': {'state': 'Contracting'},
+                'risk': {'state': 'Stressed'},
+                'policy': {'stance': 'Restrictive', 'direction': 'Tightening'},
+            },
+        }
+        result = self._call(conditions)
+        self.assertIn('Stagflation', result)
+        self.assertIn('Contracting', result)
+
+    def test_deflation_risk_neutral(self):
+        conditions = {
+            'quadrant': 'Deflation Risk',
+            'dimensions': {
+                'liquidity': {'state': 'Neutral'},
+                'risk': {'state': 'Elevated'},
+                'policy': {'stance': 'Accommodative', 'direction': 'Easing'},
+            },
+        }
+        result = self._call(conditions)
+        self.assertIn('Deflation Risk', result)
+
+    def test_reflation_expanding(self):
+        conditions = {
+            'quadrant': 'Reflation',
+            'dimensions': {
+                'liquidity': {'state': 'Expanding'},
+                'risk': {'state': 'Normal'},
+                'policy': {'stance': 'Neutral', 'direction': 'Paused'},
+            },
+        }
+        result = self._call(conditions)
+        self.assertIn('Reflation', result)
+
+    def test_no_old_regime_labels(self):
+        """Fallback must not mention Bull, Bear, Neutral (as regime), or Recession Watch."""
+        for quadrant in ['Goldilocks', 'Reflation', 'Stagflation', 'Deflation Risk']:
+            conditions = {
+                'quadrant': quadrant,
+                'dimensions': {
+                    'liquidity': {'state': 'Neutral'},
+                    'risk': {'state': 'Normal'},
+                    'policy': {'stance': 'Neutral', 'direction': 'Paused'},
+                },
+            }
+            result = self._call(conditions)
+            self.assertNotIn('Bull regime', result)
+            self.assertNotIn('Bear regime', result)
+            self.assertNotIn('Recession Watch', result)
+
+
+# ---------------------------------------------------------------------------
+# Security tests
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityConstraints(unittest.TestCase):
+    """Conditions data must be handled safely in prompt construction."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = read_source('ai_summary.py')
+
+    def test_no_eval_in_conditions_context(self):
+        self.assertNotIn('eval(', self.src)
+
+    def test_conditions_data_not_rendered_with_safe(self):
+        self.assertNotIn('| safe', self.src)
+
+    def test_history_data_typed(self):
+        """History data should use .get() for safe access."""
+        # Check that the history builder uses .get() not direct key access
+        idx = self.src.find('def _build_conditions_history_context')
+        block = self.src[idx:idx + 2000]
+        self.assertIn('.get(', block)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #333

## Summary
Replace old regime label with the new 4-dimension market conditions context in AI briefing prompts, add 90-day conditions history for trend detection, and expand briefing history from 3 to 14 days for foresight callbacks.

## Changes
- **AI prompts**: Replace Bull/Bear/Neutral/Recession Watch regime with quadrant, liquidity, risk, and policy dimensions (scores, states, driving metrics)
- **90-day history**: Load conditions history from `market_conditions_history.json` with transition detection, streak counting, and composite scores
- **14-day briefing history**: Expanded from 3 days to enable "I told you this might happen" pattern
- **Narrative structure**: Updated from 2-paragraph to 3-paragraph quadrant-led format (what's happening, what's changing, what to do)
- **Rule-based fallback**: Coherent briefing from dimension states when AI is unavailable
- **Token limit**: Increased max_tokens from 600 to 800 for longer narrative
- **Tests**: New `test_us3251_conditions_briefing.py` + updated anchoring tests

## Testing
- ✅ All unit tests passing
- ✅ Design review approved
- ✅ QA verification complete

## Design Spec
Implements [docs/specs/US-325-ai-briefing-conditions-spec.md](docs/specs/US-325-ai-briefing-conditions-spec.md)