### PR TITLE
US-15.1.1: Add 3 new FRED inflation series & swap 5Y breakeven

### DIFF
--- a/signaltrackers/market_conditions.py
+++ b/signaltrackers/market_conditions.py
@@ -440,16 +440,6 @@ def _load_inflation_signals() -> dict[str, Optional[pd.Series]]:
     else:
         signals['T10YIE'] = None
 
-    # 5Y Breakeven (T5YIE) — daily, level change
-    t5yie_df = _load_csv('breakeven_inflation_5y')
-    t5yie = _to_series(t5yie_df, 'breakeven_inflation_5y')
-    if t5yie is not None and len(t5yie) >= 253:
-        level_change = t5yie.diff(252)
-        z = _rolling_zscore(level_change, 1260)
-        signals['T5YIE'] = z
-    else:
-        signals['T5YIE'] = None
-
     # CPI (CPIAUCSL) — monthly, acceleration
     cpi_df = _load_csv('cpi')
     cpi = _to_series(cpi_df, 'cpi')

--- a/signaltrackers/market_signals.py
+++ b/signaltrackers/market_signals.py
@@ -122,6 +122,10 @@ class MarketSignalsTracker:
             'potential_gdp': 'GDPPOT',              # CBO Potential GDP (quarterly) — Taylor Rule calibration; subject to large revisions
             'unemployment_rate': 'UNRATE',           # Unemployment Rate (monthly, %) — for Okun's Law output gap
             'natural_unemployment_rate': 'NROU',     # CBO Natural Rate of Unemployment (quarterly, %) — for Okun's Law
+            # --- Inflation Composite Redesign (Phase 15) ---
+            'median_cpi': 'MEDCPIM158SFRBCLE',       # Cleveland Fed Median CPI (monthly) — noise-filtered trend inflation
+            'inflation_expectations_5y5y': 'T5YIFR',  # 5Y5Y Forward Inflation Expectation Rate (daily) — long-run expectations anchor
+            'michigan_inflation_expectations': 'MICH', # University of Michigan 1-Year Inflation Expectations (monthly) — consumer expectations
         }
 
         # ETF tickers organized by category


### PR DESCRIPTION
Fixes #462

## Summary
- Add 3 new FRED inflation series: Cleveland Fed Median CPI (`MEDCPIM158SFRBCLE`), 5Y5Y Forward Inflation Expectations (`T5YIFR`), and Michigan 1-Year Inflation Expectations (`MICH`)
- Remove `T5YIE` (5Y Breakeven) from inflation composite inputs (retained for other dashboard uses)
- Foundation for Phase 15 — Inflation Composite Redesign

## Changes
- Added 3 new series to `fred_series` dict in `market_signals.py`
- Removed T5YIE signal loading from `_load_inflation_signals()` in `market_conditions.py`
- New CSV data files: `median_cpi.csv`, `inflation_expectations_5y5y.csv`, `michigan_inflation_expectations.csv`

## Testing
- ✅ All unit tests passing (0 regressions vs main baseline)
- ✅ Data collection runs without errors
- ✅ All 3 new series produce valid CSV data
- ✅ QA verification complete and approved
- ✅ No design review needed (backend-only)

## Design Spec
Implements `docs/INFLATION-COMPOSITE-REDESIGN.md` sections 3.1–3.5