### PR TITLE
US-325.6: AI briefing audience calibration

### DIFF
--- a/signaltrackers/ai_summary.py
+++ b/signaltrackers/ai_summary.py
@@ -868,7 +868,7 @@ def generate_daily_summary(market_data_summary, top_movers, top_movers_1d=None):
 4. You're honest about uncertainty but confident in your analysis
 5. You make people SMARTER about markets, not just informed
 
-Your style is conversational but substantive - like a really smart friend who happens to be a market expert. You're not stuffy or formal, but you're also not dumbed down. Write for a financially literate non-professional — someone who reads the WSJ and owns ETFs but doesn't work in finance. Use financial terms freely, but always make the implication clear in plain language.
+Your style is conversational but substantive - like a really smart friend who happens to be a market expert. You're not stuffy or formal, but you're also not dumbed down. Write for a financially literate non-professional — someone who reads the WSJ and owns ETFs but doesn't work in finance. Use financial terms freely, but always make the implication clear in plain language. Avoid z-scores, basis point counts, and percentile references — translate these into plain-language magnitude (e.g., "near historic highs," "the largest move in months").
 
 CRITICAL RULES:
 - Write EXACTLY 3 paragraphs (200-250 words total)
@@ -1097,7 +1097,7 @@ def generate_crypto_summary(crypto_data_summary):
         # Crypto-specific system prompt
         system_prompt = """You are a Bitcoin/crypto market analyst providing daily briefings for the Crypto page of a financial dashboard. Your audience understands both traditional finance and crypto - they track Bitcoin alongside macro liquidity indicators like the Fed balance sheet, NFCI, and Fear & Greed index.
 
-Your style matches the main market briefing: conversational but substantive, connecting dots between Bitcoin and macro liquidity conditions. Write for a financially literate non-professional — someone who reads the WSJ and owns ETFs but doesn't work in finance. Use financial terms freely, but always make the implication clear in plain language.
+Your style matches the main market briefing: conversational but substantive, connecting dots between Bitcoin and macro liquidity conditions. Write for a financially literate non-professional — someone who reads the WSJ and owns ETFs but doesn't work in finance. Use financial terms freely, but always make the implication clear in plain language. Avoid z-scores, basis point counts, and percentile references — translate these into plain-language magnitude (e.g., "near historic highs," "the largest move in months").
 
 CRITICAL RULES:
 - Write EXACTLY 3 paragraphs (250-350 words total)
@@ -1310,7 +1310,7 @@ def generate_equity_summary(equity_data_summary):
         # Equity-specific system prompt
         system_prompt = """You are an equity market analyst providing daily briefings for the Equity Markets page of a financial dashboard. Your audience understands markets and wants actionable insight on stock market dynamics - breadth, rotation, and key themes.
 
-Your style matches the main market briefing: conversational but substantive, connecting dots between indices, sectors, and market structure. Write for a financially literate non-professional — someone who reads the WSJ and owns ETFs but doesn't work in finance. Use financial terms freely, but always make the implication clear in plain language.
+Your style matches the main market briefing: conversational but substantive, connecting dots between indices, sectors, and market structure. Write for a financially literate non-professional — someone who reads the WSJ and owns ETFs but doesn't work in finance. Use financial terms freely, but always make the implication clear in plain language. Avoid z-scores, basis point counts, and percentile references — translate these into plain-language magnitude (e.g., "near historic highs," "the largest move in months").
 
 CRITICAL RULES:
 - Write EXACTLY 3 paragraphs (250-350 words total)
@@ -1526,7 +1526,7 @@ def generate_rates_summary(rates_data_summary):
         # Rates-specific system prompt
         system_prompt = """You are a fixed income analyst providing daily briefings for the Rates & Yield Curve page of a financial dashboard. Your audience understands markets and wants actionable insight on interest rates, the yield curve, and their implications.
 
-Your style matches the main market briefing: conversational but substantive, connecting dots between rates, the curve, inflation expectations, and what they mean for other assets. Write for a financially literate non-professional — someone who reads the WSJ and owns ETFs but doesn't work in finance. Use financial terms freely, but always make the implication clear in plain language.
+Your style matches the main market briefing: conversational but substantive, connecting dots between rates, the curve, inflation expectations, and what they mean for other assets. Write for a financially literate non-professional — someone who reads the WSJ and owns ETFs but doesn't work in finance. Use financial terms freely, but always make the implication clear in plain language. Avoid z-scores, basis point counts, and percentile references — translate these into plain-language magnitude (e.g., "near historic highs," "the largest move in months").
 
 CRITICAL RULES:
 - Write EXACTLY 3 paragraphs (250-350 words total)
@@ -1742,7 +1742,7 @@ def generate_dollar_summary(dollar_data_summary):
         # Dollar-specific system prompt
         system_prompt = """You are a currency analyst providing daily briefings for the Dollar & Currency page of a financial dashboard. Your audience understands markets and wants actionable insight on the US dollar, currency dynamics, and their cross-asset implications.
 
-Your style matches the main market briefing: conversational but substantive, connecting dots between the dollar, Fed policy, global central bank divergence, and implications for other assets. Write for a financially literate non-professional — someone who reads the WSJ and owns ETFs but doesn't work in finance. Use financial terms freely, but always make the implication clear in plain language.
+Your style matches the main market briefing: conversational but substantive, connecting dots between the dollar, Fed policy, global central bank divergence, and implications for other assets. Write for a financially literate non-professional — someone who reads the WSJ and owns ETFs but doesn't work in finance. Use financial terms freely, but always make the implication clear in plain language. Avoid z-scores, basis point counts, and percentile references — translate these into plain-language magnitude (e.g., "near historic highs," "the largest move in months").
 
 CRITICAL RULES:
 - Write EXACTLY 3 paragraphs (250-350 words total)
@@ -1950,7 +1950,7 @@ def generate_credit_summary(credit_data_summary):
 
         system_prompt = """You are a credit market analyst providing daily briefings for the Credit Markets page of a financial dashboard. Your audience understands markets and wants actionable insight on corporate credit conditions, spread dynamics, and what credit is signaling about the economy.
 
-Your style matches the main market briefing: conversational but substantive, connecting dots between spread levels, market conditions, default risk, and cross-asset implications. Write for a financially literate non-professional — someone who reads the WSJ and owns ETFs but doesn't work in finance. Use financial terms freely, but always make the implication clear in plain language.
+Your style matches the main market briefing: conversational but substantive, connecting dots between spread levels, market conditions, default risk, and cross-asset implications. Write for a financially literate non-professional — someone who reads the WSJ and owns ETFs but doesn't work in finance. Use financial terms freely, but always make the implication clear in plain language. Avoid z-scores, basis point counts, and percentile references — translate these into plain-language magnitude (e.g., "near historic highs," "the largest move in months").
 
 CRITICAL RULES:
 - Write EXACTLY 3 paragraphs (250-350 words total)
@@ -2266,7 +2266,7 @@ def generate_portfolio_summary(portfolio_data, market_context, user_client=None,
         # Portfolio-specific system prompt
         system_prompt = """You are a portfolio analyst providing personalized briefings based on a user's investment allocations and current market conditions. Your audience is an individual investor who wants actionable insight on how their portfolio is positioned relative to current market dynamics.
 
-Your style is conversational but substantive - you connect the dots between the user's holdings, current market conditions, and the insights from the day's other market briefings. Write for a financially literate non-professional — someone who reads the WSJ and owns ETFs but doesn't work in finance. Use financial terms freely, but always make the implication clear in plain language.
+Your style is conversational but substantive - you connect the dots between the user's holdings, current market conditions, and the insights from the day's other market briefings. Write for a financially literate non-professional — someone who reads the WSJ and owns ETFs but doesn't work in finance. Use financial terms freely, but always make the implication clear in plain language. Avoid z-scores, basis point counts, and percentile references — translate these into plain-language magnitude (e.g., "near historic highs," "the largest move in months").
 
 CRITICAL RULES:
 - Write EXACTLY 3-4 paragraphs (300-400 words total)

--- a/signaltrackers/dashboard.py
+++ b/signaltrackers/dashboard.py
@@ -3379,7 +3379,7 @@ def api_chatbot():
     system_prompt = (
         "You are an AI assistant helping an individual investor understand macro financial markets. "
         "Write for a financially literate non-professional — someone who reads the WSJ and owns ETFs but doesn't work in finance. "
-        "Use financial terms freely, but always make the implication clear in plain language. "
+        "Use financial terms freely, but always make the implication clear in plain language. Avoid z-scores, basis point counts, and percentile references — translate these into plain-language magnitude (e.g., 'near historic highs,' 'the largest move in months'). "
         "You provide clear, concise explanations of market conditions, economic indicators, and financial concepts. "
         "The dashboard uses a four-quadrant conditions framework (Goldilocks, Reflation, Stagflation, Deflation Risk) "
         "with four dimensions: quadrant (growth vs inflation), liquidity, risk, and policy. "
@@ -3903,7 +3903,8 @@ def api_chatbot_section_opening():
         "You are SignalTrackers AI, a financial market assistant helping an individual investor "
         "understand macro financial markets. Write for a financially literate non-professional — "
         "someone who reads the WSJ and owns ETFs but doesn't work in finance. Use financial terms "
-        "freely, but always make the implication clear in plain language. Provide clear, concise "
+        "freely, but always make the implication clear in plain language. Avoid z-scores, basis point counts, and percentile references — "
+        "translate these into plain-language magnitude (e.g., \"near historic highs,\" \"the largest move in months\"). Provide clear, concise "
         "explanations of market conditions, economic indicators, and financial concepts. Be direct "
         "and data-driven. Keep your response to 2-3 short paragraphs."
     )
@@ -6103,7 +6104,7 @@ def api_chat():
         print(f"[CHAT] Provider: {provider}, Web search available: {web_search_available}")
 
         # Build system message - now tool-based, not data-dump
-        system_message = """You are a financial markets expert assistant with access to real-time market data through tools. Write for a financially literate non-professional — someone who reads the WSJ and owns ETFs but doesn't work in finance. Use financial terms freely, but always make the implication clear in plain language.
+        system_message = """You are a financial markets expert assistant with access to real-time market data through tools. Write for a financially literate non-professional — someone who reads the WSJ and owns ETFs but doesn't work in finance. Use financial terms freely, but always make the implication clear in plain language. Avoid z-scores, basis point counts, and percentile references — translate these into plain-language magnitude (e.g., "near historic highs," "the largest move in months").
 
 AVAILABLE TOOLS:
 1. **list_available_metrics** - Discover all available market data series (credit spreads, equities, safe havens, etc.)

--- a/signaltrackers/news_pipeline.py
+++ b/signaltrackers/news_pipeline.py
@@ -110,7 +110,7 @@ def _generate_cross_market_summary(articles: list[dict]) -> str | None:
     system_prompt = (
         "You are a senior macro analyst writing a daily market briefing. "
         "Write for a financially literate non-professional — someone who reads the WSJ and owns ETFs but doesn't work in finance. "
-        "Use financial terms freely, but always make the implication clear in plain language. "
+        "Use financial terms freely, but always make the implication clear in plain language. Avoid z-scores, basis point counts, and percentile references — translate these into plain-language magnitude (e.g., 'near historic highs,' 'the largest move in months'). "
         "Write a comprehensive cross-market summary of today's news in 3-5 prose paragraphs. "
         "Do NOT use bullet points or headers. Write in flowing, analytical prose. "
         "Cover the major themes across macro, equities, rates, credit, crypto, and currencies. "
@@ -153,7 +153,7 @@ def _generate_topic_summary(topic: str, articles: list[dict]) -> str | None:
     system_prompt = (
         f"You are a senior {topic_label.lower()} market analyst writing a brief news summary. "
         "Write for a financially literate non-professional — someone who reads the WSJ and owns ETFs but doesn't work in finance. "
-        "Use financial terms freely, but always make the implication clear in plain language. "
+        "Use financial terms freely, but always make the implication clear in plain language. Avoid z-scores, basis point counts, and percentile references — translate these into plain-language magnitude (e.g., 'near historic highs,' 'the largest move in months'). "
         f"Summarize today's {topic_label.lower()} news in 1-2 concise paragraphs of flowing prose. "
         "Do NOT use bullet points, headers, or lists. Focus on the most significant developments, "
         "key numbers, and market implications. Be direct and authoritative."


### PR DESCRIPTION
Fixes #361

## Summary
Calibrates all 12 AI briefing prompts for a financially literate non-professional audience — someone who reads the WSJ and owns ETFs but doesn't work in finance. Adds audience guidance and bans specialist vocabulary (z-scores, basis points, percentiles) while preserving analytical depth.

## Changes
- **ai_summary.py**: 7 prompts updated (daily, crypto, equity, rates, dollar, credit, portfolio)
- **dashboard.py**: 3 prompts updated (chatbot, section-opening, chat system message)
- **news_pipeline.py**: 2 prompts updated (cross_market_summary, topic_summary)

## Testing
- ✅ Full test suite: 3842 passed (matches baseline)
- ✅ QA verified all 12/12 prompts updated correctly
- ✅ QA re-verified specialist vocabulary ban after feedback round
- ✅ No regressions