### PR TITLE
US-12.2.1: Usage metering database model and migration

### DIFF
--- a/signaltrackers/migrations/versions/g2a3b4c5d6e7_add_ai_usage_records_table.py
+++ b/signaltrackers/migrations/versions/g2a3b4c5d6e7_add_ai_usage_records_table.py
@@ -1,0 +1,53 @@
+"""Add ai_usage_records table
+
+Revision ID: g2a3b4c5d6e7
+Revises: f1a2b3c4d5e6
+Create Date: 2026-03-27 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'g2a3b4c5d6e7'
+down_revision = 'c3d4e5f6a7b8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if 'ai_usage_records' not in inspector.get_table_names():
+        op.create_table(
+            'ai_usage_records',
+            sa.Column('id', sa.Integer(), primary_key=True),
+            sa.Column('user_id', sa.String(36), sa.ForeignKey('users.id', ondelete='CASCADE'), nullable=False),
+            sa.Column('interaction_type', sa.String(30), nullable=False),
+            sa.Column('timestamp', sa.DateTime(), nullable=False),
+            sa.Column('input_tokens', sa.Integer(), nullable=True),
+            sa.Column('output_tokens', sa.Integer(), nullable=True),
+            sa.Column('cache_read_tokens', sa.Integer(), nullable=True),
+            sa.Column('cache_creation_tokens', sa.Integer(), nullable=True),
+            sa.Column('model', sa.String(100), nullable=False),
+            sa.Column('estimated_cost', sa.Numeric(precision=12, scale=8), nullable=False),
+        )
+    # Create indexes if they don't already exist (table may have been created by db.create_all())
+    existing_indexes = {idx['name'] for idx in inspector.get_indexes('ai_usage_records')}
+    if 'ix_ai_usage_records_user_id' not in existing_indexes:
+        op.create_index('ix_ai_usage_records_user_id', 'ai_usage_records', ['user_id'])
+    if 'ix_ai_usage_records_interaction_type' not in existing_indexes:
+        op.create_index('ix_ai_usage_records_interaction_type', 'ai_usage_records', ['interaction_type'])
+    if 'ix_ai_usage_records_timestamp' not in existing_indexes:
+        op.create_index('ix_ai_usage_records_timestamp', 'ai_usage_records', ['timestamp'])
+    if 'ix_ai_usage_records_user_type_time' not in existing_indexes:
+        op.create_index('ix_ai_usage_records_user_type_time', 'ai_usage_records', ['user_id', 'interaction_type', 'timestamp'])
+
+
+def downgrade():
+    op.drop_index('ix_ai_usage_records_user_type_time', table_name='ai_usage_records')
+    op.drop_index('ix_ai_usage_records_timestamp', table_name='ai_usage_records')
+    op.drop_index('ix_ai_usage_records_interaction_type', table_name='ai_usage_records')
+    op.drop_index('ix_ai_usage_records_user_id', table_name='ai_usage_records')
+    op.drop_table('ai_usage_records')

--- a/signaltrackers/models/__init__.py
+++ b/signaltrackers/models/__init__.py
@@ -8,5 +8,6 @@ from models.user import User
 from models.portfolio import PortfolioAllocation
 from models.portfolio_summary import PortfolioSummary
 from models.alert import AlertPreference, Alert
+from models.ai_usage import AIUsageRecord
 
-__all__ = ['User', 'PortfolioAllocation', 'PortfolioSummary', 'AlertPreference', 'Alert']
+__all__ = ['User', 'PortfolioAllocation', 'PortfolioSummary', 'AlertPreference', 'Alert', 'AIUsageRecord']

--- a/signaltrackers/models/ai_usage.py
+++ b/signaltrackers/models/ai_usage.py
@@ -1,0 +1,42 @@
+"""
+AI Usage Record Model
+
+Database model for tracking AI usage metering data.
+"""
+
+from datetime import datetime
+
+from extensions import db
+
+
+class AIUsageRecord(db.Model):
+    """Records each AI interaction for usage metering."""
+
+    __tablename__ = 'ai_usage_records'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.String(36), db.ForeignKey('users.id', ondelete='CASCADE'), nullable=False)
+    interaction_type = db.Column(db.String(30), nullable=False)  # chatbot, portfolio_analysis, section_ai, sentence_drill_in
+    timestamp = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    input_tokens = db.Column(db.Integer, nullable=True)
+    output_tokens = db.Column(db.Integer, nullable=True)
+    cache_read_tokens = db.Column(db.Integer, nullable=True)
+    cache_creation_tokens = db.Column(db.Integer, nullable=True)
+    model = db.Column(db.String(100), nullable=False)
+    estimated_cost = db.Column(db.Numeric(precision=12, scale=8), nullable=False)
+
+    # Indexes for Admin Analytics access patterns
+    __table_args__ = (
+        db.Index('ix_ai_usage_records_user_id', 'user_id'),
+        db.Index('ix_ai_usage_records_interaction_type', 'interaction_type'),
+        db.Index('ix_ai_usage_records_timestamp', 'timestamp'),
+        db.Index('ix_ai_usage_records_user_type_time', 'user_id', 'interaction_type', 'timestamp'),
+    )
+
+    # Relationship
+    user = db.relationship('User', backref=db.backref('ai_usage_records', lazy='dynamic'))
+
+    VALID_INTERACTION_TYPES = {'chatbot', 'portfolio_analysis', 'section_ai', 'sentence_drill_in'}
+
+    def __repr__(self):
+        return f'<AIUsageRecord {self.id} user={self.user_id} type={self.interaction_type}>'


### PR DESCRIPTION
Fixes #391

## Summary
Adds the `ai_usage_records` database table and Alembic migration to store AI usage metering data. This is the data foundation for Phase 12 — measuring AI usage patterns before setting prices in Phase 13.

## Changes
- New `AIUsageRecord` model (`signaltrackers/models/ai_usage.py`) with fields: user_id, interaction_type (4 types), timestamp (UTC), input/output/cache tokens (nullable), model, estimated_cost (Numeric 12,8)
- Alembic migration with idempotent upgrade to handle `db.create_all()` race condition
- Indexes on user_id, interaction_type, timestamp, plus compound index for Admin Analytics access pattern
- Foreign key to users table with CASCADE delete
- Model registered in `models/__init__.py`

## Testing
- ✅ All unit tests passing (3180/3180, 0 new regressions)
- ✅ Migration upgrade/downgrade/re-upgrade round-trip verified
- ✅ QA verification complete (all acceptance criteria met)

## Design Spec
Backend-only story — no design spec required.