### PR TITLE
US-12.2.2: Instrument AI service layer to record usage metering

### DIFF
--- a/signaltrackers/ai_summary.py
+++ b/signaltrackers/ai_summary.py
@@ -163,6 +163,8 @@ def call_ai_with_tools(client, system_prompt, user_prompt, max_tokens=600, log_p
 
 def _call_openai_with_tools(client, system_prompt, user_prompt, max_tokens, log_prefix):
     """OpenAI-specific implementation of AI call with tools."""
+    from services.usage_metering import extract_usage_openai, accumulate_usage
+
     messages = [
         {"role": "system", "content": system_prompt},
         {"role": "user", "content": user_prompt}
@@ -186,6 +188,7 @@ def _call_openai_with_tools(client, system_prompt, user_prompt, max_tokens, log_
     # economic data, Fed policy, sector developments, geopolitical events)
     max_iterations = 6
     iteration = 0
+    total_usage = {}
 
     while iteration < max_iterations:
         iteration += 1
@@ -203,6 +206,7 @@ def _call_openai_with_tools(client, system_prompt, user_prompt, max_tokens, log_
             api_params["tool_choice"] = tool_choice
 
         response = client.chat.completions.create(**api_params)
+        total_usage = accumulate_usage(total_usage, extract_usage_openai(response))
         response_message = response.choices[0].message
 
         print(f"{log_prefix} Response finish_reason: {response.choices[0].finish_reason}")
@@ -245,13 +249,17 @@ def _call_openai_with_tools(client, system_prompt, user_prompt, max_tokens, log_
             return {
                 'success': False,
                 'content': None,
-                'error': 'API returned empty response'
+                'error': 'API returned empty response',
+                'usage': total_usage,
+                'model': OPENAI_MODEL,
             }
 
         return {
             'success': True,
             'content': content.strip(),
-            'error': None
+            'error': None,
+            'usage': total_usage,
+            'model': OPENAI_MODEL,
         }
 
     # Exceeded max iterations
@@ -259,12 +267,16 @@ def _call_openai_with_tools(client, system_prompt, user_prompt, max_tokens, log_
     return {
         'success': False,
         'content': None,
-        'error': 'Exceeded maximum tool call iterations'
+        'error': 'Exceeded maximum tool call iterations',
+        'usage': total_usage,
+        'model': OPENAI_MODEL,
     }
 
 
 def _call_anthropic_with_tools(client, system_prompt, user_prompt, max_tokens, log_prefix):
     """Anthropic-specific implementation of AI call with tools."""
+    from services.usage_metering import extract_usage_anthropic, accumulate_usage
+
     messages = [
         {"role": "user", "content": user_prompt}
     ]
@@ -299,6 +311,7 @@ def _call_anthropic_with_tools(client, system_prompt, user_prompt, max_tokens, l
     # economic data, Fed policy, sector developments, geopolitical events)
     max_iterations = 6
     iteration = 0
+    total_usage = {}
 
     while iteration < max_iterations:
         iteration += 1
@@ -327,6 +340,7 @@ def _call_anthropic_with_tools(client, system_prompt, user_prompt, max_tokens, l
             api_params["max_tokens"] = max_tokens
             response = client.messages.create(**api_params)
 
+        total_usage = accumulate_usage(total_usage, extract_usage_anthropic(response))
         print(f"{log_prefix} Response stop_reason: {response.stop_reason}")
 
         # Check for tool use
@@ -384,13 +398,17 @@ def _call_anthropic_with_tools(client, system_prompt, user_prompt, max_tokens, l
             return {
                 'success': False,
                 'content': None,
-                'error': 'API returned empty response'
+                'error': 'API returned empty response',
+                'usage': total_usage,
+                'model': ANTHROPIC_MODEL,
             }
 
         return {
             'success': True,
             'content': content.strip(),
-            'error': None
+            'error': None,
+            'usage': total_usage,
+            'model': ANTHROPIC_MODEL,
         }
 
     # Exceeded max iterations
@@ -398,7 +416,9 @@ def _call_anthropic_with_tools(client, system_prompt, user_prompt, max_tokens, l
     return {
         'success': False,
         'content': None,
-        'error': 'Exceeded maximum tool call iterations'
+        'error': 'Exceeded maximum tool call iterations',
+        'usage': total_usage,
+        'model': ANTHROPIC_MODEL,
     }
 
 
@@ -2302,7 +2322,9 @@ Remember: Analyze their allocation against current market conditions, be specifi
             return {
                 'success': False,
                 'summary': None,
-                'error': result['error']
+                'error': result['error'],
+                'usage': result.get('usage', {}),
+                'model': result.get('model'),
             }
 
         summary = result['content']
@@ -2329,7 +2351,9 @@ Remember: Analyze their allocation against current market conditions, be specifi
         return {
             'success': True,
             'summary': summary,
-            'error': None
+            'error': None,
+            'usage': result.get('usage', {}),
+            'model': result.get('model'),
         }
 
     except Exception as e:

--- a/signaltrackers/dashboard.py
+++ b/signaltrackers/dashboard.py
@@ -3371,6 +3371,10 @@ def api_chatbot():
         if web_search_available:
             tools.append({"type": "function", "function": SEARCH_FUNCTION_DEFINITION})
 
+    # Usage metering: accumulate tokens across agentic loop iterations
+    from services.usage_metering import extract_usage, accumulate_usage, record_usage
+    total_usage = {}
+
     try:
         if provider == 'anthropic':
             # Use structured system prompt with cache_control for prompt caching (US-325.7)
@@ -3413,6 +3417,8 @@ def api_chatbot():
                 print(f"[CHATBOT-ANTHROPIC] stop_reason: {response.stop_reason}, "
                       f"input_tokens: {usage.input_tokens}, "
                       f"cache_creation: {cache_creation}, cache_read: {cache_read}")
+
+                total_usage = accumulate_usage(total_usage, extract_usage(response, 'anthropic'))
 
                 tool_use_blocks = [block for block in response.content if block.type == "tool_use"]
                 text_blocks = [block for block in response.content if block.type == "text"]
@@ -3459,6 +3465,7 @@ def api_chatbot():
                     tools=tools,
                     tool_choice="auto"
                 )
+                total_usage = accumulate_usage(total_usage, extract_usage(response, 'openai'))
                 response_message = response.choices[0].message
 
                 print(f"[CHATBOT-OPENAI] finish_reason: {response.choices[0].finish_reason}")
@@ -3488,6 +3495,21 @@ def api_chatbot():
             ai_response = "I apologize, but I wasn't able to generate a response. Please try again."
 
         ai_response = _filter_reasoning_artifacts(ai_response)
+
+        # Record usage metering for authenticated users (US-12.2.2)
+        try:
+            if current_user.is_authenticated:
+                # Detect sentence drill-in vs regular chatbot
+                is_drill_in = bool(context.get('briefing_text'))
+                interaction_type = 'sentence_drill_in' if is_drill_in else 'chatbot'
+                record_usage(
+                    user_id=current_user.id,
+                    interaction_type=interaction_type,
+                    model_name=model,
+                    **total_usage,
+                )
+        except Exception:
+            app.logger.exception('Chatbot metering error (non-fatal)')
 
         return jsonify({
             'response': ai_response,
@@ -3838,6 +3860,20 @@ def api_chatbot_section_opening():
                 max_tokens=512
             )
             ai_response = response.choices[0].message.content
+
+        # Record usage metering for authenticated users (US-12.2.2)
+        try:
+            if current_user.is_authenticated:
+                from services.usage_metering import extract_usage, record_usage
+                usage_data = extract_usage(response, provider)
+                record_usage(
+                    user_id=current_user.id,
+                    interaction_type='section_ai',
+                    model_name=model,
+                    **usage_data,
+                )
+        except Exception:
+            app.logger.exception('Section opening metering error (non-fatal)')
 
         return jsonify({
             'response': ai_response,
@@ -4273,6 +4309,21 @@ def api_generate_portfolio_summary():
             market_summary,
             user_id=current_user.id
         )
+
+        # Record usage metering (US-12.2.2) — always authenticated via @login_required
+        try:
+            usage_data = result.get('usage', {})
+            model_used = result.get('model')
+            if model_used:
+                from services.usage_metering import record_usage
+                record_usage(
+                    user_id=current_user.id,
+                    interaction_type='portfolio_analysis',
+                    model_name=model_used,
+                    **usage_data,
+                )
+        except Exception:
+            app.logger.exception('Portfolio summary metering error (non-fatal)')
 
         if result['success']:
             return jsonify({

--- a/signaltrackers/services/usage_metering.py
+++ b/signaltrackers/services/usage_metering.py
@@ -1,0 +1,163 @@
+"""
+Usage Metering Service
+
+Records AI interaction usage data (tokens, cost) for registered users.
+Metering is silent and failure-safe — errors are logged but never break AI features.
+"""
+
+import logging
+from decimal import Decimal
+
+from extensions import db
+from models.ai_usage import AIUsageRecord
+
+logger = logging.getLogger(__name__)
+
+# Token pricing per million tokens (USD)
+# Source: provider pricing pages, updated as needed
+MODEL_PRICING = {
+    # Anthropic models
+    'claude-opus-4-6': {
+        'input': Decimal('15.00'),
+        'output': Decimal('75.00'),
+        'cache_read': Decimal('1.50'),
+        'cache_creation': Decimal('18.75'),
+    },
+    'claude-sonnet-4-6': {
+        'input': Decimal('3.00'),
+        'output': Decimal('15.00'),
+        'cache_read': Decimal('0.30'),
+        'cache_creation': Decimal('3.75'),
+    },
+    # OpenAI models
+    'gpt-5.2': {
+        'input': Decimal('2.50'),
+        'output': Decimal('10.00'),
+        'cache_read': Decimal('1.25'),
+        'cache_creation': Decimal('0'),
+    },
+}
+
+# Fallback pricing if model not found
+_DEFAULT_PRICING = {
+    'input': Decimal('3.00'),
+    'output': Decimal('15.00'),
+    'cache_read': Decimal('0.30'),
+    'cache_creation': Decimal('3.75'),
+}
+
+_PER_MILLION = Decimal('1000000')
+
+
+def _get_pricing(model_name):
+    """Get pricing for a model, falling back to default if unknown."""
+    # Try exact match first, then prefix match
+    if model_name in MODEL_PRICING:
+        return MODEL_PRICING[model_name]
+    for key in MODEL_PRICING:
+        if model_name.startswith(key):
+            return MODEL_PRICING[key]
+    logger.warning(f"Unknown model for pricing: {model_name}, using defaults")
+    return _DEFAULT_PRICING
+
+
+def calculate_cost(model_name, input_tokens, output_tokens,
+                   cache_read_tokens=None, cache_creation_tokens=None):
+    """Calculate estimated cost in USD for the given token counts."""
+    pricing = _get_pricing(model_name)
+    cost = Decimal('0')
+    if input_tokens:
+        cost += Decimal(str(input_tokens)) * pricing['input'] / _PER_MILLION
+    if output_tokens:
+        cost += Decimal(str(output_tokens)) * pricing['output'] / _PER_MILLION
+    if cache_read_tokens:
+        cost += Decimal(str(cache_read_tokens)) * pricing['cache_read'] / _PER_MILLION
+    if cache_creation_tokens:
+        cost += Decimal(str(cache_creation_tokens)) * pricing['cache_creation'] / _PER_MILLION
+    return cost
+
+
+def extract_usage_anthropic(response):
+    """Extract token usage from an Anthropic API response."""
+    usage = getattr(response, 'usage', None)
+    if usage is None:
+        return {}
+    return {
+        'input_tokens': getattr(usage, 'input_tokens', None),
+        'output_tokens': getattr(usage, 'output_tokens', None),
+        'cache_read_tokens': getattr(usage, 'cache_read_input_tokens', None) or None,
+        'cache_creation_tokens': getattr(usage, 'cache_creation_input_tokens', None) or None,
+    }
+
+
+def extract_usage_openai(response):
+    """Extract token usage from an OpenAI API response."""
+    usage = getattr(response, 'usage', None)
+    if usage is None:
+        return {}
+    return {
+        'input_tokens': getattr(usage, 'prompt_tokens', None),
+        'output_tokens': getattr(usage, 'completion_tokens', None),
+        'cache_read_tokens': None,
+        'cache_creation_tokens': None,
+    }
+
+
+def extract_usage(response, provider):
+    """Extract token usage from an AI provider response."""
+    if provider == 'anthropic':
+        return extract_usage_anthropic(response)
+    return extract_usage_openai(response)
+
+
+def accumulate_usage(total, new_usage):
+    """Accumulate token counts across multiple API calls (agentic loops)."""
+    for key in ('input_tokens', 'output_tokens', 'cache_read_tokens', 'cache_creation_tokens'):
+        new_val = new_usage.get(key)
+        if new_val is not None:
+            total[key] = (total.get(key) or 0) + new_val
+    return total
+
+
+def record_usage(user_id, interaction_type, model_name,
+                 input_tokens=None, output_tokens=None,
+                 cache_read_tokens=None, cache_creation_tokens=None):
+    """Record an AI usage metering entry. Fails silently — never breaks AI features.
+
+    Args:
+        user_id: The authenticated user's ID (required, non-null).
+        interaction_type: One of AIUsageRecord.VALID_INTERACTION_TYPES.
+        model_name: The AI model used (e.g., 'claude-sonnet-4-6').
+        input_tokens: Number of input/prompt tokens (nullable).
+        output_tokens: Number of output/completion tokens (nullable).
+        cache_read_tokens: Anthropic cache read tokens (nullable).
+        cache_creation_tokens: Anthropic cache creation tokens (nullable).
+    """
+    try:
+        estimated_cost = calculate_cost(
+            model_name, input_tokens, output_tokens,
+            cache_read_tokens, cache_creation_tokens
+        )
+
+        record = AIUsageRecord(
+            user_id=user_id,
+            interaction_type=interaction_type,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=cache_read_tokens,
+            cache_creation_tokens=cache_creation_tokens,
+            model=model_name,
+            estimated_cost=estimated_cost,
+        )
+        db.session.add(record)
+        db.session.commit()
+        logger.info(
+            f"Metered {interaction_type} for user {user_id}: "
+            f"in={input_tokens} out={output_tokens} cost=${estimated_cost:.8f}"
+        )
+    except Exception:
+        logger.exception(f"Failed to record usage metering for user {user_id}")
+        try:
+            db.session.rollback()
+        except Exception:
+            pass


### PR DESCRIPTION
Fixes #392

## Summary
- Add usage metering service (`services/usage_metering.py`) with token pricing, cost calculation, and failure-safe DB recording
- Instrument all four AI endpoints: chatbot, portfolio analysis, section AI buttons, and sentence drill-in
- Modify `call_ai_with_tools` (both OpenAI and Anthropic paths) to accumulate and return token usage across tool-calling iterations
- All metering is silent, failure-isolated, and excludes anonymous users

## Changes
- **Engineer:** New usage metering service module; instrumented chatbot, section-opening, and portfolio summary endpoints; extended `call_ai_with_tools` to return accumulated token usage
- **QA:** Full test plan verified — all acceptance criteria met, 0 new test regressions

## Testing
- ✅ All unit tests passing (0 new regressions vs main)
- ✅ QA verification complete — all 30+ test plan items verified
- ✅ No design review needed (backend-only)

## Design Spec
Implements backend metering per Phase 12 AI Foundation & Metering milestone.