### PR TITLE
US-12.3.1: Per-session anonymous rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,3 +67,13 @@ MAIL_DEFAULT_SENDER=SignalTrackers <briefings@signaltrackers.com>
 # For local development: http://localhost:5000
 # For production: https://yourdomain.com
 BASE_URL=http://localhost:5000
+
+# =============================================================================
+# Anonymous Session Rate Limits (US-12.3.1)
+# =============================================================================
+
+# Lifetime AI call budget per anonymous session (resets on cookie clear)
+# Chatbot messages (includes section-opening calls)
+ANON_SESSION_LIMIT_CHATBOT=5
+# Analysis calls (summary generation endpoints)
+ANON_SESSION_LIMIT_ANALYSIS=2

--- a/signaltrackers/config.py
+++ b/signaltrackers/config.py
@@ -37,6 +37,10 @@ class Config:
     RATELIMIT_STORAGE_URI = 'memory://'
     RATELIMIT_DEFAULT = '100 per minute'
 
+    # Anonymous session AI limits (lifetime per session)
+    ANON_SESSION_LIMIT_CHATBOT = int(os.environ.get('ANON_SESSION_LIMIT_CHATBOT', 5))
+    ANON_SESSION_LIMIT_ANALYSIS = int(os.environ.get('ANON_SESSION_LIMIT_ANALYSIS', 2))
+
     # Optional services
     FRED_API_KEY = os.environ.get('FRED_API_KEY')
     TAVILY_API_KEY = os.environ.get('TAVILY_API_KEY')

--- a/signaltrackers/dashboard.py
+++ b/signaltrackers/dashboard.py
@@ -60,6 +60,7 @@ from conditions_config import (
 )
 from property_interpretation_config import get_property_interpretation
 from market_conditions import update_market_conditions_cache, get_market_conditions, get_conditions_history, build_implications_matrix
+from services.rate_limiting import anonymous_rate_limit, CATEGORY_CHATBOT, CATEGORY_ANALYSIS
 
 
 app = Flask(__name__)
@@ -2929,6 +2930,7 @@ def api_ai_summary():
 
 
 @app.route('/api/ai-summary/generate', methods=['POST'])
+@anonymous_rate_limit(CATEGORY_ANALYSIS)
 def api_generate_summary():
     """Manually trigger AI summary generation."""
     try:
@@ -2967,6 +2969,7 @@ def api_crypto_summary():
 
 
 @app.route('/api/crypto-summary/generate', methods=['POST'])
+@anonymous_rate_limit(CATEGORY_ANALYSIS)
 def api_generate_crypto_summary():
     """Manually trigger crypto AI summary generation."""
     try:
@@ -3003,6 +3006,7 @@ def api_equity_summary():
 
 
 @app.route('/api/equity-summary/generate', methods=['POST'])
+@anonymous_rate_limit(CATEGORY_ANALYSIS)
 def api_generate_equity_summary():
     """Manually trigger equity AI summary generation."""
     try:
@@ -3039,6 +3043,7 @@ def api_rates_summary():
 
 
 @app.route('/api/rates-summary/generate', methods=['POST'])
+@anonymous_rate_limit(CATEGORY_ANALYSIS)
 def api_generate_rates_summary():
     """Manually trigger rates AI summary generation."""
     try:
@@ -3075,6 +3080,7 @@ def api_dollar_summary():
 
 
 @app.route('/api/dollar-summary/generate', methods=['POST'])
+@anonymous_rate_limit(CATEGORY_ANALYSIS)
 def api_generate_dollar_summary():
     """Manually trigger dollar AI summary generation."""
     try:
@@ -3111,6 +3117,7 @@ def api_credit_summary():
 
 
 @app.route('/api/credit-summary/generate', methods=['POST'])
+@anonymous_rate_limit(CATEGORY_ANALYSIS)
 def api_generate_credit_summary():
     """Manually trigger credit AI summary generation."""
     try:
@@ -3218,6 +3225,7 @@ def _build_chatbot_enrichment_context():
 
 @app.route('/api/chatbot', methods=['POST'])
 @csrf.exempt
+@anonymous_rate_limit(CATEGORY_CHATBOT)
 def api_chatbot():
     """Handle AI chatbot conversation requests using the system API key."""
     from services.ai_service import get_system_ai_client, get_system_chatbot_model
@@ -3774,6 +3782,7 @@ def _get_section_live_data(section_id: str) -> str:
 
 @app.route('/api/chatbot/section-opening', methods=['POST'])
 @csrf.exempt
+@anonymous_rate_limit(CATEGORY_CHATBOT)
 def api_chatbot_section_opening():
     """Generate an AI-powered opening message for a section AI button click.
 
@@ -4122,6 +4131,7 @@ def api_market_conditions_synthesis():
 
 
 @app.route('/api/market-conditions-synthesis/generate', methods=['POST'])
+@anonymous_rate_limit(CATEGORY_ANALYSIS)
 def api_generate_market_synthesis():
     """Manually trigger market conditions synthesis generation."""
     try:

--- a/signaltrackers/services/rate_limiting.py
+++ b/signaltrackers/services/rate_limiting.py
@@ -1,0 +1,133 @@
+"""
+Anonymous Session Rate Limiting Service
+
+Tracks per-session AI usage for anonymous users via Flask session.
+Registered users bypass anonymous session limits.
+
+Designed to be extended by US-12.3.2 (global daily cap) and
+US-12.3.3 (per-user registered limits).
+"""
+
+import logging
+from functools import wraps
+from flask import jsonify, session, current_app
+from flask_login import current_user
+
+logger = logging.getLogger(__name__)
+
+# Endpoint category constants
+CATEGORY_CHATBOT = 'chatbot'
+CATEGORY_ANALYSIS = 'analysis'
+
+# Session keys for tracking usage counts
+_SESSION_KEY_PREFIX = 'rate_limit_'
+
+# Default limits (overridable via app config)
+DEFAULT_LIMITS = {
+    CATEGORY_CHATBOT: 5,
+    CATEGORY_ANALYSIS: 2,
+}
+
+
+def _get_limit(category):
+    """Get the configured limit for a category.
+
+    Checks app config first (set from env vars), falls back to defaults.
+    """
+    config_key = f'ANON_SESSION_LIMIT_{category.upper()}'
+    return current_app.config.get(config_key, DEFAULT_LIMITS.get(category, 0))
+
+
+def _session_key(category):
+    """Get the session storage key for a category counter."""
+    return f'{_SESSION_KEY_PREFIX}{category}'
+
+
+def check_anonymous_rate_limit(category):
+    """Check if the current anonymous session has exceeded its rate limit.
+
+    Args:
+        category: The endpoint category (CATEGORY_CHATBOT or CATEGORY_ANALYSIS).
+
+    Returns:
+        None if the request is allowed.
+        A dict with rate limit response data if the request should be blocked.
+    """
+    try:
+        # Registered users bypass anonymous session limits
+        if current_user.is_authenticated:
+            return None
+
+        limit = _get_limit(category)
+        key = _session_key(category)
+        current_count = session.get(key, 0)
+
+        if current_count >= limit:
+            return {
+                'limited': True,
+                'message': (
+                    'You\'ve reached your free session limit for this feature. '
+                    'Create a free account to get higher limits and a '
+                    'personalized experience.'
+                ),
+                'limit_type': 'anonymous_session',
+                'category': category,
+            }
+
+        return None
+
+    except Exception:
+        # Never block a request due to rate limiting errors
+        logger.exception('Anonymous rate limit check error (non-fatal)')
+        return None
+
+
+def anonymous_rate_limit(category):
+    """Decorator that enforces anonymous session rate limits on an endpoint.
+
+    Checks the limit before the request and records usage after a successful
+    response (2xx status).
+
+    Args:
+        category: The endpoint category (CATEGORY_CHATBOT or CATEGORY_ANALYSIS).
+    """
+    def decorator(f):
+        @wraps(f)
+        def wrapped(*args, **kwargs):
+            limit_response = check_anonymous_rate_limit(category)
+            if limit_response:
+                return jsonify(limit_response), 429
+
+            result = f(*args, **kwargs)
+
+            # Record usage on successful responses
+            # Flask views can return (response, status) tuples or Response objects
+            status = 200
+            if isinstance(result, tuple):
+                status = result[1] if len(result) > 1 else 200
+            if 200 <= status < 300:
+                record_anonymous_usage(category)
+
+            return result
+        return wrapped
+    return decorator
+
+
+def record_anonymous_usage(category):
+    """Increment the anonymous session usage counter for a category.
+
+    Call this AFTER a successful AI response is generated (not before).
+
+    Args:
+        category: The endpoint category (CATEGORY_CHATBOT or CATEGORY_ANALYSIS).
+    """
+    try:
+        if current_user.is_authenticated:
+            return
+
+        key = _session_key(category)
+        session[key] = session.get(key, 0) + 1
+
+    except Exception:
+        # Never break AI features due to rate limiting errors
+        logger.exception('Anonymous rate limit record error (non-fatal)')

--- a/tests/test_us1231_anonymous_rate_limiting.py
+++ b/tests/test_us1231_anonymous_rate_limiting.py
@@ -1,0 +1,487 @@
+"""
+US-12.3.1: Per-session anonymous rate limiting
+
+Tests for:
+- Anonymous session rate limit checking and enforcement
+- Usage counter tracking via Flask session
+- Registered users bypass anonymous limits
+- Configurable limits via app config
+- Structured JSON response format
+- Decorator integration on AI endpoints
+- Reusable decorator pattern
+- Edge cases: first request, counter initialization, tampered sessions
+"""
+
+import ast
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+REPO_ROOT = Path(__file__).parent.parent
+SIGNALTRACKERS_DIR = REPO_ROOT / 'signaltrackers'
+
+sys.path.insert(0, str(SIGNALTRACKERS_DIR))
+
+DASHBOARD_FILE = SIGNALTRACKERS_DIR / 'dashboard.py'
+RATE_LIMITING_FILE = SIGNALTRACKERS_DIR / 'services' / 'rate_limiting.py'
+CONFIG_FILE = SIGNALTRACKERS_DIR / 'config.py'
+
+DASHBOARD_SOURCE = DASHBOARD_FILE.read_text()
+RATE_LIMITING_SOURCE = RATE_LIMITING_FILE.read_text()
+CONFIG_SOURCE = CONFIG_FILE.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _get_decorator_names(source: str, func_name: str) -> list:
+    """Extract decorator names for a given function from source."""
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == func_name:
+            decorators = []
+            for d in node.decorator_list:
+                if isinstance(d, ast.Call):
+                    if isinstance(d.func, ast.Name):
+                        decorators.append(d.func.id)
+                    elif isinstance(d.func, ast.Attribute):
+                        decorators.append(d.func.attr)
+                elif isinstance(d, ast.Attribute):
+                    decorators.append(d.attr)
+                elif isinstance(d, ast.Name):
+                    decorators.append(d.id)
+            return decorators
+    return []
+
+
+# ---------------------------------------------------------------------------
+# AC1: Session tracks usage counts
+# ---------------------------------------------------------------------------
+
+class TestSessionTracking:
+    """Verify Flask session is used to track anonymous usage counts."""
+
+    def test_rate_limiting_imports_session(self):
+        """rate_limiting.py imports Flask session."""
+        assert 'from flask import' in RATE_LIMITING_SOURCE
+        assert 'session' in RATE_LIMITING_SOURCE
+
+    def test_session_key_prefix_defined(self):
+        """Session keys use a consistent prefix."""
+        assert '_SESSION_KEY_PREFIX' in RATE_LIMITING_SOURCE
+
+    def test_record_usage_increments_session(self):
+        """record_anonymous_usage increments a session counter."""
+        assert 'session[key] = session.get(key, 0) + 1' in RATE_LIMITING_SOURCE
+
+
+# ---------------------------------------------------------------------------
+# AC2: Default limits configured
+# ---------------------------------------------------------------------------
+
+class TestDefaultLimits:
+    """Verify default limits: ~5 chatbot, ~2 analysis."""
+
+    def test_default_chatbot_limit(self):
+        """Default chatbot limit is 5."""
+        assert "CATEGORY_CHATBOT: 5" in RATE_LIMITING_SOURCE or \
+               "'chatbot': 5" in RATE_LIMITING_SOURCE
+
+    def test_default_analysis_limit(self):
+        """Default analysis limit is 2."""
+        assert "CATEGORY_ANALYSIS: 2" in RATE_LIMITING_SOURCE or \
+               "'analysis': 2" in RATE_LIMITING_SOURCE
+
+    def test_config_has_anon_session_limits(self):
+        """config.py defines ANON_SESSION_LIMIT_ variables."""
+        assert 'ANON_SESSION_LIMIT_CHATBOT' in CONFIG_SOURCE
+        assert 'ANON_SESSION_LIMIT_ANALYSIS' in CONFIG_SOURCE
+
+
+# ---------------------------------------------------------------------------
+# AC3: Limits configurable via environment variables
+# ---------------------------------------------------------------------------
+
+class TestConfigurableLimits:
+    """Verify limits are configurable without code changes."""
+
+    def test_config_reads_env_vars(self):
+        """Config reads limits from environment variables."""
+        assert "os.environ.get('ANON_SESSION_LIMIT_CHATBOT'" in CONFIG_SOURCE
+        assert "os.environ.get('ANON_SESSION_LIMIT_ANALYSIS'" in CONFIG_SOURCE
+
+    def test_rate_limiting_reads_app_config(self):
+        """rate_limiting.py reads limits from app config."""
+        assert 'current_app.config.get' in RATE_LIMITING_SOURCE
+
+    def test_env_example_documents_limits(self):
+        """The .env.example file documents the rate limit variables."""
+        env_example_path = REPO_ROOT / '.env.example'
+        if not env_example_path.exists():
+            pytest.skip('.env.example not available in container')
+        env_example = env_example_path.read_text()
+        assert 'ANON_SESSION_LIMIT_CHATBOT' in env_example
+        assert 'ANON_SESSION_LIMIT_ANALYSIS' in env_example
+
+
+# ---------------------------------------------------------------------------
+# AC4: Structured JSON response on limit hit
+# ---------------------------------------------------------------------------
+
+class TestRateLimitResponse:
+    """Verify structured JSON response format."""
+
+    def test_response_has_limited_field(self):
+        """Rate limit response includes 'limited': True."""
+        assert "'limited': True" in RATE_LIMITING_SOURCE
+
+    def test_response_has_limit_type(self):
+        """Rate limit response includes limit_type: 'anonymous_session'."""
+        assert "'limit_type': 'anonymous_session'" in RATE_LIMITING_SOURCE
+
+    def test_response_has_message(self):
+        """Rate limit response includes a user-facing message."""
+        assert "'message'" in RATE_LIMITING_SOURCE
+
+    def test_response_has_category(self):
+        """Rate limit response includes the category."""
+        assert "'category': category" in RATE_LIMITING_SOURCE
+
+    def test_decorator_returns_429(self):
+        """Decorator returns HTTP 429 when limit exceeded."""
+        assert '429' in RATE_LIMITING_SOURCE
+
+
+# ---------------------------------------------------------------------------
+# AC5: Signup encouragement message
+# ---------------------------------------------------------------------------
+
+class TestSignupMessage:
+    """Verify the limit response encourages signup."""
+
+    def test_message_mentions_account(self):
+        """Limit message encourages creating an account."""
+        # Check the message contains signup-related text
+        assert 'account' in RATE_LIMITING_SOURCE.lower() or \
+               'sign' in RATE_LIMITING_SOURCE.lower()
+
+
+# ---------------------------------------------------------------------------
+# AC6: Registered users bypass anonymous limits
+# ---------------------------------------------------------------------------
+
+class TestRegisteredUserBypass:
+    """Verify authenticated users are not affected by anonymous limits."""
+
+    def test_check_bypasses_authenticated_users(self):
+        """check_anonymous_rate_limit returns None for authenticated users."""
+        assert 'current_user.is_authenticated' in RATE_LIMITING_SOURCE
+
+    def test_record_skips_authenticated_users(self):
+        """record_anonymous_usage skips incrementing for authenticated users."""
+        # Both check and record functions should check is_authenticated
+        occurrences = RATE_LIMITING_SOURCE.count('current_user.is_authenticated')
+        assert occurrences >= 2, \
+            "Both check and record functions should check is_authenticated"
+
+
+# ---------------------------------------------------------------------------
+# AC7: Reusable decorator
+# ---------------------------------------------------------------------------
+
+class TestReusableDecorator:
+    """Verify decorator is reusable and parameterized."""
+
+    def test_decorator_exists(self):
+        """anonymous_rate_limit decorator function is defined."""
+        assert 'def anonymous_rate_limit(category)' in RATE_LIMITING_SOURCE
+
+    def test_decorator_is_parameterized(self):
+        """Decorator accepts a category parameter."""
+        tree = ast.parse(RATE_LIMITING_SOURCE)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == 'anonymous_rate_limit':
+                args = [a.arg for a in node.args.args]
+                assert 'category' in args
+                break
+        else:
+            pytest.fail("anonymous_rate_limit function not found")
+
+    def test_decorator_uses_functools_wraps(self):
+        """Decorator preserves function metadata with @wraps."""
+        assert 'from functools import wraps' in RATE_LIMITING_SOURCE
+        assert '@wraps(f)' in RATE_LIMITING_SOURCE
+
+    def test_category_constants_exported(self):
+        """Category constants are defined for reuse."""
+        assert 'CATEGORY_CHATBOT' in RATE_LIMITING_SOURCE
+        assert 'CATEGORY_ANALYSIS' in RATE_LIMITING_SOURCE
+
+
+# ---------------------------------------------------------------------------
+# Decorator applied to all AI endpoints
+# ---------------------------------------------------------------------------
+
+class TestEndpointDecoration:
+    """Verify anonymous_rate_limit decorator is applied to all AI endpoints."""
+
+    # Chatbot endpoints → CATEGORY_CHATBOT
+    def test_chatbot_endpoint_has_rate_limit(self):
+        decorators = _get_decorator_names(DASHBOARD_SOURCE, 'api_chatbot')
+        assert 'anonymous_rate_limit' in decorators
+
+    def test_section_opening_endpoint_has_rate_limit(self):
+        decorators = _get_decorator_names(DASHBOARD_SOURCE, 'api_chatbot_section_opening')
+        assert 'anonymous_rate_limit' in decorators
+
+    # Summary/analysis endpoints → CATEGORY_ANALYSIS
+    def test_ai_summary_endpoint_has_rate_limit(self):
+        decorators = _get_decorator_names(DASHBOARD_SOURCE, 'api_generate_summary')
+        assert 'anonymous_rate_limit' in decorators
+
+    def test_crypto_summary_endpoint_has_rate_limit(self):
+        decorators = _get_decorator_names(DASHBOARD_SOURCE, 'api_generate_crypto_summary')
+        assert 'anonymous_rate_limit' in decorators
+
+    def test_equity_summary_endpoint_has_rate_limit(self):
+        decorators = _get_decorator_names(DASHBOARD_SOURCE, 'api_generate_equity_summary')
+        assert 'anonymous_rate_limit' in decorators
+
+    def test_rates_summary_endpoint_has_rate_limit(self):
+        decorators = _get_decorator_names(DASHBOARD_SOURCE, 'api_generate_rates_summary')
+        assert 'anonymous_rate_limit' in decorators
+
+    def test_dollar_summary_endpoint_has_rate_limit(self):
+        decorators = _get_decorator_names(DASHBOARD_SOURCE, 'api_generate_dollar_summary')
+        assert 'anonymous_rate_limit' in decorators
+
+    def test_credit_summary_endpoint_has_rate_limit(self):
+        decorators = _get_decorator_names(DASHBOARD_SOURCE, 'api_generate_credit_summary')
+        assert 'anonymous_rate_limit' in decorators
+
+    def test_market_synthesis_endpoint_has_rate_limit(self):
+        decorators = _get_decorator_names(DASHBOARD_SOURCE, 'api_generate_market_synthesis')
+        assert 'anonymous_rate_limit' in decorators
+
+
+# ---------------------------------------------------------------------------
+# Import wiring
+# ---------------------------------------------------------------------------
+
+class TestImportWiring:
+    """Verify dashboard.py imports rate limiting components."""
+
+    def test_dashboard_imports_decorator(self):
+        assert 'from services.rate_limiting import' in DASHBOARD_SOURCE
+        assert 'anonymous_rate_limit' in DASHBOARD_SOURCE
+
+    def test_dashboard_imports_categories(self):
+        assert 'CATEGORY_CHATBOT' in DASHBOARD_SOURCE
+        assert 'CATEGORY_ANALYSIS' in DASHBOARD_SOURCE
+
+
+# ---------------------------------------------------------------------------
+# Security: silent failure pattern
+# ---------------------------------------------------------------------------
+
+class TestSilentFailure:
+    """Verify rate limiting never breaks AI features on error."""
+
+    def test_check_has_exception_handler(self):
+        """check_anonymous_rate_limit catches all exceptions."""
+        func_src = _get_function_source_from_file(RATE_LIMITING_SOURCE, 'check_anonymous_rate_limit')
+        assert 'except Exception' in func_src
+        assert 'return None' in func_src
+
+    def test_record_has_exception_handler(self):
+        """record_anonymous_usage catches all exceptions."""
+        func_src = _get_function_source_from_file(RATE_LIMITING_SOURCE, 'record_anonymous_usage')
+        assert 'except Exception' in func_src
+
+    def test_non_ai_endpoints_not_decorated(self):
+        """Page load routes (non-AI) are not decorated with rate limiting."""
+        # The index/home route should NOT have the decorator
+        decorators = _get_decorator_names(DASHBOARD_SOURCE, 'index')
+        assert 'anonymous_rate_limit' not in decorators
+
+
+def _get_function_source_from_file(source: str, func_name: str) -> str:
+    """Extract a function's source from a source string."""
+    tree = ast.parse(source)
+    lines = source.splitlines()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == func_name:
+            start = node.lineno - 1
+            end = node.end_lineno
+            return '\n'.join(lines[start:end])
+    return ''
+
+
+# ---------------------------------------------------------------------------
+# Functional tests with Flask app context
+# ---------------------------------------------------------------------------
+
+class TestFunctionalRateLimiting:
+    """Functional tests using Flask test infrastructure."""
+
+    @pytest.fixture
+    def app(self):
+        """Create a minimal Flask app with LoginManager for testing."""
+        from flask import Flask
+        from flask_login import LoginManager
+        app = Flask(__name__)
+        app.config['SECRET_KEY'] = 'test-secret'
+        app.config['ANON_SESSION_LIMIT_CHATBOT'] = 3
+        app.config['ANON_SESSION_LIMIT_ANALYSIS'] = 1
+        login_manager = LoginManager()
+        login_manager.init_app(app)
+
+        @login_manager.user_loader
+        def load_user(user_id):
+            return None
+
+        return app
+
+    def test_check_allows_within_limit(self, app):
+        """Requests within the limit are allowed."""
+        import services.rate_limiting as rl
+
+        with app.test_request_context():
+            # Anonymous user (default with LoginManager, no login)
+            result = rl.check_anonymous_rate_limit(rl.CATEGORY_CHATBOT)
+            assert result is None
+
+    def test_check_blocks_at_limit(self, app):
+        """Requests at the limit are blocked."""
+        import services.rate_limiting as rl
+        from flask import session
+
+        with app.test_request_context():
+            session['rate_limit_chatbot'] = 3  # at the limit
+            result = rl.check_anonymous_rate_limit(rl.CATEGORY_CHATBOT)
+            assert result is not None
+            assert result['limited'] is True
+            assert result['limit_type'] == 'anonymous_session'
+            assert result['category'] == 'chatbot'
+            assert 'message' in result
+
+    def test_check_allows_authenticated_user(self, app):
+        """Authenticated users bypass limits entirely."""
+        import services.rate_limiting as rl
+        from flask import session
+
+        mock_user = MagicMock()
+        mock_user.is_authenticated = True
+
+        with app.test_request_context():
+            session['rate_limit_chatbot'] = 999  # way over limit
+            with patch.object(rl, 'current_user', mock_user):
+                result = rl.check_anonymous_rate_limit(rl.CATEGORY_CHATBOT)
+                assert result is None
+
+    def test_record_increments_counter(self, app):
+        """Recording usage increments the session counter."""
+        import services.rate_limiting as rl
+        from flask import session
+
+        with app.test_request_context():
+            assert session.get('rate_limit_chatbot', 0) == 0
+            rl.record_anonymous_usage(rl.CATEGORY_CHATBOT)
+            assert session.get('rate_limit_chatbot') == 1
+            rl.record_anonymous_usage(rl.CATEGORY_CHATBOT)
+            assert session.get('rate_limit_chatbot') == 2
+
+    def test_record_skips_authenticated_user(self, app):
+        """Recording usage does nothing for authenticated users."""
+        import services.rate_limiting as rl
+        from flask import session
+
+        mock_user = MagicMock()
+        mock_user.is_authenticated = True
+
+        with app.test_request_context():
+            with patch.object(rl, 'current_user', mock_user):
+                rl.record_anonymous_usage(rl.CATEGORY_CHATBOT)
+                assert session.get('rate_limit_chatbot') is None
+
+    def test_separate_category_counters(self, app):
+        """Chatbot and analysis have independent counters."""
+        import services.rate_limiting as rl
+        from flask import session
+
+        with app.test_request_context():
+            # Use up all analysis budget (limit=1)
+            rl.record_anonymous_usage(rl.CATEGORY_ANALYSIS)
+            assert rl.check_anonymous_rate_limit(rl.CATEGORY_ANALYSIS) is not None
+            # Chatbot should still be available
+            assert rl.check_anonymous_rate_limit(rl.CATEGORY_CHATBOT) is None
+
+    def test_decorator_blocks_and_returns_429(self, app):
+        """Decorator returns 429 JSON response when limit exceeded."""
+        import services.rate_limiting as rl
+        from flask import jsonify
+
+        @app.route('/test-endpoint', methods=['POST'])
+        @rl.anonymous_rate_limit(rl.CATEGORY_CHATBOT)
+        def test_view():
+            return jsonify({'status': 'success'})
+
+        with app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess['rate_limit_chatbot'] = 3  # at the limit
+
+            resp = client.post('/test-endpoint')
+            assert resp.status_code == 429
+            data = resp.get_json()
+            assert data['limited'] is True
+
+    def test_decorator_allows_and_records_on_success(self, app):
+        """Decorator allows request and records usage on 2xx response."""
+        import services.rate_limiting as rl
+        from flask import jsonify
+
+        @app.route('/test-ok', methods=['POST'])
+        @rl.anonymous_rate_limit(rl.CATEGORY_CHATBOT)
+        def test_ok_view():
+            return jsonify({'status': 'success'})
+
+        with app.test_client() as client:
+            resp = client.post('/test-ok')
+            assert resp.status_code == 200
+
+            with client.session_transaction() as sess:
+                assert sess.get('rate_limit_chatbot') == 1
+
+    def test_decorator_skips_record_on_error(self, app):
+        """Decorator does not record usage when endpoint returns error."""
+        import services.rate_limiting as rl
+        from flask import jsonify
+
+        @app.route('/test-error', methods=['POST'])
+        @rl.anonymous_rate_limit(rl.CATEGORY_ANALYSIS)
+        def test_error_view():
+            return jsonify({'status': 'error'}), 500
+
+        with app.test_client() as client:
+            resp = client.post('/test-error')
+            assert resp.status_code == 500
+
+            with client.session_transaction() as sess:
+                assert sess.get('rate_limit_analysis', 0) == 0
+
+    def test_first_request_initializes_counter(self, app):
+        """First request in a new session starts counter at 0."""
+        import services.rate_limiting as rl
+        from flask import session
+
+        with app.test_request_context():
+            # No session key set — should allow
+            assert 'rate_limit_chatbot' not in session
+            result = rl.check_anonymous_rate_limit(rl.CATEGORY_CHATBOT)
+            assert result is None


### PR DESCRIPTION
Fixes #395

## Summary
Implements per-session anonymous rate limiting for AI endpoints (chatbot and portfolio analysis). Each anonymous session gets a configurable lifetime budget tracked via Flask session cookies.

## Changes
- Added `signaltrackers/services/rate_limiting.py` — reusable `@anonymous_rate_limit(category)` decorator with `check_anonymous_rate_limit()` and `record_anonymous_usage()` functions
- Updated `signaltrackers/dashboard.py` — applied rate limiting decorator to chatbot and analysis endpoints
- Updated `signaltrackers/config.py` — added `ANON_SESSION_LIMIT_CHATBOT` (5) and `ANON_SESSION_LIMIT_ANALYSIS` (2) config values
- Updated `.env.example` — documented new environment variables
- Added `tests/test_us1231_anonymous_rate_limiting.py` — comprehensive test suite (487 lines)

## Testing
- ✅ All unit tests passing
- ✅ QA verification complete
- ✅ Backend-only (no design review needed)

## Spec
Backend-only implementation per parent feature #379. No design spec required.