### PR TITLE
US-325.4: Per-topic AI news summaries for market-specific briefings

### DIFF
--- a/signaltrackers/ai_summary.py
+++ b/signaltrackers/ai_summary.py
@@ -489,8 +489,8 @@ def _get_stored_news_context(topic: str | None = None) -> str | None:
     Read news context from the stored news pipeline data.
 
     If topic is None, returns the cross-market summary string (for daily briefing).
-    If topic is given (e.g. 'crypto'), returns formatted article snippets for that topic.
-    Returns None if no stored data is available or the topic has no matching articles.
+    If topic is given (e.g. 'crypto'), returns the pre-built AI topic summary.
+    Returns None if no stored data is available or the topic has no content.
     """
     try:
         from news_pipeline import get_stored_news
@@ -504,22 +504,15 @@ def _get_stored_news_context(topic: str | None = None) -> str | None:
     if topic is None:
         return stored.get('summary')
 
-    articles = [a for a in stored.get('articles', []) if a.get('topic') == topic]
-    if not articles:
-        return None
+    # Use pre-built AI topic summary if available
+    topic_summaries = stored.get('topic_summaries', {})
+    topic_summary = topic_summaries.get(topic)
+    if topic_summary:
+        topic_label = topic.replace('_', ' ').title()
+        return f"## Today's {topic_label} News\n{topic_summary}"
 
-    topic_label = topic.replace('_', ' ').title()
-    parts = [f"## Today's {topic_label} News"]
-    for art in articles[:8]:
-        headline = art.get('headline', '')
-        content = art.get('raw_content', '') or ''
-        snippet = content[:200] if content else ''
-        if snippet:
-            parts.append(f"- {headline}: {snippet}...")
-        else:
-            parts.append(f"- {headline}")
-
-    return '\n'.join(parts)
+    # No pre-built summary available for this topic
+    return None
 
 
 def fetch_news_for_summary():

--- a/signaltrackers/news_pipeline.py
+++ b/signaltrackers/news_pipeline.py
@@ -129,7 +129,74 @@ def _generate_cross_market_summary(articles: list[dict]) -> str | None:
         return _summarize_with_openai(system_prompt, user_prompt)
 
 
-def _summarize_with_openai(system_prompt: str, user_prompt: str) -> str | None:
+def _generate_topic_summary(topic: str, articles: list[dict]) -> str | None:
+    """
+    Generate a focused 1-2 paragraph AI summary for a single market topic.
+    Returns the summary string, or None on failure.
+    """
+    if not articles:
+        return None
+
+    digest_parts = []
+    for art in articles[:10]:
+        content_snippet = (art['raw_content'] or '')[:600]
+        digest_parts.append(
+            f"{art['headline']}\n"
+            f"Source: {art['source']}\n"
+            f"{content_snippet}"
+        )
+    digest = '\n\n---\n\n'.join(digest_parts)
+
+    topic_label = topic.replace('_', ' ').title()
+    system_prompt = (
+        f"You are a senior {topic_label.lower()} market analyst writing a brief news summary. "
+        f"Summarize today's {topic_label.lower()} news in 1-2 concise paragraphs of flowing prose. "
+        "Do NOT use bullet points, headers, or lists. Focus on the most significant developments, "
+        "key numbers, and market implications. Be direct and authoritative."
+    )
+    user_prompt = (
+        f"Today's date: {date.today().isoformat()}\n\n"
+        f"Here are today's {topic_label.lower()} articles:\n\n{digest}\n\n"
+        f"Write your {topic_label.lower()} news summary now."
+    )
+
+    provider = os.environ.get('AI_PROVIDER', 'openai').lower()
+    if provider == 'anthropic':
+        return _summarize_with_anthropic(system_prompt, user_prompt, max_tokens=500)
+    else:
+        return _summarize_with_openai(system_prompt, user_prompt, max_tokens=500)
+
+
+def _generate_all_topic_summaries(all_articles: list[dict]) -> dict[str, str]:
+    """
+    Generate per-topic AI summaries for market-specific briefings.
+    Returns a dict mapping topic name to summary string.
+    Topics with no articles are skipped.
+    """
+    # Group articles by topic (exclude 'macro' — it's only for cross-market)
+    topic_articles: dict[str, list[dict]] = {}
+    for art in all_articles:
+        topic = art.get('topic', '')
+        if topic and topic != 'macro':
+            topic_articles.setdefault(topic, []).append(art)
+
+    topic_summaries = {}
+    for topic, articles in topic_articles.items():
+        logger.info('[news_pipeline] Generating topic summary: %s (%d articles)', topic, len(articles))
+        try:
+            summary = _generate_topic_summary(topic, articles)
+            if summary:
+                topic_summaries[topic] = summary
+                logger.info('[news_pipeline] Topic summary for %s: %d chars', topic, len(summary))
+            else:
+                logger.warning('[news_pipeline] Topic summary for %s returned empty', topic)
+        except Exception as exc:
+            logger.warning('[news_pipeline] Topic summary for %s failed: %s', topic, exc)
+
+    return topic_summaries
+
+
+def _summarize_with_openai(system_prompt: str, user_prompt: str, max_tokens: int = 1200) -> str | None:
     try:
         from openai import OpenAI
         api_key = os.environ.get('OPENAI_API_KEY')
@@ -142,7 +209,7 @@ def _summarize_with_openai(system_prompt: str, user_prompt: str) -> str | None:
                 {'role': 'system', 'content': system_prompt},
                 {'role': 'user', 'content': user_prompt},
             ],
-            max_completion_tokens=1200,
+            max_completion_tokens=max_tokens,
             temperature=0.6,
         )
         content = resp.choices[0].message.content
@@ -152,7 +219,7 @@ def _summarize_with_openai(system_prompt: str, user_prompt: str) -> str | None:
         return None
 
 
-def _summarize_with_anthropic(system_prompt: str, user_prompt: str) -> str | None:
+def _summarize_with_anthropic(system_prompt: str, user_prompt: str, max_tokens: int = 1200) -> str | None:
     try:
         import anthropic as anthropic_lib
         api_key = os.environ.get('ANTHROPIC_API_KEY')
@@ -161,7 +228,7 @@ def _summarize_with_anthropic(system_prompt: str, user_prompt: str) -> str | Non
         client = anthropic_lib.Anthropic(api_key=api_key)
         msg = client.messages.create(
             model='claude-opus-4-6',
-            max_tokens=1200,
+            max_tokens=max_tokens,
             system=system_prompt,
             messages=[{'role': 'user', 'content': user_prompt}],
         )
@@ -235,6 +302,11 @@ def run_news_pipeline() -> bool:
     else:
         logger.warning('[news_pipeline] Summary generation failed or returned empty')
 
+    # Generate per-topic AI summaries for market-specific briefings
+    logger.info('[news_pipeline] Generating per-topic summaries...')
+    topic_summaries = _generate_all_topic_summaries(all_articles) if all_articles else {}
+    logger.info('[news_pipeline] Generated %d topic summaries', len(topic_summaries))
+
     # Build record
     eastern = pytz.timezone('US/Eastern')
     record = {
@@ -242,6 +314,7 @@ def run_news_pipeline() -> bool:
         'fetched_at': datetime.now(eastern).isoformat(),
         'articles': all_articles,
         'summary': summary,
+        'topic_summaries': topic_summaries,
     }
 
     # Load, update, prune, save

--- a/tests/test_us2594_news_wiring.py
+++ b/tests/test_us2594_news_wiring.py
@@ -225,11 +225,11 @@ class TestStoredNewsContextHelper:
             "Helper must return stored summary when topic is None"
         )
 
-    def test_helper_filters_by_topic(self):
-        """Helper filters articles by topic when topic is given."""
+    def test_helper_uses_topic_summaries(self):
+        """Helper uses pre-built topic summaries when topic is given."""
         helper_src = _get_function_source(AI_SUMMARY_SOURCE, '_get_stored_news_context')
-        assert "topic" in helper_src and "articles" in helper_src, (
-            "Helper must filter stored articles by topic"
+        assert "topic" in helper_src and "topic_summaries" in helper_src, (
+            "Helper must use pre-built topic_summaries for market-specific briefings"
         )
 
     def test_helper_returns_none_when_stored_is_none(self):
@@ -261,18 +261,15 @@ class TestStoredNewsContextHelper:
             assert result == 'Cross-market summary text here.'
 
     def test_helper_runtime_with_topic(self):
-        """Runtime: returns formatted articles for matching topic."""
+        """Runtime: returns pre-built AI topic summary for matching topic."""
         stored = {
             'date': date.today().isoformat(),
-            'articles': [
-                {'headline': 'BTC surges', 'url': 'https://crypto.example.com',
-                 'source': 'crypto.example.com', 'timestamp': 'ts', 'topic': 'crypto',
-                 'raw_content': 'Bitcoin hit a new high.'},
-                {'headline': 'Stocks fall', 'url': 'https://stocks.example.com',
-                 'source': 'stocks.example.com', 'timestamp': 'ts', 'topic': 'equity',
-                 'raw_content': 'Markets fell.'},
-            ],
+            'articles': [],
             'summary': 'Summary.',
+            'topic_summaries': {
+                'crypto': 'Bitcoin surged to new highs amid renewed institutional interest.',
+                'equity': 'Equity markets fell on rising rate concerns.',
+            },
         }
         with patch('news_pipeline.get_stored_news', return_value=stored):
             ai_mod = _load_ai_summary()
@@ -280,8 +277,8 @@ class TestStoredNewsContextHelper:
                 pytest.skip("Could not load ai_summary module in test env")
             result = ai_mod._get_stored_news_context(topic='crypto')
             assert result is not None
-            assert 'BTC surges' in result
-            assert 'Stocks fall' not in result  # equity article excluded
+            assert 'Bitcoin surged' in result
+            assert 'Equity markets' not in result  # equity summary excluded
 
     def test_helper_runtime_no_stored_data(self):
         """Runtime: returns None when get_stored_news() returns None."""
@@ -292,16 +289,15 @@ class TestStoredNewsContextHelper:
             result = ai_mod._get_stored_news_context()
             assert result is None
 
-    def test_helper_runtime_empty_topic_articles(self):
-        """Runtime: returns None for topic with no matching articles."""
+    def test_helper_runtime_empty_topic_summary(self):
+        """Runtime: returns None for topic with no pre-built summary."""
         stored = {
             'date': date.today().isoformat(),
-            'articles': [
-                {'headline': 'Equity news', 'url': 'https://eq.com',
-                 'source': 'eq.com', 'timestamp': 'ts', 'topic': 'equity',
-                 'raw_content': 'Content.'},
-            ],
+            'articles': [],
             'summary': 'Summary.',
+            'topic_summaries': {
+                'equity': 'Equity markets summary.',
+            },
         }
         with patch('news_pipeline.get_stored_news', return_value=stored):
             ai_mod = _load_ai_summary()


### PR DESCRIPTION
Fixes #349

## Summary
Adds per-topic AI news summaries to the news pipeline so market-specific briefings (crypto, equity, rates, dollar, credit) receive clean, AI-summarized news context instead of raw 200-character webpage truncations with garbage text.

## Changes
- `signaltrackers/news_pipeline.py` — Added `_generate_topic_summary()` and `_generate_all_topic_summaries()` to generate per-topic AI summaries during the news pipeline run
- `signaltrackers/ai_summary.py` — Updated `_get_stored_news_context()` to use pre-built topic summaries; removed raw content truncation path
- `tests/test_us2594_news_wiring.py` — Updated tests to reflect new topic summary behavior

## Testing
- ✅ 57/57 story tests passing
- ✅ Full suite: 3842 passed (0 new regressions)
- ✅ QA verification complete — all 5 acceptance criteria verified
- ✅ Security checks passed (no unsafe template filters, proper dict access)
- ✅ Edge cases covered (empty topics, per-topic error isolation, content caps)