### PR TITLE
US-14.1.1: CSS Custom Properties & Font Loading for MacroClarity Rebrand

### DIFF
--- a/signaltrackers/static/css/dashboard.css
+++ b/signaltrackers/static/css/dashboard.css
@@ -8,6 +8,26 @@
     --dark-bg: #212529;
     --ai-color: #6366F1;   /* indigo-500 — AI identity, matches chatbot FAB */
     --ai-accent: #F59E0B;  /* amber-500 — sparkle mark */
+
+    /* MacroClarity rebrand — typography tokens */
+    --font-display: 'Noto Serif', Georgia, 'Times New Roman', serif;
+    --font-interface: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+                      'Roboto', 'Helvetica Neue', Arial, sans-serif;
+
+    /* MacroClarity rebrand — surface tonal hierarchy */
+    --surface: #f8f9ff;
+    --surface-container-low: #eff4ff;
+    --surface-container-lowest: #ffffff;
+
+    /* MacroClarity rebrand — brand colors (from logo) */
+    --brand-navy-dark: #09264c;
+    --brand-navy-medium: #0e3a67;
+
+    /* MacroClarity rebrand — primary text */
+    --on-surface: #0b1c30;
+
+    /* MacroClarity rebrand — navy-tinted shadow */
+    --shadow-navy: rgba(11, 28, 48, 0.06);
 }
 
 body {

--- a/signaltrackers/templates/base.html
+++ b/signaltrackers/templates/base.html
@@ -6,6 +6,9 @@
     <meta name="description" content="Daily macro intelligence briefings for individual investors. Track credit, equities, rates, safe havens, crypto, and currency markets in one dashboard.">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{% block title %}SignalTrackers - Macro Intelligence Platform{% endblock %}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Serif:wght@700&display=swap" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}">


### PR DESCRIPTION
Fixes #441

## Summary
Defines the CSS design token foundation for the MacroClarity rebrand: Google Fonts loading (Inter + Noto Serif), typography tokens, surface tonal hierarchy, brand colors, and navy-tinted shadow — all as CSS custom properties. This is pure infrastructure; no visual changes are applied yet.

## Changes
- Added preconnect hints and Google Fonts stylesheet to `base.html` (Inter 400/500/600/700, Noto Serif 700, `font-display: swap`)
- Defined CSS custom properties in `dashboard.css` `:root`: `--font-display`, `--font-interface`, `--surface`, `--surface-container-low`, `--surface-container-lowest`, `--brand-navy-dark`, `--brand-navy-medium`, `--on-surface`, `--shadow-navy`
- No existing properties modified or removed

## Testing
- ✅ All unit tests passing (0 new regressions vs main baseline)
- ✅ Design review approved
- ✅ QA verification complete — all 10 acceptance criteria met

## Design Spec
Implements [docs/specs/rebrand-macroclarity.md](docs/specs/rebrand-macroclarity.md) — sections 2 (Color System) and 3 (Typography)