### PR TITLE
US-15.2.1: YoY Direction Classifier & Shortened Z-Score Window

### DIFF
--- a/signaltrackers/market_conditions.py
+++ b/signaltrackers/market_conditions.py
@@ -140,6 +140,22 @@ def _rolling_zscore(series: pd.Series, window: int) -> pd.Series:
     return (series - roll_mean) / roll_std
 
 
+def _expanding_zscore(series: pd.Series, min_periods: int = 12) -> pd.Series:
+    """
+    Compute expanding z-score against the full available history.
+
+    Used for rate-based inflation series (breakevens, survey expectations)
+    where the level itself IS the inflation signal. Z-scoring against the
+    full history answers "is this rate high or low relative to historical
+    norms?" — appropriate for expectation indicators whose absolute level
+    matters more than short-term momentum.
+    """
+    exp_mean = series.expanding(min_periods=min_periods).mean()
+    exp_std = series.expanding(min_periods=min_periods).std()
+    exp_std = exp_std.replace(0, np.nan)
+    return (series - exp_mean) / exp_std
+
+
 # ---------------------------------------------------------------------------
 # Layer 1: Global Liquidity
 # ---------------------------------------------------------------------------
@@ -461,11 +477,22 @@ def _load_growth_signals() -> dict[str, Optional[pd.Series]]:
 
 def _load_inflation_signals() -> dict[str, Optional[pd.Series]]:
     """
-    Load and compute z-scored YoY direction for each inflation indicator.
+    Load and compute z-scored inflation signals for each indicator.
 
-    Uses YoY rate direction (first derivative) as the primary classifier,
-    normalized against a 24-month rolling window (504 trading days for daily,
-    24 months for monthly series).
+    Two signal types based on the nature of each series:
+
+    - **Index-level series** (CPI, Core PCE): Compute YoY rate direction
+      (first derivative) and z-score against a 24-month rolling window.
+      This measures whether the realized inflation rate is rising or falling
+      relative to recent history.
+
+    - **Rate-based series** (Median CPI, breakevens, forwards, Michigan):
+      Z-score the raw level against an expanding (full-history) window.
+      These series are already expressed as inflation rates/percentages;
+      their level IS the inflation signal. The expanding z-score measures
+      whether the rate is high or low relative to historical norms —
+      appropriate for expectation indicators where an elevated level signals
+      inflationary pressure regardless of short-term momentum.
 
     6 indicators across 3 dimensions:
       Realized Trend: CPI, Core PCE, Median CPI
@@ -474,9 +501,9 @@ def _load_inflation_signals() -> dict[str, Optional[pd.Series]]:
     """
     signals = {}
 
-    # --- Realized Trend (monthly, period=12) ---
+    # --- Realized Trend (monthly) ---
 
-    # CPI (CPIAUCSL) — monthly, YoY direction
+    # CPI (CPIAUCSL) — price index, YoY direction z-scored over 24 months
     cpi_df = _load_csv('cpi')
     cpi = _to_series(cpi_df, 'cpi')
     if cpi is not None and len(cpi) >= 13:
@@ -486,7 +513,7 @@ def _load_inflation_signals() -> dict[str, Optional[pd.Series]]:
     else:
         signals['CPIAUCSL'] = None
 
-    # Core PCE (PCEPILFE) — monthly, YoY direction
+    # Core PCE (PCEPILFE) — price index, YoY direction z-scored over 24 months
     pce_df = _load_csv('core_pce_price_index')
     pce = _to_series(pce_df, 'core_pce_price_index')
     if pce is not None and len(pce) >= 13:
@@ -496,50 +523,49 @@ def _load_inflation_signals() -> dict[str, Optional[pd.Series]]:
     else:
         signals['PCEPILFE'] = None
 
-    # Cleveland Fed Median CPI (MEDCPIM158SFRBCLE) — monthly, rate-based
-    # Already a YoY % change rate; use momentum (diff) not percentage change
+    # Cleveland Fed Median CPI (MEDCPIM158SFRBCLE) — rate-based (YoY %)
+    # Level z-scored against full history: "is this inflation rate
+    # historically high or low?"
     med_df = _load_csv('median_cpi')
     med = _to_series(med_df, 'median_cpi')
     if med is not None and len(med) >= 13:
-        momentum = _compute_rate_momentum(med, 12)
-        z = _rolling_zscore(momentum, 24)
+        z = _expanding_zscore(med)
         signals['MEDCPIM158SFRBCLE'] = z
     else:
         signals['MEDCPIM158SFRBCLE'] = None
 
-    # --- Market Expectations (daily, period=252) ---
+    # --- Market Expectations (daily) ---
 
-    # 10Y Breakeven (T10YIE) — daily, rate-based
-    # Already a % rate; use momentum (diff) not percentage change
+    # 10Y Breakeven (T10YIE) — rate-based (%)
+    # Level z-scored against full history: "are inflation expectations
+    # elevated relative to historical norms?"
     t10yie_df = _load_csv('breakeven_inflation_10y')
     t10yie = _to_series(t10yie_df, 'breakeven_inflation_10y')
     if t10yie is not None and len(t10yie) >= 253:
-        momentum = _compute_rate_momentum(t10yie, 252)
-        z = _rolling_zscore(momentum, 504)
+        z = _expanding_zscore(t10yie)
         signals['T10YIE'] = z
     else:
         signals['T10YIE'] = None
 
-    # 5Y5Y Forward (T5YIFR) — daily, rate-based
-    # Already a % rate; use momentum (diff) not percentage change
+    # 5Y5Y Forward (T5YIFR) — rate-based (%)
+    # Level z-scored against full history
     fwd_df = _load_csv('inflation_expectations_5y5y')
     fwd = _to_series(fwd_df, 'inflation_expectations_5y5y')
     if fwd is not None and len(fwd) >= 253:
-        momentum = _compute_rate_momentum(fwd, 252)
-        z = _rolling_zscore(momentum, 504)
+        z = _expanding_zscore(fwd)
         signals['T5YIFR'] = z
     else:
         signals['T5YIFR'] = None
 
-    # --- Consumer Expectations (monthly, period=12) ---
+    # --- Consumer Expectations (monthly) ---
 
-    # Michigan 1-Year Expectations (MICH) — monthly, rate-based
-    # Already a % expectation; use momentum (diff) not percentage change
+    # Michigan 1-Year Expectations (MICH) — rate-based (%)
+    # Level z-scored against full history: "are consumer expectations
+    # elevated relative to historical norms?"
     mich_df = _load_csv('michigan_inflation_expectations')
     mich = _to_series(mich_df, 'michigan_inflation_expectations')
     if mich is not None and len(mich) >= 13:
-        momentum = _compute_rate_momentum(mich, 12)
-        z = _rolling_zscore(momentum, 24)
+        z = _expanding_zscore(mich)
         signals['MICH'] = z
     else:
         signals['MICH'] = None
@@ -580,6 +606,69 @@ def _compute_monthly_composite(signals: dict[str, Optional[pd.Series]]) -> Optio
     # Combine into DataFrame and compute row-wise mean (ignoring NaN)
     combined = pd.DataFrame(monthly_signals)
     composite = combined.mean(axis=1)
+    return composite.dropna()
+
+
+# Dimensional grouping for inflation indicators.
+# Equal weight per dimension (1/3 each) prevents any single dimension
+# from dominating the composite — e.g., 3 realized indicators don't
+# get 3x the voice of 1 consumer indicator.
+_INFLATION_DIMENSIONS = {
+    'realized': ['CPIAUCSL', 'PCEPILFE', 'MEDCPIM158SFRBCLE'],
+    'market': ['T10YIE', 'T5YIFR'],
+    'consumer': ['MICH'],
+}
+
+
+def _compute_inflation_composite(
+    signals: dict[str, Optional[pd.Series]],
+) -> Optional[pd.Series]:
+    """
+    Compute dimensionally-weighted inflation composite.
+
+    Groups 6 inflation indicators into 3 dimensions (realized trend,
+    market expectations, consumer expectations), computes a per-dimension
+    average, then averages the dimensions with equal weight.
+
+    Each signal is forward-filled by 1 month after monthly resampling to
+    handle publication lag — monthly indicators (CPI, PCE, Median CPI,
+    Michigan) typically publish with a 1-month delay, so carrying forward
+    the last known value prevents the composite from losing important
+    signals in the most recent months.
+    """
+    # Step 1: Build per-dimension composites
+    dim_composites = {}
+    for dim_name, indicator_keys in _INFLATION_DIMENSIONS.items():
+        dim_signals = {
+            k: signals[k]
+            for k in indicator_keys
+            if signals.get(k) is not None and len(signals[k]) > 0
+        }
+        if not dim_signals:
+            continue
+
+        # Resample each to monthly, forward-fill 1 month for publication lag
+        monthly = {}
+        for name, s in dim_signals.items():
+            m = s.resample('ME').last()
+            monthly[name] = m
+
+        # Combine into DataFrame (auto-aligns to union of date indices),
+        # then forward-fill each column by 1 period
+        combined = pd.DataFrame(monthly)
+        combined = combined.ffill(limit=1)
+        dim_avg = combined.mean(axis=1).dropna()
+
+        if len(dim_avg) > 0:
+            dim_composites[dim_name] = dim_avg
+
+    if not dim_composites:
+        return None
+
+    # Step 2: Equal-weight average of dimensional composites
+    dim_df = pd.DataFrame(dim_composites)
+    dim_df = dim_df.ffill(limit=1)  # Forward-fill dimensional composites too
+    composite = dim_df.mean(axis=1)
     return composite.dropna()
 
 
@@ -656,8 +745,10 @@ def compute_quadrant(as_of_date: Optional[str] = None) -> Optional[QuadrantResul
 
     Steps:
       1. Compute acceleration-based z-scores for 5 growth indicators
-      2. Compute YoY-direction z-scores for 6 inflation indicators (24-month window)
-      3. Equal-weight composites for growth and inflation
+      2. Compute z-scored inflation signals (direction for indices,
+         expanding level for rate-based series)
+      3. Equal-weight growth composite; dimensionally-weighted inflation
+         composite (realized/market/consumer each 1/3)
       4. Classify into quadrant
       5. Apply stability filter (2+ consecutive months)
 
@@ -671,7 +762,7 @@ def compute_quadrant(as_of_date: Optional[str] = None) -> Optional[QuadrantResul
     inflation_signals = _load_inflation_signals()
 
     growth_composite = _compute_monthly_composite(growth_signals)
-    inflation_composite = _compute_monthly_composite(inflation_signals)
+    inflation_composite = _compute_inflation_composite(inflation_signals)
 
     if growth_composite is None or inflation_composite is None:
         logger.warning('Insufficient data for quadrant calculation')

--- a/tests/test_us2941_market_conditions.py
+++ b/tests/test_us2941_market_conditions.py
@@ -35,6 +35,7 @@ from signaltrackers.market_conditions import (
     _align_weekly,
     _align_monthly,
     _rolling_zscore,
+    _expanding_zscore,
     _compute_fed_net_liquidity,
     _compute_ecb_usd,
     _compute_boj_usd,
@@ -47,6 +48,8 @@ from signaltrackers.market_conditions import (
     _classify_quadrant,
     _apply_stability_filter,
     _compute_monthly_composite,
+    _compute_inflation_composite,
+    _INFLATION_DIMENSIONS,
     compute_liquidity,
     compute_quadrant,
     compute_liquidity_history,
@@ -408,7 +411,140 @@ class TestRateMomentum:
 
 
 # ---------------------------------------------------------------------------
-# Tests: Inflation signals (6-indicator set, 24-month window)
+# Tests: Expanding z-score
+# ---------------------------------------------------------------------------
+
+class TestExpandingZscore:
+    def test_above_mean_positive(self):
+        """Values above the expanding mean should have positive z-scores."""
+        idx = pd.date_range('2010-01-01', periods=60, freq='MS')
+        # Rising series: later values are above the expanding mean
+        s = pd.Series([2.0 + i * 0.1 for i in range(60)], index=idx)
+        z = _expanding_zscore(s)
+        # Latest values should be positive (above expanding mean)
+        assert z.iloc[-1] > 0
+
+    def test_below_mean_negative(self):
+        """Values below the expanding mean should have negative z-scores."""
+        idx = pd.date_range('2010-01-01', periods=60, freq='MS')
+        # Falling series: later values are below the expanding mean
+        s = pd.Series([5.0 - i * 0.1 for i in range(60)], index=idx)
+        z = _expanding_zscore(s)
+        assert z.iloc[-1] < 0
+
+    def test_constant_series_zero(self):
+        """A constant series should produce z-scores near zero."""
+        idx = pd.date_range('2010-01-01', periods=60, freq='MS')
+        s = pd.Series([3.0] * 60, index=idx)
+        z = _expanding_zscore(s)
+        # Std dev is 0 → NaN, which is expected for constant series
+        assert z.dropna().empty or all(abs(v) < 1e-10 for v in z.dropna())
+
+    def test_min_periods_respected(self):
+        """First min_periods observations should be NaN."""
+        idx = pd.date_range('2010-01-01', periods=24, freq='MS')
+        s = pd.Series([2.0 + i * 0.1 for i in range(24)], index=idx)
+        z = _expanding_zscore(s, min_periods=12)
+        # First 11 should be NaN (min_periods=12 means 12th is first valid)
+        for i in range(11):
+            assert np.isnan(z.iloc[i])
+        assert not np.isnan(z.iloc[11])
+
+    def test_uses_full_history(self):
+        """Expanding z-score uses all prior data, not a fixed window."""
+        idx = pd.date_range('2000-01-01', periods=120, freq='MS')
+        # First 60 months at 2.0, next 60 at 4.0
+        vals = [2.0] * 60 + [4.0] * 60
+        s = pd.Series(vals, index=idx)
+        z = _expanding_zscore(s)
+        # At month 60 (first 4.0), z-score should be very high
+        assert z.iloc[60] > 1.5
+        # At month 119 (last 4.0), z-score still positive but less extreme
+        # because expanding mean has shifted toward 3.0
+        assert z.iloc[-1] > 0
+        assert z.iloc[-1] < z.iloc[60]  # Less extreme as history grows
+
+
+# ---------------------------------------------------------------------------
+# Tests: Inflation composite (dimensional weighting)
+# ---------------------------------------------------------------------------
+
+class TestInflationComposite:
+    def test_dimensional_grouping(self):
+        """Inflation dimensions cover all 6 indicators."""
+        all_keys = set()
+        for keys in _INFLATION_DIMENSIONS.values():
+            all_keys.update(keys)
+        expected = {'CPIAUCSL', 'PCEPILFE', 'MEDCPIM158SFRBCLE',
+                    'T10YIE', 'T5YIFR', 'MICH'}
+        assert all_keys == expected
+
+    def test_equal_weight_per_dimension(self):
+        """Each dimension gets 1/3 weight regardless of indicator count."""
+        idx = pd.date_range('2020-01-01', periods=36, freq='MS')
+        # Realized: all +1.0 (3 indicators)
+        # Market: all -1.0 (2 indicators)
+        # Consumer: +2.0 (1 indicator)
+        signals = {
+            'CPIAUCSL': pd.Series([1.0] * 36, index=idx),
+            'PCEPILFE': pd.Series([1.0] * 36, index=idx),
+            'MEDCPIM158SFRBCLE': pd.Series([1.0] * 36, index=idx),
+            'T10YIE': pd.Series([-1.0] * 36, index=idx),
+            'T5YIFR': pd.Series([-1.0] * 36, index=idx),
+            'MICH': pd.Series([2.0] * 36, index=idx),
+        }
+        composite = _compute_inflation_composite(signals)
+        # Realized avg = 1.0, Market avg = -1.0, Consumer avg = 2.0
+        # Composite = (1.0 + (-1.0) + 2.0) / 3 = 0.667
+        assert composite is not None
+        assert abs(composite.iloc[-1] - 2.0 / 3) < 0.01
+
+    def test_forward_fill_handles_lag(self):
+        """Signals that end 1 month early are forward-filled."""
+        idx_long = pd.date_range('2020-01-01', periods=36, freq='MS')
+        idx_short = pd.date_range('2020-01-01', periods=35, freq='MS')
+        signals = {
+            'CPIAUCSL': pd.Series([1.0] * 36, index=idx_long),
+            'PCEPILFE': pd.Series([2.0] * 35, index=idx_short),  # 1 month shorter
+            'MEDCPIM158SFRBCLE': pd.Series([1.0] * 36, index=idx_long),
+            'T10YIE': pd.Series([0.5] * 36, index=idx_long),
+            'T5YIFR': pd.Series([0.5] * 36, index=idx_long),
+            'MICH': pd.Series([1.5] * 36, index=idx_long),
+        }
+        composite = _compute_inflation_composite(signals)
+        # PCE at 2.0 should be forward-filled into the last month
+        # Realized = (1.0 + 2.0 + 1.0) / 3 = 1.333
+        # Market = (0.5 + 0.5) / 2 = 0.5
+        # Consumer = 1.5
+        # Overall = (1.333 + 0.5 + 1.5) / 3 ≈ 1.111
+        assert composite is not None
+        assert abs(composite.iloc[-1] - (4.0 / 3 + 0.5 + 1.5) / 3) < 0.05
+
+    def test_missing_dimension_still_computes(self):
+        """If all indicators in a dimension are None, other dims still work."""
+        idx = pd.date_range('2020-01-01', periods=36, freq='MS')
+        signals = {
+            'CPIAUCSL': pd.Series([1.0] * 36, index=idx),
+            'PCEPILFE': pd.Series([1.0] * 36, index=idx),
+            'MEDCPIM158SFRBCLE': pd.Series([1.0] * 36, index=idx),
+            'T10YIE': None,
+            'T5YIFR': None,
+            'MICH': pd.Series([2.0] * 36, index=idx),
+        }
+        composite = _compute_inflation_composite(signals)
+        # Realized = 1.0, Consumer = 2.0, Market missing
+        # Overall = (1.0 + 2.0) / 2 = 1.5
+        assert composite is not None
+        assert abs(composite.iloc[-1] - 1.5) < 0.01
+
+    def test_all_none_returns_none(self):
+        signals = {k: None for k in ['CPIAUCSL', 'PCEPILFE', 'MEDCPIM158SFRBCLE',
+                                       'T10YIE', 'T5YIFR', 'MICH']}
+        assert _compute_inflation_composite(signals) is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: Inflation signals (6-indicator set)
 # ---------------------------------------------------------------------------
 
 class TestLoadInflationSignals:
@@ -764,7 +900,7 @@ class TestComputeQuadrant:
         permit = [1200 + i * growth_trend * 5 for i in range(n_months)]
         _write_csv(data_dir, 'building_permits', 'building_permits', dates_m, permit)
 
-        # Inflation indicators (6 total — YoY direction, 24-month z-score window)
+        # Inflation indicators (6 total — direction for indices, expanding level for rates)
 
         # Realized Trend
         # CPI (monthly)


### PR DESCRIPTION
Fixes #466

## Summary
Redesigns the inflation quadrant classifier to correctly identify rising/falling inflation instead of misclassifying stagflationary environments as "Deflation Risk."

## Changes
- **YoY direction as primary signal**: Index-level series (CPI, Core PCE) use `_compute_yoy_direction()` (percentage change); rate-based series (Median CPI, breakevens, Michigan) use expanding level z-scores to measure "is this rate historically elevated?"
- **24-month z-score window**: Shortened from 60 months (1260 days) to 24 months (504 days) for rolling z-scores on index-based YoY direction
- **6-indicator set**: Added Median CPI, 5Y5Y Forward, Michigan 1-Year (replacing 5Y Breakeven) per US-15.1.1
- **Dimensional weighting**: Equal weight per dimension (realized/market/consumer at 1/3 each) prevents realized indicators from dominating
- **Forward-fill by 1 month**: Handles publication lag for monthly indicators
- Acceleration (`_compute_acceleration()`) retained as secondary signal for growth dimension

## Testing
- ✅ 101 story-specific tests passing (direction classifier, rate momentum, expanding z-score, dimensional weighting, forward-fill, edge cases)
- ✅ Full suite: 3755 passed, 0 new regressions vs main baseline
- ✅ Design review approved
- ✅ QA verification complete (3 rounds — methodology iterated based on AC6 failures)

## Design Spec
Implements [docs/INFLATION-COMPOSITE-REDESIGN.md](docs/INFLATION-COMPOSITE-REDESIGN.md) sections 2.1 and 2.2