### PR TITLE
US-15.2.3: Graduated Stability Filter — Transition Watch State

### DIFF
--- a/signaltrackers/ai_summary.py
+++ b/signaltrackers/ai_summary.py
@@ -596,6 +596,12 @@ def _build_conditions_context(conditions):
     parts = ["## CURRENT MARKET CONDITIONS"]
     parts.append(f"Quadrant: {quadrant}")
 
+    # Transition watch (graduated stability filter)
+    tw = quad_dims.get('transition_watch')
+    if tw is not None:
+        direction = tw.get('direction', 'Unknown')
+        parts.append(f"  ⚠ Transition Watch — signals shifting toward {direction} (month {tw.get('month', 1)} of 2 for confirmation)")
+
     # Growth/inflation composites if available
     growth = quad_dims.get('growth_composite')
     inflation = quad_dims.get('inflation_composite')
@@ -724,8 +730,14 @@ def _build_conditions_history_context(history, days=90):
         if liq_score is not None:
             liq_str = f"{liq_state}({liq_score:.2f})"
 
+        # Transition watch indicator
+        tw = entry.get('transition_watch') or dims.get('quadrant', {}).get('transition_watch')
+        tw_str = ""
+        if tw is not None:
+            tw_str = f" [WATCH→{tw.get('direction', '?')}]"
+
         parts.append(
-            f"  {date}: {quadrant}{score_str} | Liq: {liq_str} | Risk: {risk_state} | Policy: {policy_stance}/{policy_dir}"
+            f"  {date}: {quadrant}{score_str}{tw_str} | Liq: {liq_str} | Risk: {risk_state} | Policy: {policy_stance}/{policy_dir}"
         )
 
     # Compute summary statistics for the AI

--- a/signaltrackers/market_conditions.py
+++ b/signaltrackers/market_conditions.py
@@ -56,6 +56,7 @@ class QuadrantResult:
     inflation_breadth: Optional[int] = None        # Count of indicators agreeing on majority direction
     inflation_breadth_total: Optional[int] = None   # Total indicators available
     inflation_components: Optional[dict] = None     # Per-indicator detail: {name: {direction, z_score, raw_value}}
+    transition_watch: Optional[dict] = None         # None if confirmed; {direction: str, month: int} if in transition
 
 
 @dataclass
@@ -899,6 +900,64 @@ def _apply_stability_filter(
     return pd.Series(result, index=quadrant_series.index)
 
 
+def _apply_graduated_stability_filter(
+    quadrant_series: pd.Series,
+    required_consecutive: int = 2,
+) -> tuple:
+    """Apply graduated stability filter with transition watch state.
+
+    Instead of silently suppressing month-1 transitions, this filter reports
+    them as "Transition Watch" — an early warning that signals are shifting.
+
+    Returns:
+        (stable_series, transition_watch_series)
+        - stable_series: pd.Series of confirmed quadrant labels (same as binary filter)
+        - transition_watch_series: pd.Series of dicts or None per time step.
+          None = confirmed; {'direction': str, 'month': int} = watching.
+    """
+    if len(quadrant_series) == 0:
+        return quadrant_series, pd.Series([], dtype=object)
+
+    stable_result = []
+    watch_result = []
+    current_stable = quadrant_series.iloc[0]
+
+    for i, q in enumerate(quadrant_series):
+        if i == 0:
+            # First data point is always confirmed
+            stable_result.append(current_stable)
+            watch_result.append(None)
+            continue
+
+        if q == current_stable:
+            # Same as confirmed — no transition
+            stable_result.append(current_stable)
+            watch_result.append(None)
+        else:
+            # New quadrant detected — count consecutive months backward
+            count = 1
+            for j in range(i - 1, max(i - required_consecutive, -1), -1):
+                if quadrant_series.iloc[j] == q:
+                    count += 1
+                else:
+                    break
+
+            if count >= required_consecutive:
+                # Threshold met — confirm transition
+                current_stable = q
+                stable_result.append(current_stable)
+                watch_result.append(None)
+            else:
+                # Not yet confirmed — transition watch
+                stable_result.append(current_stable)
+                watch_result.append({'direction': q, 'month': count})
+
+    return (
+        pd.Series(stable_result, index=quadrant_series.index),
+        pd.Series(watch_result, index=quadrant_series.index),
+    )
+
+
 def _classify_quadrant(growth: float, inflation: float) -> str:
     """Classify into one of four quadrants based on growth and inflation composites."""
     if growth > 0 and inflation <= 0:
@@ -959,8 +1018,10 @@ def compute_quadrant(as_of_date: Optional[str] = None) -> Optional[QuadrantResul
         index=common_idx,
     )
 
-    # Apply stability filter
-    stable_quadrants = _apply_stability_filter(raw_quadrants, required_consecutive=2)
+    # Apply graduated stability filter (transition watch for early warning)
+    stable_quadrants, watch_series = _apply_graduated_stability_filter(
+        raw_quadrants, required_consecutive=2,
+    )
 
     # Determine as_of cutoff
     if as_of_date is not None:
@@ -973,6 +1034,7 @@ def compute_quadrant(as_of_date: Optional[str] = None) -> Optional[QuadrantResul
         inflation_aligned = inflation_aligned.reindex(common_idx)
         raw_quadrants = raw_quadrants.reindex(common_idx)
         stable_quadrants = stable_quadrants.reindex(common_idx)
+        watch_series = watch_series.reindex(common_idx)
 
     if len(common_idx) == 0:
         return None
@@ -982,6 +1044,7 @@ def compute_quadrant(as_of_date: Optional[str] = None) -> Optional[QuadrantResul
     i_val = float(inflation_aligned.iloc[-1])
     raw_q = raw_quadrants.iloc[-1]
     stable_q = stable_quadrants.iloc[-1]
+    tw = watch_series.iloc[-1]  # None or {'direction': str, 'month': int}
 
     return QuadrantResult(
         quadrant=stable_q,
@@ -993,6 +1056,7 @@ def compute_quadrant(as_of_date: Optional[str] = None) -> Optional[QuadrantResul
         inflation_breadth=breadth,
         inflation_breadth_total=breadth_total,
         inflation_components=components,
+        transition_watch=tw,
     )
 
 
@@ -1102,7 +1166,9 @@ def compute_quadrant_history(start_date: Optional[str] = None) -> Optional[pd.Da
         [_classify_quadrant(g, i) for g, i in zip(growth_aligned, inflation_aligned)],
         index=common_idx,
     )
-    stable_quadrants = _apply_stability_filter(raw_quadrants, required_consecutive=2)
+    stable_quadrants, watch_series = _apply_graduated_stability_filter(
+        raw_quadrants, required_consecutive=2,
+    )
 
     return pd.DataFrame({
         'date': common_idx,
@@ -1110,6 +1176,7 @@ def compute_quadrant_history(start_date: Optional[str] = None) -> Optional[pd.Da
         'inflation': inflation_aligned.values,
         'raw_quadrant': raw_quadrants.values,
         'quadrant': stable_quadrants.values,
+        'transition_watch': watch_series.values,
     })
 
 
@@ -2088,6 +2155,7 @@ def update_market_conditions_cache() -> Optional[dict]:
                     'inflation_breadth': quadrant_result.inflation_breadth,
                     'inflation_breadth_total': quadrant_result.inflation_breadth_total,
                     'inflation_components': quadrant_result.inflation_components,
+                    'transition_watch': quadrant_result.transition_watch,
                 },
                 'risk': {
                     'state': risk_state,
@@ -2206,6 +2274,7 @@ def _append_conditions_history(cache_data: dict) -> None:
         'growth_score': quad_dims.get('growth_composite'),
         'inflation_score': quad_dims.get('inflation_composite'),
         'raw_quadrant': quad_dims.get('state', cache_data.get('quadrant')),
+        'transition_watch': quad_dims.get('transition_watch'),
         'dimensions': dims,
         'asset_expectations': cache_data.get('asset_expectations', []),
         'updated_at': cache_data.get('updated_at'),

--- a/tests/test_us1523_transition_watch.py
+++ b/tests/test_us1523_transition_watch.py
@@ -1,0 +1,390 @@
+"""
+Tests for US-15.2.3: Graduated Stability Filter — Transition Watch State.
+
+Covers:
+  - Graduated stability filter (watch vs confirmed)
+  - Transition watch state in QuadrantResult
+  - First data point treated as confirmed
+  - 2-month confirmation threshold maintained
+  - Revert before month 2 cancels watch
+  - Rapid oscillation handling
+  - Three-way oscillation handling
+  - Sustained quadrant (no watch triggered)
+  - Empty / single data point edge cases
+  - Transition watch in cache/history data model
+  - AI briefing context includes transition watch
+  - Non-inflation dimensions unchanged
+"""
+
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# Ensure the project root is on sys.path
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO_ROOT)
+
+from signaltrackers.market_conditions import (
+    _apply_graduated_stability_filter,
+    _apply_stability_filter,
+    QuadrantResult,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper to build a quadrant series from labels
+# ---------------------------------------------------------------------------
+
+def _make_series(labels):
+    """Create a pd.Series of quadrant labels with monthly index."""
+    idx = pd.date_range('2024-01-31', periods=len(labels), freq='ME')
+    return pd.Series(labels, index=idx)
+
+
+# ---------------------------------------------------------------------------
+# Core graduated filter tests
+# ---------------------------------------------------------------------------
+
+class TestGraduatedStabilityFilter:
+    """Tests for _apply_graduated_stability_filter."""
+
+    def test_empty_series(self):
+        """Empty quadrant series returns empty results without errors."""
+        s = pd.Series([], dtype=object)
+        stable, watch = _apply_graduated_stability_filter(s)
+        assert len(stable) == 0
+        assert len(watch) == 0
+
+    def test_single_data_point_confirmed(self):
+        """First data point is treated as confirmed (no transition watch)."""
+        s = _make_series(['Goldilocks'])
+        stable, watch = _apply_graduated_stability_filter(s)
+        assert stable.iloc[0] == 'Goldilocks'
+        assert watch.iloc[0] is None
+
+    def test_sustained_quadrant_no_watch(self):
+        """Same quadrant sustained for many months — no transition watch ever triggered."""
+        s = _make_series(['Reflation'] * 6)
+        stable, watch = _apply_graduated_stability_filter(s)
+        for i in range(6):
+            assert stable.iloc[i] == 'Reflation'
+            assert watch.iloc[i] is None
+
+    def test_month1_transition_watch(self):
+        """Month 1 in new quadrant: transition watch, confirmed quadrant unchanged."""
+        s = _make_series(['Goldilocks', 'Goldilocks', 'Stagflation'])
+        stable, watch = _apply_graduated_stability_filter(s)
+
+        # Month 1 and 2: confirmed Goldilocks, no watch
+        assert stable.iloc[0] == 'Goldilocks'
+        assert watch.iloc[0] is None
+        assert stable.iloc[1] == 'Goldilocks'
+        assert watch.iloc[1] is None
+
+        # Month 3: still confirmed Goldilocks, but watch toward Stagflation
+        assert stable.iloc[2] == 'Goldilocks'
+        assert watch.iloc[2] is not None
+        assert watch.iloc[2]['direction'] == 'Stagflation'
+        assert watch.iloc[2]['month'] == 1
+
+    def test_month2_confirms_transition(self):
+        """After 2 consecutive months in new quadrant, transition confirmed, watch removed."""
+        s = _make_series(['Goldilocks', 'Goldilocks', 'Stagflation', 'Stagflation'])
+        stable, watch = _apply_graduated_stability_filter(s)
+
+        # Month 3: watch
+        assert stable.iloc[2] == 'Goldilocks'
+        assert watch.iloc[2] is not None
+        assert watch.iloc[2]['direction'] == 'Stagflation'
+
+        # Month 4: confirmed Stagflation, watch cleared
+        assert stable.iloc[3] == 'Stagflation'
+        assert watch.iloc[3] is None
+
+    def test_revert_before_month2_cancels_watch(self):
+        """Signal reverts before month 2 — transition watch cancelled, no false confirmation."""
+        s = _make_series(['Goldilocks', 'Goldilocks', 'Stagflation', 'Goldilocks'])
+        stable, watch = _apply_graduated_stability_filter(s)
+
+        # Month 3: watch toward Stagflation
+        assert watch.iloc[2] is not None
+        assert watch.iloc[2]['direction'] == 'Stagflation'
+
+        # Month 4: reverted — back to confirmed Goldilocks, watch cleared
+        assert stable.iloc[3] == 'Goldilocks'
+        assert watch.iloc[3] is None
+
+    def test_rapid_oscillation_no_false_transitions(self):
+        """Rapid oscillation (A→B→A→B): no false transitions — each new direction resets."""
+        s = _make_series([
+            'Goldilocks', 'Stagflation', 'Goldilocks', 'Stagflation',
+            'Goldilocks', 'Stagflation',
+        ])
+        stable, watch = _apply_graduated_stability_filter(s)
+
+        # Confirmed quadrant should stay Goldilocks throughout (never 2 consecutive of anything else)
+        for i in range(6):
+            assert stable.iloc[i] == 'Goldilocks'
+
+        # Odd months should have watch toward Stagflation
+        for i in [1, 3, 5]:
+            assert watch.iloc[i] is not None
+            assert watch.iloc[i]['direction'] == 'Stagflation'
+
+        # Even months should have no watch
+        for i in [0, 2, 4]:
+            assert watch.iloc[i] is None
+
+    def test_three_way_oscillation(self):
+        """Three-way oscillation (A→B→C): watch resets from B to C."""
+        s = _make_series([
+            'Goldilocks', 'Goldilocks',
+            'Stagflation',   # watch -> Stagflation
+            'Reflation',     # watch -> Reflation (resets)
+        ])
+        stable, watch = _apply_graduated_stability_filter(s)
+
+        # Month 3: watch toward Stagflation
+        assert watch.iloc[2] is not None
+        assert watch.iloc[2]['direction'] == 'Stagflation'
+
+        # Month 4: watch toward Reflation (not stale Stagflation watch)
+        assert watch.iloc[3] is not None
+        assert watch.iloc[3]['direction'] == 'Reflation'
+        assert stable.iloc[3] == 'Goldilocks'  # still Goldilocks confirmed
+
+    def test_transition_then_sustained(self):
+        """Transition confirmed, then new quadrant sustained — no further watches."""
+        s = _make_series([
+            'Goldilocks', 'Stagflation', 'Stagflation',
+            'Stagflation', 'Stagflation',
+        ])
+        stable, watch = _apply_graduated_stability_filter(s)
+
+        # Month 2: watch
+        assert watch.iloc[1] is not None
+
+        # Month 3: confirmed Stagflation
+        assert stable.iloc[2] == 'Stagflation'
+        assert watch.iloc[2] is None
+
+        # Months 4-5: sustained, no watch
+        assert stable.iloc[3] == 'Stagflation'
+        assert watch.iloc[3] is None
+        assert stable.iloc[4] == 'Stagflation'
+        assert watch.iloc[4] is None
+
+    def test_matches_binary_filter_stable_output(self):
+        """The stable quadrant output matches the original binary filter exactly."""
+        labels = [
+            'Goldilocks', 'Goldilocks', 'Stagflation', 'Stagflation',
+            'Reflation', 'Reflation', 'Reflation', 'Deflation Risk',
+            'Deflation Risk', 'Goldilocks',
+        ]
+        s = _make_series(labels)
+
+        binary = _apply_stability_filter(s, required_consecutive=2)
+        graduated_stable, _ = _apply_graduated_stability_filter(s, required_consecutive=2)
+
+        pd.testing.assert_series_equal(binary, graduated_stable)
+
+    def test_watch_direction_includes_quadrant_name(self):
+        """Transition watch direction is one of the four quadrant names."""
+        valid_names = {'Goldilocks', 'Reflation', 'Stagflation', 'Deflation Risk'}
+        s = _make_series(['Goldilocks', 'Deflation Risk'])
+        _, watch = _apply_graduated_stability_filter(s)
+        assert watch.iloc[1] is not None
+        assert watch.iloc[1]['direction'] in valid_names
+
+
+# ---------------------------------------------------------------------------
+# QuadrantResult integration
+# ---------------------------------------------------------------------------
+
+class TestQuadrantResultTransitionWatch:
+    """Test that QuadrantResult carries transition_watch correctly."""
+
+    def test_default_none(self):
+        """QuadrantResult.transition_watch defaults to None."""
+        r = QuadrantResult(
+            quadrant='Goldilocks',
+            growth_composite=0.5,
+            inflation_composite=-0.3,
+            raw_quadrant='Goldilocks',
+            stable=True,
+        )
+        assert r.transition_watch is None
+
+    def test_with_transition_watch(self):
+        """QuadrantResult can carry a transition_watch dict."""
+        tw = {'direction': 'Stagflation', 'month': 1}
+        r = QuadrantResult(
+            quadrant='Goldilocks',
+            growth_composite=0.5,
+            inflation_composite=-0.3,
+            raw_quadrant='Stagflation',
+            stable=False,
+            transition_watch=tw,
+        )
+        assert r.transition_watch == tw
+        assert r.transition_watch['direction'] == 'Stagflation'
+
+
+# ---------------------------------------------------------------------------
+# Data model tests (cache/history shape)
+# ---------------------------------------------------------------------------
+
+class TestTransitionWatchDataModel:
+    """Test transition_watch field in history entry shape."""
+
+    def test_history_entry_has_transition_watch_null(self):
+        """When no transition, transition_watch is None (not omitted)."""
+        # Simulate the entry structure from _append_conditions_history
+        quad_dims = {
+            'state': 'Goldilocks',
+            'growth_composite': 0.5,
+            'inflation_composite': -0.3,
+            'transition_watch': None,
+        }
+        entry = {
+            'quadrant': 'Goldilocks',
+            'transition_watch': quad_dims.get('transition_watch'),
+        }
+        assert 'transition_watch' in entry
+        assert entry['transition_watch'] is None
+
+    def test_history_entry_has_transition_watch_active(self):
+        """When transition watch is active, field includes target quadrant name."""
+        tw = {'direction': 'Stagflation', 'month': 1}
+        quad_dims = {
+            'state': 'Goldilocks',
+            'transition_watch': tw,
+        }
+        entry = {
+            'quadrant': 'Goldilocks',
+            'transition_watch': quad_dims.get('transition_watch'),
+        }
+        assert entry['transition_watch'] is not None
+        assert entry['transition_watch']['direction'] == 'Stagflation'
+
+    def test_backwards_compat_missing_field(self):
+        """Existing history entries without transition_watch are handled gracefully."""
+        # Old entry format
+        old_entry = {
+            'quadrant': 'Goldilocks',
+            'growth_score': 0.5,
+            'inflation_score': -0.3,
+        }
+        # Code should use .get() — returns None
+        tw = old_entry.get('transition_watch')
+        assert tw is None
+
+
+# ---------------------------------------------------------------------------
+# AI briefing context tests
+# ---------------------------------------------------------------------------
+
+class TestBriefingContextTransitionWatch:
+    """Test that AI briefing context includes transition watch info."""
+
+    def test_conditions_context_with_watch(self):
+        """When transition watch is active, briefing context includes the direction."""
+        from signaltrackers.ai_summary import _build_conditions_context
+
+        conditions = {
+            'quadrant': 'Goldilocks',
+            'dimensions': {
+                'quadrant': {
+                    'growth_composite': 0.5,
+                    'inflation_composite': -0.3,
+                    'transition_watch': {'direction': 'Stagflation', 'month': 1},
+                },
+                'liquidity': {'state': 'Ample', 'score': 0.8},
+                'risk': {'state': 'Calm', 'score': 1},
+                'policy': {'stance': 'Neutral', 'direction': 'Paused'},
+            },
+            'asset_expectations': [],
+        }
+        ctx = _build_conditions_context(conditions)
+        assert 'Transition Watch' in ctx
+        assert 'Stagflation' in ctx
+
+    def test_conditions_context_no_watch(self):
+        """When transition watch is null, briefing does not mention a transition."""
+        from signaltrackers.ai_summary import _build_conditions_context
+
+        conditions = {
+            'quadrant': 'Goldilocks',
+            'dimensions': {
+                'quadrant': {
+                    'growth_composite': 0.5,
+                    'inflation_composite': -0.3,
+                    'transition_watch': None,
+                },
+                'liquidity': {'state': 'Ample', 'score': 0.8},
+                'risk': {'state': 'Calm', 'score': 1},
+                'policy': {'stance': 'Neutral', 'direction': 'Paused'},
+            },
+            'asset_expectations': [],
+        }
+        ctx = _build_conditions_context(conditions)
+        assert 'Transition Watch' not in ctx
+
+    def test_conditions_context_missing_watch_field(self):
+        """Old conditions dict without transition_watch field — no crash, no mention."""
+        from signaltrackers.ai_summary import _build_conditions_context
+
+        conditions = {
+            'quadrant': 'Goldilocks',
+            'dimensions': {
+                'quadrant': {
+                    'growth_composite': 0.5,
+                    'inflation_composite': -0.3,
+                },
+                'liquidity': {'state': 'Ample'},
+                'risk': {'state': 'Calm'},
+                'policy': {'stance': 'Neutral', 'direction': 'Paused'},
+            },
+            'asset_expectations': [],
+        }
+        ctx = _build_conditions_context(conditions)
+        assert 'Transition Watch' not in ctx
+
+    def test_history_context_with_watch(self):
+        """History context shows transition watch indicator for entries with active watch."""
+        from signaltrackers.ai_summary import _build_conditions_history_context
+        from datetime import date, timedelta
+
+        today = date.today()
+        d1 = str(today - timedelta(days=30))
+        d2 = str(today - timedelta(days=1))
+
+        history = {
+            d1: {
+                'quadrant': 'Goldilocks',
+                'transition_watch': None,
+                'dimensions': {
+                    'liquidity': {'state': 'Ample'},
+                    'risk': {'state': 'Calm'},
+                    'policy': {'stance': 'Neutral', 'direction': 'Paused'},
+                },
+            },
+            d2: {
+                'quadrant': 'Goldilocks',
+                'transition_watch': {'direction': 'Stagflation', 'month': 1},
+                'dimensions': {
+                    'liquidity': {'state': 'Ample'},
+                    'risk': {'state': 'Calm'},
+                    'policy': {'stance': 'Neutral', 'direction': 'Paused'},
+                },
+            },
+        }
+        ctx = _build_conditions_history_context(history, days=60)
+        assert 'WATCH→Stagflation' in ctx
+        # First entry should not have watch indicator
+        lines = ctx.split('\n')
+        d1_line = [l for l in lines if d1 in l][0]
+        assert 'WATCH' not in d1_line


### PR DESCRIPTION
Fixes #468

## Summary
Implements a graduated stability filter for the inflation quadrant dimension. Instead of the binary 2-month delay, month 1 in a new quadrant now shows a "Transition Watch" early warning, and month 2 confirms the regime change.

## Changes
- Added `_apply_graduated_stability_filter` with watch/confirmed logic
- `transition_watch` field added to `QuadrantResult`, cache data, and `market_conditions_history.json`
- AI briefing context surfaces transition watch status (current + historical)
- Only the quadrant dimension uses the graduated filter; liquidity, risk, and policy are unchanged
- 20 new tests covering all acceptance criteria and edge cases

## Testing
- ✅ 20/20 story tests passing (test_us1523_transition_watch.py)
- ✅ 102/102 market conditions regression tests passing
- ✅ Full suite: 3776 passed, 0 new regressions
- ✅ Design review approved
- ✅ QA verification complete

## Design Spec
Implements section 2.4 of `docs/INFLATION-COMPOSITE-REDESIGN.md`