### PR TITLE
US-13.1.1: Billing module & Stripe SDK setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,3 +87,28 @@ ANON_SESSION_LIMIT_ANALYSIS=2
 REGISTERED_DAILY_LIMIT_CHATBOT=25
 # Analysis calls (portfolio analysis, summary generation)
 REGISTERED_DAILY_LIMIT_ANALYSIS=5
+
+# =============================================================================
+# Stripe Billing (Phase 13 — Subscriptions)
+# =============================================================================
+
+# Stripe Secret Key — server-side API calls
+# Find at: https://dashboard.stripe.com/apikeys (use "Secret key")
+# For development, use a test-mode key (starts with sk_test_)
+STRIPE_SECRET_KEY=
+
+# Stripe Publishable Key — client-side checkout
+# Find at: https://dashboard.stripe.com/apikeys (use "Publishable key")
+# For development, use a test-mode key (starts with pk_test_)
+STRIPE_PUBLISHABLE_KEY=
+
+# Stripe Webhook Signing Secret — verifies webhook payloads
+# Find at: https://dashboard.stripe.com/webhooks → select endpoint → "Signing secret"
+# For local dev with Stripe CLI: stripe listen --forward-to localhost:5000/billing/webhook
+# The CLI prints the signing secret on startup (starts with whsec_)
+STRIPE_WEBHOOK_SECRET=
+
+# Stripe Price ID — the subscription price to charge
+# Create a Product + Price at: https://dashboard.stripe.com/products
+# Copy the Price ID (starts with price_)
+STRIPE_PRICE_ID=

--- a/signaltrackers/billing/__init__.py
+++ b/signaltrackers/billing/__init__.py
@@ -1,0 +1,67 @@
+"""
+Billing Module — Stripe Integration
+
+Provides Stripe client initialization and billing utilities.
+All secrets are read from environment variables; the module degrades
+gracefully when Stripe credentials are not configured.
+"""
+
+import os
+import logging
+
+import stripe
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Stripe client configuration
+# ---------------------------------------------------------------------------
+
+_stripe_configured = False
+
+
+def init_stripe(app=None):
+    """Initialise the Stripe SDK from environment variables.
+
+    Call once at application startup.  If ``STRIPE_SECRET_KEY`` is not set
+    (or is empty), the module stays in an unconfigured state and all
+    billing operations will be unavailable — but the rest of the
+    application continues to work normally.
+    """
+    global _stripe_configured
+
+    secret_key = os.environ.get("STRIPE_SECRET_KEY", "").strip()
+
+    if not secret_key:
+        logger.info("Stripe not configured — STRIPE_SECRET_KEY is not set. "
+                     "Billing features will be unavailable.")
+        _stripe_configured = False
+        return False
+
+    stripe.api_key = secret_key
+    _stripe_configured = True
+    logger.info("Stripe SDK initialised successfully.")
+    return True
+
+
+def is_stripe_configured() -> bool:
+    """Return *True* if Stripe has been initialised with a secret key."""
+    return _stripe_configured
+
+
+def get_publishable_key() -> str | None:
+    """Return the Stripe publishable key for client-side use, or *None*."""
+    key = os.environ.get("STRIPE_PUBLISHABLE_KEY", "").strip()
+    return key or None
+
+
+def get_webhook_secret() -> str | None:
+    """Return the webhook signing secret, or *None*."""
+    secret = os.environ.get("STRIPE_WEBHOOK_SECRET", "").strip()
+    return secret or None
+
+
+def get_price_id() -> str | None:
+    """Return the configured Stripe Price ID, or *None*."""
+    price_id = os.environ.get("STRIPE_PRICE_ID", "").strip()
+    return price_id or None

--- a/signaltrackers/config.py
+++ b/signaltrackers/config.py
@@ -52,6 +52,12 @@ class Config:
     FRED_API_KEY = os.environ.get('FRED_API_KEY')
     TAVILY_API_KEY = os.environ.get('TAVILY_API_KEY')
 
+    # Stripe billing
+    STRIPE_SECRET_KEY = os.environ.get('STRIPE_SECRET_KEY', '')
+    STRIPE_PUBLISHABLE_KEY = os.environ.get('STRIPE_PUBLISHABLE_KEY', '')
+    STRIPE_WEBHOOK_SECRET = os.environ.get('STRIPE_WEBHOOK_SECRET', '')
+    STRIPE_PRICE_ID = os.environ.get('STRIPE_PRICE_ID', '')
+
     # Email configuration (Flask-Mail)
     MAIL_SERVER = os.environ.get('MAIL_SERVER', 'smtp-relay.brevo.com')
     MAIL_PORT = int(os.environ.get('MAIL_PORT', 587))

--- a/signaltrackers/dashboard.py
+++ b/signaltrackers/dashboard.py
@@ -61,6 +61,7 @@ from conditions_config import (
 from property_interpretation_config import get_property_interpretation
 from market_conditions import update_market_conditions_cache, get_market_conditions, get_conditions_history, build_implications_matrix
 from services.rate_limiting import anonymous_rate_limit, CATEGORY_CHATBOT, CATEGORY_ANALYSIS
+from billing import init_stripe
 
 
 app = Flask(__name__)
@@ -70,6 +71,9 @@ app.config.from_object(get_config())
 
 # Initialize extensions (database, login manager, CSRF, rate limiting)
 init_extensions(app)
+
+# Initialize Stripe billing (gracefully skipped when env vars are absent)
+init_stripe(app)
 
 # Initialize OpenAI client (only if API key is available)
 openai_api_key = os.environ.get('OPENAI_API_KEY')

--- a/signaltrackers/requirements.txt
+++ b/signaltrackers/requirements.txt
@@ -15,6 +15,9 @@ flask-wtf>=1.2.0
 flask-limiter>=3.5.0
 flask-mail==0.9.1
 
+# Payments
+stripe>=8.0.0
+
 # Security
 email-validator>=2.0.0
 

--- a/tests/test_us1311_billing_module_stripe_setup.py
+++ b/tests/test_us1311_billing_module_stripe_setup.py
@@ -1,0 +1,289 @@
+"""
+US-13.1.1: Billing Module & Stripe SDK Setup
+
+Tests for:
+- Billing module exists as an architecturally distinct area
+- Stripe Python SDK is installed and importable
+- Stripe client initialises from environment variables
+- Application starts when Stripe env vars are absent (graceful degradation)
+- .env.example documents all required Stripe variables
+- No hardcoded Stripe keys in the codebase
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+REPO_ROOT = Path(__file__).parent.parent
+SIGNALTRACKERS_DIR = REPO_ROOT / "signaltrackers"
+BILLING_DIR = SIGNALTRACKERS_DIR / "billing"
+
+sys.path.insert(0, str(SIGNALTRACKERS_DIR))
+
+
+# ===========================================================================
+# Module Structure
+# ===========================================================================
+
+class TestBillingModuleStructure:
+    """Billing module exists as an architecturally distinct area."""
+
+    def test_billing_directory_exists(self):
+        assert BILLING_DIR.is_dir(), "signaltrackers/billing/ directory must exist"
+
+    def test_billing_init_exists(self):
+        init_file = BILLING_DIR / "__init__.py"
+        assert init_file.is_file(), "signaltrackers/billing/__init__.py must exist"
+
+    def test_billing_module_importable(self):
+        import billing
+        assert hasattr(billing, "init_stripe")
+        assert hasattr(billing, "is_stripe_configured")
+        assert hasattr(billing, "get_publishable_key")
+        assert hasattr(billing, "get_webhook_secret")
+        assert hasattr(billing, "get_price_id")
+
+
+# ===========================================================================
+# Stripe SDK
+# ===========================================================================
+
+class TestStripeSdkInstalled:
+    """Stripe Python SDK is installed and importable."""
+
+    def test_stripe_importable(self):
+        import stripe
+        assert hasattr(stripe, "api_key")
+        assert hasattr(stripe, "VERSION")
+
+
+# ===========================================================================
+# Stripe Client Initialisation
+# ===========================================================================
+
+class TestStripeClientInit:
+    """Stripe client initialises from environment variables."""
+
+    def test_init_stripe_with_key(self):
+        import stripe
+        from billing import init_stripe, is_stripe_configured
+
+        with patch.dict(os.environ, {"STRIPE_SECRET_KEY": "sk_test_fake123"}):
+            result = init_stripe()
+            assert result is True
+            assert is_stripe_configured() is True
+            assert stripe.api_key == "sk_test_fake123"
+
+    def test_init_stripe_without_key(self):
+        from billing import init_stripe, is_stripe_configured
+
+        env = os.environ.copy()
+        env.pop("STRIPE_SECRET_KEY", None)
+        with patch.dict(os.environ, env, clear=True):
+            result = init_stripe()
+            assert result is False
+            assert is_stripe_configured() is False
+
+    def test_init_stripe_empty_key(self):
+        from billing import init_stripe, is_stripe_configured
+
+        with patch.dict(os.environ, {"STRIPE_SECRET_KEY": ""}):
+            result = init_stripe()
+            assert result is False
+            assert is_stripe_configured() is False
+
+    def test_init_stripe_whitespace_key(self):
+        from billing import init_stripe, is_stripe_configured
+
+        with patch.dict(os.environ, {"STRIPE_SECRET_KEY": "   "}):
+            result = init_stripe()
+            assert result is False
+            assert is_stripe_configured() is False
+
+    def test_no_hardcoded_keys(self):
+        """No Stripe keys hardcoded anywhere in the codebase."""
+        import re
+
+        patterns = [
+            r"sk_test_[A-Za-z0-9]{10,}",
+            r"sk_live_[A-Za-z0-9]{10,}",
+            r"pk_test_[A-Za-z0-9]{10,}",
+            r"pk_live_[A-Za-z0-9]{10,}",
+            r"whsec_[A-Za-z0-9]{10,}",
+        ]
+
+        violations = []
+        for py_file in SIGNALTRACKERS_DIR.rglob("*.py"):
+            content = py_file.read_text()
+            for pattern in patterns:
+                if re.search(pattern, content):
+                    violations.append(f"{py_file.relative_to(REPO_ROOT)}: matches {pattern}")
+
+        assert not violations, (
+            "Hardcoded Stripe keys found:\n" + "\n".join(violations)
+        )
+
+
+# ===========================================================================
+# Helper Functions
+# ===========================================================================
+
+class TestHelperFunctions:
+    """Publishable key, webhook secret, and price ID helpers."""
+
+    def test_get_publishable_key_set(self):
+        from billing import get_publishable_key
+
+        with patch.dict(os.environ, {"STRIPE_PUBLISHABLE_KEY": "pk_test_abc"}):
+            assert get_publishable_key() == "pk_test_abc"
+
+    def test_get_publishable_key_unset(self):
+        from billing import get_publishable_key
+
+        env = os.environ.copy()
+        env.pop("STRIPE_PUBLISHABLE_KEY", None)
+        with patch.dict(os.environ, env, clear=True):
+            assert get_publishable_key() is None
+
+    def test_get_publishable_key_empty(self):
+        from billing import get_publishable_key
+
+        with patch.dict(os.environ, {"STRIPE_PUBLISHABLE_KEY": ""}):
+            assert get_publishable_key() is None
+
+    def test_get_webhook_secret_set(self):
+        from billing import get_webhook_secret
+
+        with patch.dict(os.environ, {"STRIPE_WEBHOOK_SECRET": "whsec_test"}):
+            assert get_webhook_secret() == "whsec_test"
+
+    def test_get_webhook_secret_unset(self):
+        from billing import get_webhook_secret
+
+        env = os.environ.copy()
+        env.pop("STRIPE_WEBHOOK_SECRET", None)
+        with patch.dict(os.environ, env, clear=True):
+            assert get_webhook_secret() is None
+
+    def test_get_price_id_set(self):
+        from billing import get_price_id
+
+        with patch.dict(os.environ, {"STRIPE_PRICE_ID": "price_123"}):
+            assert get_price_id() == "price_123"
+
+    def test_get_price_id_unset(self):
+        from billing import get_price_id
+
+        env = os.environ.copy()
+        env.pop("STRIPE_PRICE_ID", None)
+        with patch.dict(os.environ, env, clear=True):
+            assert get_price_id() is None
+
+
+# ===========================================================================
+# Graceful Degradation
+# ===========================================================================
+
+class TestGracefulDegradation:
+    """App starts and works when Stripe env vars are absent."""
+
+    def test_billing_import_without_env_vars(self):
+        """Importing the billing module never raises, even without env vars."""
+        env = os.environ.copy()
+        for key in ("STRIPE_SECRET_KEY", "STRIPE_PUBLISHABLE_KEY",
+                     "STRIPE_WEBHOOK_SECRET", "STRIPE_PRICE_ID"):
+            env.pop(key, None)
+
+        with patch.dict(os.environ, env, clear=True):
+            from billing import init_stripe, is_stripe_configured
+            init_stripe()
+            assert is_stripe_configured() is False
+
+    def test_invalid_key_format_no_crash(self):
+        """Malformed key doesn't crash at init time."""
+        from billing import init_stripe, is_stripe_configured
+
+        with patch.dict(os.environ, {"STRIPE_SECRET_KEY": "not-a-real-key"}):
+            result = init_stripe()
+            # A non-empty string is accepted at init; validation happens on use
+            assert result is True
+            assert is_stripe_configured() is True
+
+
+# ===========================================================================
+# .env.example Configuration
+# ===========================================================================
+
+class TestEnvExample:
+    """.env.example documents all Stripe variables with comments."""
+
+    @pytest.fixture(autouse=True)
+    def _load_env_example(self):
+        env_example = REPO_ROOT / ".env.example"
+        assert env_example.is_file(), ".env.example must exist"
+        self.content = env_example.read_text()
+
+    @pytest.mark.parametrize("var", [
+        "STRIPE_SECRET_KEY",
+        "STRIPE_PUBLISHABLE_KEY",
+        "STRIPE_WEBHOOK_SECRET",
+        "STRIPE_PRICE_ID",
+    ])
+    def test_variable_present(self, var):
+        assert var in self.content, f"{var} must be in .env.example"
+
+    def test_no_real_keys_in_env_example(self):
+        """Placeholder values only — no actual Stripe keys."""
+        import re
+        for pattern in (r"sk_test_\w{10,}", r"sk_live_\w{10,}",
+                        r"pk_test_\w{10,}", r"pk_live_\w{10,}",
+                        r"whsec_\w{10,}"):
+            assert not re.search(pattern, self.content), (
+                f".env.example must not contain real keys matching {pattern}"
+            )
+
+    def test_variables_have_comments(self):
+        """Each Stripe variable should have an explanatory comment nearby."""
+        lines = self.content.splitlines()
+        for var in ("STRIPE_SECRET_KEY", "STRIPE_PUBLISHABLE_KEY",
+                     "STRIPE_WEBHOOK_SECRET", "STRIPE_PRICE_ID"):
+            # Find the line with the variable
+            var_idx = next(
+                (i for i, line in enumerate(lines) if var in line and not line.strip().startswith("#")),
+                None,
+            )
+            assert var_idx is not None, f"{var} not found as a variable line"
+            # Check that at least one comment line precedes it within 5 lines
+            preceding = lines[max(0, var_idx - 5):var_idx]
+            has_comment = any(line.strip().startswith("#") for line in preceding)
+            assert has_comment, f"{var} should have an explanatory comment above it"
+
+
+# ===========================================================================
+# Security — .env not committed
+# ===========================================================================
+
+class TestSecurity:
+    """Ensure .env is gitignored."""
+
+    def test_env_in_gitignore(self):
+        gitignore = REPO_ROOT / ".gitignore"
+        assert gitignore.is_file()
+        content = gitignore.read_text()
+        assert ".env" in content, ".env must be listed in .gitignore"
+
+    def test_env_file_not_tracked(self):
+        """If a .env file exists, it should not be tracked by git."""
+        import subprocess
+
+        result = subprocess.run(
+            ["git", "ls-files", ".env"],
+            capture_output=True, text=True, cwd=str(REPO_ROOT),
+        )
+        assert result.stdout.strip() == "", ".env must not be tracked by git"


### PR DESCRIPTION
Fixes #418

## Summary
Adds the billing module foundation and Stripe SDK integration for Phase 13. All payment-related features will build on this infrastructure.

## Changes
- `signaltrackers/billing/__init__.py` — billing module with `init_stripe()`, `is_stripe_configured()`, and helpers for publishable key, webhook secret, and price ID
- Stripe SDK (`stripe>=8.0.0`) added to requirements.txt
- Stripe config vars added to Flask `Config` class in `config.py`
- `init_stripe()` called at app startup in `dashboard.py` — gracefully skips when env vars absent
- `.env.example` updated with all 4 Stripe variables with explanatory comments
- 26 integration tests covering module structure, SDK init, graceful degradation, env.example validation, and security

## Testing
- ✅ All 26 story tests passing
- ✅ Full regression suite: 3609/3609 passed (0 new regressions)
- ✅ QA verification complete — all acceptance criteria met
- ✅ No design review needed (backend-only)
- ✅ No hardcoded Stripe keys in codebase