### PR TITLE
US-14.6.1: Email Template MacroClarity Rebrand

### DIFF
--- a/signaltrackers/templates/email/alert_notification.html
+++ b/signaltrackers/templates/email/alert_notification.html
@@ -1,6 +1,6 @@
 {% extends "email/base_email.html" %}
 
-{% block title %}Market Alert{% if alerts|length > 1 %}s{% endif %} - SignalTrackers{% endblock %}
+{% block title %}Market Alert{% if alerts|length > 1 %}s{% endif %} - MacroClarity{% endblock %}
 
 {% block content %}
 <!-- Remove the default padding from base template for custom layout -->

--- a/signaltrackers/templates/email/alert_notification.txt
+++ b/signaltrackers/templates/email/alert_notification.txt
@@ -1,7 +1,7 @@
 {% extends "email/base_email.txt" %}
 
 {% block content %}
-SIGNALTRACKERS MARKET ALERT{% if alerts|length > 1 %}S{% endif %}
+MACROCLARITY MARKET ALERT{% if alerts|length > 1 %}S{% endif %}
 {{ triggered_time }}
 ================================================================================
 

--- a/signaltrackers/templates/email/base_email.html
+++ b/signaltrackers/templates/email/base_email.html
@@ -3,7 +3,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <title>{% block title %}SignalTrackers{% endblock %}</title>
+    <title>{% block title %}MacroClarity{% endblock %}</title>
 </head>
 <body style="margin: 0; padding: 0; font-family: Arial, Helvetica, sans-serif; background-color: #f4f4f4;">
     <table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color: #f4f4f4;">
@@ -14,16 +14,16 @@
 
                     <!-- Header -->
                     <tr>
-                        <td align="center" style="padding: 30px 30px 20px 30px; background-color: #1e3a5f; border-radius: 8px 8px 0 0;">
+                        <td align="center" style="padding: 30px 30px 20px 30px; background-color: #09264c; border-radius: 8px 8px 0 0;">
                             <table border="0" cellpadding="0" cellspacing="0" width="100%">
                                 <tr>
                                     <td align="center" style="color: #ffffff; font-size: 28px; font-weight: bold; letter-spacing: -0.5px;">
-                                        SignalTrackers
+                                        MacroClarity
                                     </td>
                                 </tr>
                                 <tr>
                                     <td align="center" style="padding-top: 8px; color: #a8c5e8; font-size: 14px; font-weight: normal;">
-                                        Macro Financial Intelligence
+                                        Macro Finance Data &amp; Analysis
                                     </td>
                                 </tr>
                             </table>
@@ -46,11 +46,11 @@
                                 <tr>
                                     <td align="center" style="color: #666666; font-size: 12px; line-height: 1.5;">
                                         <p style="margin: 0 0 10px 0;">
-                                            This email was sent by <strong>SignalTrackers</strong>
+                                            This email was sent by <strong>MacroClarity</strong>
                                         </p>
                                         <p style="margin: 0 0 10px 0;">
                                             {% block unsubscribe_text %}
-                                            <a href="{{ unsubscribe_url }}" style="color: #1e3a5f; text-decoration: underline;">Unsubscribe</a> from these emails
+                                            <a href="{{ unsubscribe_url }}" style="color: #09264c; text-decoration: underline;">Unsubscribe</a> from these emails
                                             {% endblock %}
                                         </p>
                                         <p style="margin: 0; color: #999999; font-size: 11px;">

--- a/signaltrackers/templates/email/base_email.txt
+++ b/signaltrackers/templates/email/base_email.txt
@@ -1,6 +1,6 @@
 {% block header %}
 ================================================================================
-SIGNALTRACKERS - Macro Financial Intelligence
+MACROCLARITY - Macro Finance Data & Analysis
 ================================================================================
 {% endblock %}
 
@@ -10,7 +10,7 @@ SIGNALTRACKERS - Macro Financial Intelligence
 {% block footer %}
 --------------------------------------------------------------------------------
 
-This email was sent by SignalTrackers
+This email was sent by MacroClarity
 
 {% block unsubscribe_text %}
 To unsubscribe from these emails, visit: {{ unsubscribe_url }}

--- a/signaltrackers/templates/email/daily_briefing.html
+++ b/signaltrackers/templates/email/daily_briefing.html
@@ -1,6 +1,6 @@
 {% extends "email/base_email.html" %}
 
-{% block title %}Your Daily Market Briefing - SignalTrackers{% endblock %}
+{% block title %}Your Daily Market Briefing - MacroClarity{% endblock %}
 
 {% block content %}
 <!-- Remove the default padding from base template for custom layout -->

--- a/signaltrackers/templates/email/test_email.html
+++ b/signaltrackers/templates/email/test_email.html
@@ -1,14 +1,14 @@
 {% extends "email/base_email.html" %}
 
-{% block title %}Email Test - SignalTrackers{% endblock %}
+{% block title %}Email Test - MacroClarity{% endblock %}
 
 {% block content %}
-<h2 style="color: #1e3a5f; font-size: 22px; margin: 0 0 20px 0; font-weight: 600;">
+<h2 style="color: #09264c; font-size: 22px; margin: 0 0 20px 0; font-weight: 600;">
     Email Configuration Test
 </h2>
 
 <p style="margin: 0 0 16px 0;">
-    Congratulations! Your SignalTrackers email service is configured correctly.
+    Congratulations! Your MacroClarity email service is configured correctly.
 </p>
 
 <p style="margin: 0 0 16px 0;">
@@ -17,7 +17,7 @@
 
 <table border="0" cellpadding="0" cellspacing="0" width="100%" style="margin: 20px 0;">
     <tr>
-        <td style="padding: 20px; background-color: #e8f4f8; border-left: 4px solid #1e3a5f; border-radius: 4px;">
+        <td style="padding: 20px; background-color: #e8f4f8; border-left: 4px solid #09264c; border-radius: 4px;">
             <p style="margin: 0; color: #333333; font-size: 14px;">
                 <strong>✓ Email Service Status:</strong> Operational<br/>
                 <strong>✓ HTML Rendering:</strong> Supported<br/>

--- a/signaltrackers/templates/email/test_email.txt
+++ b/signaltrackers/templates/email/test_email.txt
@@ -4,7 +4,7 @@
 EMAIL CONFIGURATION TEST
 ================================================================================
 
-Congratulations! Your SignalTrackers email service is configured correctly.
+Congratulations! Your MacroClarity email service is configured correctly.
 
 This test email was successfully sent to: {{ recipient_email }}
 


### PR DESCRIPTION
Fixes #453

## Summary
Updates all email templates to reflect the MacroClarity rebrand — header background color changed from `#1e3a5f` to `#09264c`, brand name from "SignalTrackers" to "MacroClarity", and tagline from "Macro Financial Intelligence" to "Macro Finance Data & Analysis".

## Changes
- Email header background color updated to brand navy dark (`#09264c`)
- All "SignalTrackers" references replaced with "MacroClarity" in email templates
- Tagline updated to "Macro Finance Data & Analysis"
- Inline styles updated (email templates don't use CSS custom properties)

## Testing
- ✅ All unit tests passing
- ✅ Design review approved
- ✅ QA verification complete

## Design Spec
Implements [docs/specs/rebrand-macroclarity.md](docs/specs/rebrand-macroclarity.md) — sections 4 (Email Templates) and 7 (Text Replacement Map)