### PR TITLE
US-12.1.2: Remove API key configuration from settings page

### DIFF
--- a/signaltrackers/templates/settings.html
+++ b/signaltrackers/templates/settings.html
@@ -6,7 +6,7 @@
 <div class="row">
     <div class="col-12">
         <h1><i class="bi bi-gear"></i> Settings</h1>
-        <p class="text-muted">Configure your account and AI preferences.</p>
+        <p class="text-muted">Configure your account preferences.</p>
     </div>
 </div>
 


### PR DESCRIPTION
Fixes #384

## Summary
Removes the last trace of user-facing API key configuration from the settings page. US-12.1.1 already removed the form fields, provider selection, status badges, and JavaScript — this story cleans up the stale subtitle text from "Configure your account and AI preferences" to "Configure your account preferences."

## Changes
- Updated settings page subtitle to reflect that AI preferences are no longer user-configurable

## Testing
- ✅ All settings-specific tests passing (19/19)
- ✅ Full suite matches main baseline (0 regressions)
- ✅ Design review approved
- ✅ QA verification complete

## Design Spec
Part of Phase 12: AI Foundation & Metering milestone